### PR TITLE
DLA connector kill job on error

### DIFF
--- a/DataConnectors/resources/catalog/Azure_Data_Lake.xml
+++ b/DataConnectors/resources/catalog/Azure_Data_Lake.xml
@@ -5,15 +5,14 @@
      xsi:schemaLocation="urn:proactive:jobdescriptor:3.10 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.10/schedulerjob.xsd"
     name="Azure_Data_Lake" projectName="4. Cloud"
     priority="normal"
-    onTaskError="continueJobExecution"
-     maxNumberOfExecution="2"
->
+    onTaskError="cancelJob">
   <variables>
     <variable name="AZ_CRON_MONITOR" value="* * * * *" />
     <variable name="AZ_DLA_ACCOUNT" value=""/>
     <variable name="AZ_DLA_JOB" value=""/>
     <variable name="AZ_DLA_OUTPUT" value=""/>
     <variable name="AZ_DLA_SCRIPT" value=""/>
+    <variable name="AZ_SUBSCRIPTION" value=""/>
   </variables>
   <description>
     <![CDATA[ This workflow allows to submit a U-SQL job to Azure Data Analytics and retrieve the result file. ]]>
@@ -92,6 +91,17 @@ if (conn_exec.exitValue() != 0)
 }
 println("Successful connection:")
 println conn_exec.in.text
+//Set subscription if needed
+if (variables.get("AZ_SUBSCRIPTION")) {
+  def subscription_string = "az account set --subscription " + variables.get("AZ_SUBSCRIPTION")
+  def subscription_exec = subscription_string.execute()
+  subscription_exec.waitFor()
+  if (subscription_exec.exitValue() != 0)
+  {
+    println subscription_exec.err.text
+    System.exit(1)
+  }
+}
 //Validate accounts
 def account_string = "az dla account list"
 def account_exec = account_string.execute()
@@ -198,6 +208,17 @@ if (conn_exec.exitValue() != 0)
   println conn_exec.err.text
   System.exit(1)
 }
+//Set subscription if needed
+if (variables.get("AZ_SUBSCRIPTION")) {
+  def subscription_string = "az account set --subscription " + variables.get("AZ_SUBSCRIPTION")
+  def subscription_exec = subscription_string.execute()
+  subscription_exec.waitFor()
+  if (subscription_exec.exitValue() != 0)
+  {
+    println subscription_exec.err.text
+    System.exit(1)
+  }
+}
 //Get Job Status
 def search_string = "az dla job show --account " + variables.get("AZ_DLA_ACCOUNT") + " --job-identity " + variables.get("AZ_DLA_JOB_ID")
 def search_exec = search_string.execute()
@@ -214,9 +235,9 @@ if (job.endTime != null) {
   if (job.result == "Succeeded") {
     println("Job " + variables.get("AZ_DLA_JOB_ID") + " finished successfully.")
   } else {
-    println("Job " + variables.get("AZ_DLA_JOB_ID") + " finished with errors.")
-    println("Execution details:")
-    println job.stateAuditRecords
+    println("Job " + variables.get("AZ_DLA_JOB_ID") + " finished with errors:")
+    println job.errorMessage
+    System.exit(1)
   }
 } else {
   println("Waiting for job to finish...")
@@ -310,6 +331,17 @@ if (conn_exec.exitValue() != 0)
 {
   println conn_exec.err.text
   System.exit(1)
+}
+//Set subscription if needed
+if (variables.get("AZ_SUBSCRIPTION")) {
+  def subscription_string = "az account set --subscription " + variables.get("AZ_SUBSCRIPTION")
+  def subscription_exec = subscription_string.execute()
+  subscription_exec.waitFor()
+  if (subscription_exec.exitValue() != 0)
+  {
+    println subscription_exec.err.text
+    System.exit(1)
+  }
 }
 //Download output file
 def download_string = "az dls fs download --account " + variables.get("AZ_DLS_ACCOUNT") + " --source-path /" + variables.get("AZ_DLA_OUTPUT") + " --destination-path " + variables.get("AZ_DLA_OUTPUT")


### PR DESCRIPTION
In this PR we handle killing the job upon error to prevent further errors to appear.

Additionally, we add a new Subscription variable that allows to switch to other Azure subscription if we don't want to use the default one.