### PR TITLE
remove useless name in EXECUTION_CALENDARS

### DIFF
--- a/Cron/resources/catalog/start_every_2_min.xml
+++ b/Cron/resources/catalog/start_every_2_min.xml
@@ -8,7 +8,7 @@
     onTaskError="suspendTask"
 >
   <genericInformation>
-    <info name="EXECUTION_CALENDARS" value="{&quot;name&quot;:&quot;StartEvery2Minutes&quot;,&quot;cron&quot;: &quot;0 0/2 * * * ?&quot;} "/>
+    <info name="EXECUTION_CALENDARS" value="{&quot;cron&quot;: &quot;0 0/2 * * * ?&quot;} "/>
   </genericInformation>
   <taskFlow>
     <task name="Javascript_Task">

--- a/Cron/resources/catalog/start_every_first_mon_month_12h00.xml
+++ b/Cron/resources/catalog/start_every_first_mon_month_12h00.xml
@@ -8,7 +8,7 @@
     onTaskError="suspendTask"
 >
   <genericInformation>
-    <info name="EXECUTION_CALENDARS" value="{&quot;name&quot;:&quot;StartEveryFirstMondayMonth12H00&quot;,&quot;cron&quot;: &quot;0 0 12 ? * 2#1&quot;} "/>
+    <info name="EXECUTION_CALENDARS" value="{&quot;cron&quot;: &quot;0 0 12 ? * 2#1&quot;} "/>
   </genericInformation>
   <taskFlow>
     <task name="Javascript_Task">


### PR DESCRIPTION
In this PR, we update the CRON workflow examples by removing the no longer used "name" value in EXECUTION_CALENDARS. This "name" property used to cause a collision issue when trying to plan two jobs with the same name within the EXECUTION_CALENDARS even if they had different workflow names.

[Trello Card](https://trello.com/c/McP68xcN)