### PR TITLE
Add elasticsearch workflows of the client side and improve mongodb data-connector workflows

### DIFF
--- a/DataConnectors/resources/catalog/MongoDB.xml
+++ b/DataConnectors/resources/catalog/MongoDB.xml
@@ -8,10 +8,9 @@
     onTaskError="continueJobExecution"
      maxNumberOfExecution="2">
   <variables>
-    <variable name="MONGODB_DATABASE" value="" model=""/>
-    <variable name="MONGODB_HOSTNAME" value="localhost" model=""/>
+    <variable name="MONGODB_HOSTNAME" value="localhost" />
     <variable name="MONGODB_PORT" value="27018" model="PA:Integer"/>
-    <variable name="MONGODB_USER" value="" model=""/>
+    <variable name="MONGODB_USER" value="" />
   </variables>
   <description>
     <![CDATA[ Import or export data from/to MongoDB. ]]>
@@ -37,6 +36,7 @@ $MONGODB_INPUT (required) A JSON Object/Array to be inserted in MongoDB. This va
       <variables>
         <variable name="MONGODB_COLLECTION" value="" inherited="false" />
         <variable name="MONGODB_INPUT" value="" inherited="false" />
+        <variable name="MONGODB_DATABASE" value="" inherited="false" />
       </variables>
       <genericInformation>
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/mongodb.png"/>
@@ -197,6 +197,7 @@ The output of this task is saved to the local space in a JSON file (result.json)
         <variable name="MONGODB_COLLECTION" value="" inherited="false" />
         <variable name="MONGODB_QUERY" value="" inherited="false" />
         <variable name="MONGODB_OUTPUT" value="" inherited="false" />
+        <variable name="MONGODB_DATABASE" value="" inherited="false" />
       </variables>
       <genericInformation>
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/mongodb.png"/>

--- a/DatabaseServices/METADATA.json
+++ b/DatabaseServices/METADATA.json
@@ -151,6 +151,24 @@
           "contentType": "application/xml"
         },
         "file": "resources/catalog/Elasticsearch_Database_Interaction.xml"
+      },
+      {
+        "name": "Elasticsearch_Service_Start",
+        "metadata": {
+          "kind": "Workflow/standard",
+          "commitMessage": "First commit",
+          "contentType": "application/xml"
+        },
+        "file": "resources/catalog/Elasticsearch_Service_Start.xml"
+      },
+      {
+        "name": "Elasticsearch_Service_Actions",
+        "metadata": {
+          "kind": "Workflow/standard",
+          "commitMessage": "First commit",
+          "contentType": "application/xml"
+        },
+        "file": "resources/catalog/Elasticsearch_Service_Actions.xml"
       }
     ]
   }

--- a/DatabaseServices/resources/catalog/Elasticsearch_Service_Actions.xml
+++ b/DatabaseServices/resources/catalog/Elasticsearch_Service_Actions.xml
@@ -8,7 +8,7 @@
     onTaskError="continueJobExecution"
      maxNumberOfExecution="2">
   <variables>
-    <variable name="ACTION" value="Stop_Elasticsearch" model="PA:LIST(Stop_Elasticsearch, Resume_Elasticsearch, Finish_Elasticsearch)"/>
+    <variable name="ACTION" value="Finish_Elasticsearch" model="PA:LIST(Stop_Elasticsearch, Resume_Elasticsearch, Finish_Elasticsearch)"/>
   </variables>
   <description>
     <![CDATA[ This workflow manages the life-cycle of Elasticsearch PCA service. It allows to trigger three possible actions: Stop_Elasticsearch, Resume_Elasticsearch and Finish_Elasticsearch. ]]>

--- a/DatabaseServices/resources/catalog/MongoDB_Database_Interaction.xml
+++ b/DatabaseServices/resources/catalog/MongoDB_Database_Interaction.xml
@@ -38,10 +38,7 @@
             <![CDATA[
 def mongodbEndpoint = variables.get("ENDPOINT")
 def mongodbHost
-def mongodbUser = variables.get("USER")
-def mongodbPassword = variables.get("PASSWORD")
 def mongodbPort
-def mongodbPasswordKey
 
 if (mongodbEndpoint != null){
   mongodbEndpoint = mongodbEndpoint.replace("http://", "")

--- a/DatabaseServices/resources/catalog/MongoDB_Database_Interaction.xml
+++ b/DatabaseServices/resources/catalog/MongoDB_Database_Interaction.xml
@@ -1,15 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <job
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns="urn:proactive:jobdescriptor:3.10"
-        xsi:schemaLocation="urn:proactive:jobdescriptor:3.10 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.10/schedulerjob.xsd"
-        name="MongoDB_Database_Interaction" projectName="MongoDB Workflows"
-        priority="normal"
-        onTaskError="continueJobExecution"
-        maxNumberOfExecution="2">
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:proactive:jobdescriptor:3.10"
+     xsi:schemaLocation="urn:proactive:jobdescriptor:3.10 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.10/schedulerjob.xsd"
+    name="MongoDB_Database_Interaction" projectName="MongoDB Workflows"
+    priority="normal"
+    onTaskError="continueJobExecution"
+     maxNumberOfExecution="2">
   <variables>
     <variable name="ACTION" value="Finish_MongoDB" model="PA:LIST(Stop_MongoDB, Resume_MongoDB, Finish_MongoDB)"/>
-    <variable name="MONGODB_DATABASE" value="activeeon" />
     <variable name="MONGODB_INSTANCE_NAME" value="mongodb-server-1" />
     <variable name="MONGODB_PASSWORD" value="proactive" />
     <variable name="MONGODB_USER" value="mlos" />
@@ -73,6 +72,7 @@ $MONGODB_INPUT (required) A JSON Object/Array to be inserted in MongoDB. This va
       <variables>
         <variable name="MONGODB_COLLECTION" value="star_wars" inherited="false" />
         <variable name="MONGODB_INPUT" value="star_wars_people.json" inherited="false" />
+        <variable name="MONGODB_DATABASE" value="activeeon" inherited="false" />
       </variables>
       <genericInformation>
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/mongodb.png"/>
@@ -236,6 +236,7 @@ The output of this task is saved to the local space in a JSON file (result.json)
         <variable name="MONGODB_COLLECTION" value="star_wars" inherited="false" />
         <variable name="MONGODB_QUERY" value="{&quot;mass&quot;: &quot;32&quot;}" inherited="false" />
         <variable name="MONGODB_OUTPUT" value="" inherited="false" />
+        <variable name="MONGODB_DATABASE" value="activeeon" inherited="false" />
       </variables>
       <genericInformation>
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/mongodb.png"/>


### PR DESCRIPTION
In this PR, 
1) we add two workflows that manage the client side of the elasticsearch PCA service. 
2) we move the MONGODB_DATABASE variable from the workflow level to the task level 