### PR TITLE
Add a new docker PCA service

### DIFF
--- a/DatabaseServices/resources/catalog/MySQL_Database_Interaction.xml
+++ b/DatabaseServices/resources/catalog/MySQL_Database_Interaction.xml
@@ -329,7 +329,7 @@ print("END Export_Data")
     </task>
     <task name="Parse_Endpoint">
       <description>
-        <![CDATA[ The simplest task, ran by a groovy engine. ]]>
+        <![CDATA[ This task aims to parse PCA endpoint in order to retrieve a HOSTNAME and a PORT number to use them as an input in the data connector tasks. ]]>
       </description>
       <depends>
         <task ref="Start_MySQL"/>

--- a/Docker/METADATA.json
+++ b/Docker/METADATA.json
@@ -1,0 +1,52 @@
+{
+	"metadata": {
+		"slug": "Docker",
+		"name": "Docker Service",
+		"short_description": "Lifecycle management workflow of any PCA Docker service for Cloud Automation",
+		"author": "ActiveEon's Team",
+		"tags": ["Cloud Automation", "Docker", "Container", "Image"],
+		"version": "1.0"
+	},
+	"dependencies": ["CloudAutomationClient"],
+	"catalog" : {
+		"bucket" : "cloud-automation",
+		"objects" : [
+			{
+				"name" : "Docker",
+				"metadata" : {
+					"kind": "Workflow/pca",
+					"commitMessage": "First commit",
+					"contentType": "application/xml"
+				},
+				"file" : "resources/catalog/Docker.xml"
+			},
+			{
+				"name" : "Finish_Docker",
+				"metadata" : {
+					"kind": "Workflow/pca",
+					"commitMessage": "First commit",
+					"contentType": "application/xml"
+				},
+				"file" : "resources/catalog/Finish_Docker.xml"
+			},
+			{
+				"name" : "Resume_Docker",
+				"metadata" : {
+					"kind": "Workflow/pca",
+					"commitMessage": "First commit",
+					"contentType": "application/xml"
+				},
+				"file" : "resources/catalog/Resume_Docker.xml"
+			},
+			{
+				"name" : "Stop_Docker",
+				"metadata" : {
+					"kind": "Workflow/pca",
+					"commitMessage": "First commit",
+					"contentType": "application/xml"
+				},
+				"file" : "resources/catalog/Stop_Docker.xml"
+			}
+		]
+	}
+}

--- a/Docker/resources/catalog/Docker.xml
+++ b/Docker/resources/catalog/Docker.xml
@@ -1,0 +1,306 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:proactive:jobdescriptor:3.10"
+     xsi:schemaLocation="urn:proactive:jobdescriptor:3.10 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.10/schedulerjob.xsd"
+    name="Docker" projectName="Cloud Automation - Deployment"
+    priority="normal"
+    onTaskError="continueJobExecution"
+     maxNumberOfExecution="2">
+  <variables>
+    <variable name="DOCKER_CONFIG_VARS" value="" />
+    <variable name="DOCKER_CONTAINER" value="some-container" />
+    <variable name="DOCKER_ENV_VARS" value="" />
+    <variable name="DOCKER_IMAGE" value="" />
+    <variable name="DOCKER_PORT" value="" />
+  </variables>
+  <description>
+    <![CDATA[ Deploy a Docker image as a PCA service.
+The service can be started using the following variables:
+$DOCKER_IMAGE: Docker image name. It can include a tag as well.
+$DOCKER_PORT: The main image port. Please note that it will be forwarded to a random port that will be returned by this service.
+$DOCKER_CONTAINER: If you desire to stop this container and restart it later.
+$DOCKER_ENV_VARS (OPTIONAL): each environment variable should be preceded by -e 
+$DOCKER_CONFIG_VARS (OPTIONAL) if your docker image allows setting some parameters in some config files on launch ]]>
+  </description>
+  <genericInformation>
+    <info name="bucketName" value="cloud-automation"/>
+    <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+    <info name="group" value="public-objects"/>
+    <info name="pca.service.id" value="Docker"/>
+    <info name="pca.states" value="(VOID,RUNNING)"/>
+    <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/docker.png"/>
+  </genericInformation>
+  <taskFlow>
+    <task name="Loop_Over_Instance_Status">
+      <genericInformation>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/docker.png"/>
+        <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+      </genericInformation>
+      <depends>
+        <task ref="Start_Docker"/>
+      </depends>
+      <inputFiles>
+        <files  includes="cloud-automation-service-client-8.2.0-SNAPSHOT.jar" accessMode="transferFromGlobalSpace"/>
+      </inputFiles>
+      <forkEnvironment >
+        <additionalClasspath>
+          <pathElement path="cloud-automation-service-client-8.2.0-SNAPSHOT.jar"/>
+        </additionalClasspath>
+      </forkEnvironment>
+      <scriptExecutable>
+        <script>
+          <code language="groovy">
+            <![CDATA[
+import org.ow2.proactive.pca.service.client.ApiClient
+import org.ow2.proactive.pca.service.client.api.ServiceInstanceRestApi
+import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
+
+println("BEGIN " + variables.get("PA_TASK_NAME"))
+
+def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
+def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
+def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceName = variables.get("INSTANCE_NAME")
+
+println("INSTANCE_NAME="+instanceName)
+
+// Connect to Cloud Automation API
+def apiClient = new ApiClient()
+apiClient.setBasePath(pcaUrl)
+def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
+
+// Inform other platforms that other actions are canceled through Synchronization API
+def channel = "Service_Instance_" + instanceId
+synchronizationapi.put(channel, "DELETE_LAUNCHED", false)
+synchronizationapi.put(channel, "DELETE_INSTANCE", false)
+
+// Loop over service instance status
+def currentStatus = "RUNNING"
+
+while(currentStatus=="RUNNING") {
+    sleep(10000);
+    // Check docker container status
+    def ByteArrayOutputStream sout = new ByteArrayOutputStream();
+    def ByteArrayOutputStream serr = new ByteArrayOutputStream();
+    def proc = ["docker", "inspect", "--format", "{{ .State.Running }}", "${instanceName}"].execute().waitForProcessOutput(sout, serr)
+    def isContainerRunning = new String(sout.toByteArray()).trim().toBoolean()
+
+    if ((!isContainerRunning) && (!synchronizationapi.get(channel, "DELETE_LAUNCHED")) && (!synchronizationapi.get(channel, "STOP_LAUNCHED"))){
+        currentStatus = 'ERROR'
+        println("[ERROR] An internal error occured in docker container: " + instanceName)
+        // Update docker container is not running
+        def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
+        serviceInstanceData.setInstanceStatus(currentStatus)
+        serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+        break
+    }
+    // Check service instance status
+    currentStatus = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId).getInstanceStatus()
+    //println("Current Status: " + currentStatus)
+}
+
+// Allow the Delete workflow to be fulfilled
+synchronizationapi.put(channel, "DELETE_INSTANCE", true)
+
+println("END " + variables.get("PA_TASK_NAME"))
+]]>
+          </code>
+        </script>
+      </scriptExecutable>
+    </task>
+    <task name="Start_Docker"
+    
+    
+    onTaskError="cancelJob" >
+      <description>
+        <![CDATA[ Pull the given $DOCKER_IMAGE and start a container as a PCA Service.
+The service can be started using the following variables:
+$DOCKER_IMAGE: Docker image name. It can include a tag as well.
+$DOCKER_PORT: The main image port. Please note that it will be forwarded to a random port that will be returned by this service.
+$DOCKER_CONTAINER: If you desire to stop this container and restart it later.
+$DOCKER_ENV_VARS (OPTIONAL): each environment variable should be preceded by -e 
+$DOCKER_CONFIG_VARS (OPTIONAL) if your docker image allows setting some parameters in some config files on launch ]]>
+      </description>
+      <variables>
+        <variable name="DOCKER_IMAGE" value="" inherited="true" />
+        <variable name="DOCKER_PORT" value="" inherited="true" />
+        <variable name="DOCKER_ENV_VARS" value="" inherited="true" />
+        <variable name="DOCKER_CONFIG_VARS" value="" inherited="true" />
+        <variable name="DOCKER_CONTAINER" value="" inherited="true" />
+      </variables>
+      <genericInformation>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/docker.png"/>
+        <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+      </genericInformation>
+      <inputFiles>
+        <files  includes="cloud-automation-service-client-8.2.0-SNAPSHOT.jar" accessMode="transferFromGlobalSpace"/>
+      </inputFiles>
+      <forkEnvironment >
+        <additionalClasspath>
+          <pathElement path="cloud-automation-service-client-8.2.0-SNAPSHOT.jar"/>
+        </additionalClasspath>
+      </forkEnvironment>
+      <pre>
+        <script>
+          <code language="groovy">
+            <![CDATA[
+variables.put("INSTANCE_NAME",variables.get("DOCKER_CONTAINER"))
+]]>
+          </code>
+        </script>
+      </pre>
+      <scriptExecutable>
+        <script>
+          <code language="bash">
+            <![CDATA[
+echo BEGIN "$variables_PA_TASK_NAME"
+
+################################################################################
+### THIS PART IS IMAGE SPECIFIC. IF YOU NEED TO MODIFY SOMETHING, DO IT HERE ###
+DOCKER_IMAGE="$variables_DOCKER_IMAGE"
+PORT="$variables_DOCKER_PORT"
+ENV_VARS="$variables_DOCKER_ENV_VARS"
+CONFIG_VARS="$variables_DOCKER_CONFIG_VARS"
+INSTANCE_NAME="$variables_INSTANCE_NAME"
+
+if [ -z "$DOCKER_IMAGE" ]; then
+    echo ERROR: The DOCKER_IMAGE is not provided by the user. Empty value is not allowed.
+    exit 1
+fi
+
+if [ -z "$INSTANCE_NAME" ]; then
+    echo ERROR: The INSTANCE_NAME is not provided by the user. Empty value is not allowed.
+    exit 1
+fi
+
+if [ -z "$PORT" ]; then
+    echo ERROR: The PORT is not provided by the user. Empty value is not allowed.
+    exit 1
+fi
+
+echo DOCKER_IMAGE = "$DOCKER_IMAGE"
+echo DOCKER_PORT = "$PORT"
+echo DOCKER_CONTAINER = "$INSTANCE_NAME"
+echo DOCKER_ENV_VARS = "$variables_DOCKER_ENV_VARS"
+echo DOCKER_CONFIG_VARS = "$CONFIG_VARS"
+################################################################################
+
+echo "Pulling "$variables_PA_JOB_NAME" image"
+docker pull $DOCKER_IMAGE
+
+if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
+    RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)
+    STOPPED=$(docker inspect --format="{{ .State.Status }}" $INSTANCE_NAME 2> /dev/null)
+    if [ "$RUNNING" == "true" ]; then
+        echo "$INSTANCE_NAME" container is running
+        echo $INSTANCE_NAME > $INSTANCE_NAME"_status"
+	elif [ "$STOPPED" == "exited" ]; then
+		echo Starting docker container: "$INSTANCE_NAME"
+        INSTANCE_STATUS=$(docker start $INSTANCE_NAME 2>&1)
+        echo $INSTANCE_STATUS > $INSTANCE_NAME"_status"
+    fi
+else
+    ################################################################################
+    ### THIS PART IS IMAGE SPECIFIC. IF YOU NEED TO MODIFY SOMETHING, DO IT HERE ###
+    echo "Running docker container: $INSTANCE_NAME"
+    echo "docker run --name $INSTANCE_NAME -p "$PORT" "$ENV_VARS" -d "$DOCKER_IMAGE" "$CONFIG_VARS""
+    if [ -z "$ENV_VARS" -a -z "$CONFIG_VARS" ]; then
+        INSTANCE_STATUS=$(docker run --name $INSTANCE_NAME -p "$PORT" -d "$DOCKER_IMAGE" 2>&1)
+    elif [ ! -z "$ENV_VARS" -a -z "$CONFIG_VARS" ]; then
+        INSTANCE_STATUS=$(docker run --name $INSTANCE_NAME -p "$PORT" "$ENV_VARS" -d "$DOCKER_IMAGE" 2>&1)
+    elif [ -z "$ENV_VARS" -a ! -z "$CONFIG_VARS" ]; then
+        INSTANCE_STATUS=$(docker run --name $INSTANCE_NAME -p "$PORT" -d "$DOCKER_IMAGE" "$CONFIG_VARS" 2>&1)
+    else
+        INSTANCE_STATUS=$(docker run --name $INSTANCE_NAME -p "$PORT" "$ENV_VARS" -d "$DOCKER_IMAGE" "$CONFIG_VARS" 2>&1)
+    fi
+    if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
+        RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)
+        if [ "$RUNNING" == "true" ]; then
+            echo $INSTANCE_NAME > $INSTANCE_NAME"_status"
+        fi
+    else
+        echo $INSTANCE_STATUS > $INSTANCE_NAME"_status"
+    fi
+    ################################################################################
+fi
+port=$(docker inspect --format='{{(index (index .NetworkSettings.Ports "'$PORT'/tcp") 0).HostPort}}' $INSTANCE_NAME)
+echo $port > $INSTANCE_NAME"_port"
+
+# Endpoint added to the job variables using a groovy post-script
+]]>
+          </code>
+        </script>
+      </scriptExecutable>
+      <post>
+        <script>
+          <code language="groovy">
+            <![CDATA[
+/*********************************************************************************
+* THIS POSTSCRIPT PROPAGATES USEFUL INFORMATION SUCH AS:                         *
+* 1) SERVICE ENDPOINT (PROTOCOL://HOSTNAME:PORT)                                 *
+* 2) CREDENTIALS (IF THERE ARE ANY) BY ADDING THEM TO 3RD PARTY CREDENTIALS      *
+*********************************************************************************/
+
+import org.ow2.proactive.pca.service.client.ApiClient
+import org.ow2.proactive.pca.service.client.api.ServiceInstanceRestApi
+import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
+
+def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
+def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
+// Acquire service instance id and instance name
+def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceName = variables.get("INSTANCE_NAME")
+
+def hostname = new URL(paSchedulerRestUrl).getHost()
+def port = new File(instanceName+"_port").text.trim()
+def endpoint = 'http://'+ hostname + ":" + port
+
+/*********************************************************************************
+* THIS PART IS IMAGE SPECIFIC. IF YOU NEED TO MODIFY SOMETHING, DO IT HERE       *
+/********************************************************************************/
+
+/********************************************************************************/
+
+// Connect to Cloud Automation API
+def apiClient = new ApiClient()
+apiClient.setBasePath(pcaUrl)
+def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
+
+// Inform other platforms that service is running through Synchronization API
+def channel = "Service_Instance_" + instanceId
+synchronizationapi.createChannelIfAbsent(channel, false)
+synchronizationapi.put(channel, "RUNNING", true)
+synchronizationapi.put(channel, "INSTANCE_NAME", instanceName)
+
+// Update service instance data : (status, endpoint)
+def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
+def status = new File(instanceName+"_status").text.trim()
+currentStatus = (!status.equals(instanceName)) ? "ERROR" : "RUNNING"
+serviceInstanceData.setInstanceStatus(currentStatus)
+serviceInstanceData = serviceInstanceData.putInstanceEndpointsItem(instanceName, endpoint)
+serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+
+// Print warning or error messages and force job to exit with error if there are any.
+if (!status.equals(instanceName)){
+    println("[ERROR] Could not start docker container: " + instanceName + ". Docker output: " + status)
+    //serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+    System.exit(1)
+} else {
+    //otherwise add an endpoint   
+}
+
+
+
+// LOG OUTPUT
+println(variables.get("PA_JOB_NAME") + "_INSTANCE_ID: " + instanceId)
+println(variables.get("PA_JOB_NAME") + "_ENDPOINT: " + endpoint)
+
+println("END " + variables.get("PA_TASK_NAME"))
+]]>
+          </code>
+        </script>
+      </post>
+    </task>
+  </taskFlow>
+</job>

--- a/Docker/resources/catalog/Docker.xml
+++ b/Docker/resources/catalog/Docker.xml
@@ -6,7 +6,7 @@
     name="Docker" projectName="Cloud Automation - Deployment"
     priority="normal"
     onTaskError="continueJobExecution"
-     maxNumberOfExecution="2">
+     maxNumberOfExecution="2">
   <variables>
     <variable name="DOCKER_CONFIG_VARS" value="" />
     <variable name="DOCKER_CONTAINER" value="some-container" />

--- a/Docker/resources/catalog/Finish_Docker.xml
+++ b/Docker/resources/catalog/Finish_Docker.xml
@@ -6,7 +6,7 @@
     name="Finish_Docker" projectName="Cloud Automation - Lifecycle"
     priority="normal"
     onTaskError="continueJobExecution"
-     maxNumberOfExecution="2">
+     maxNumberOfExecution="2">
   <description>
     <![CDATA[ Delete Docker instance. ]]>
   </description>

--- a/Docker/resources/catalog/Finish_Docker.xml
+++ b/Docker/resources/catalog/Finish_Docker.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:proactive:jobdescriptor:3.10"
+     xsi:schemaLocation="urn:proactive:jobdescriptor:3.10 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.10/schedulerjob.xsd"
+    name="Finish_Docker" projectName="Cloud Automation - Lifecycle"
+    priority="normal"
+    onTaskError="continueJobExecution"
+     maxNumberOfExecution="2">
+  <description>
+    <![CDATA[ Delete Docker instance. ]]>
+  </description>
+  <genericInformation>
+    <info name="bucketName" value="cloud-automation"/>
+    <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+    <info name="group" value="public-objects"/>
+    <info name="pca.service.id" value="Docker"/>
+    <info name="pca.states" value="(RUNNING,FINISHED)(STOPPED,FINISHED)(ERROR,FINISHED)"/>
+    <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/docker.png"/>
+  </genericInformation>
+  <taskFlow>
+    <task name="Finish_Docker">
+      <description>
+        <![CDATA[ Finish Docker service instance and remove its docker container ]]>
+      </description>
+      <genericInformation>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/docker.png"/>
+        <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+      </genericInformation>
+      <inputFiles>
+        <files  includes="cloud-automation-service-client-8.2.0-SNAPSHOT.jar" accessMode="transferFromGlobalSpace"/>
+      </inputFiles>
+      <forkEnvironment >
+        <additionalClasspath>
+          <pathElement path="cloud-automation-service-client-8.2.0-SNAPSHOT.jar"/>
+        </additionalClasspath>
+      </forkEnvironment>
+      <pre>
+        <script>
+          <code language="groovy">
+            <![CDATA[
+/*********************************************************************************
+* THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS BEING FINISHED             *
+*********************************************************************************/
+
+// Acquire service instance id and instance name from synchro channel
+def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def channel = "Service_Instance_" + instanceId
+def instanceName = synchronizationapi.get(channel, "INSTANCE_NAME")
+variables.put("INSTANCE_NAME", instanceName)
+
+// Inform other platforms that service is being finished through Synchronization API
+synchronizationapi.put(channel, "DELETE_LAUNCHED", true)
+]]>
+          </code>
+        </script>
+      </pre>
+      <scriptExecutable>
+        <script>
+          <code language="bash">
+            <![CDATA[
+echo --- BEGIN  "$variables_PA_TASK_NAME"  ---
+
+echo Removing docker container: "$variables_INSTANCE_NAME"
+INSTANCE_NAME=$(docker rm -f $variables_INSTANCE_NAME 2>&1)
+echo $INSTANCE_NAME > $variables_INSTANCE_NAME"_status"
+]]>
+          </code>
+        </script>
+      </scriptExecutable>
+      <post>
+        <script>
+          <code language="groovy">
+            <![CDATA[
+/*********************************************************************************
+* THIS POSTSCRIPT INFORMS PLATFORM THAT PCA SERVICE IS DELETED                   *
+*********************************************************************************/
+
+import org.ow2.proactive.pca.service.client.ApiClient
+import org.ow2.proactive.pca.service.client.api.ServiceInstanceRestApi
+import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
+
+def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
+def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
+def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceName = variables.get("INSTANCE_NAME")
+    
+def ALREADY_REMOVED_MESSAGE = "Error: No such container: " + instanceName
+
+// Connect to Cloud Automation API
+def apiClient = new ApiClient()
+apiClient.setBasePath(pcaUrl)
+def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
+
+// Update service instance data : (status, endpoint)
+def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
+def status = new File(instanceName+"_status").text.trim()
+currentStatus = (!status.equals(ALREADY_REMOVED_MESSAGE) && !status.equals(instanceName)) ? "ERROR" : "FINISHED"
+serviceInstanceData.setInstanceStatus(currentStatus)
+serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+
+// Delete synchro channel
+def channel = "Service_Instance_" + instanceId
+synchronizationapi.waitUntil(channel, "DELETE_INSTANCE", "{k,x -> x == true}")
+synchronizationapi.deleteChannel(channel)
+
+// Print warning or error messages and force job to exit with error if there are any.
+if (status.equals(ALREADY_REMOVED_MESSAGE)){
+    println("[WARNING] docker container: " + instanceName + " is already removed.")
+} else if (!status.equals(instanceName)){
+    println("[ERROR] Could not remove docker container: " + instanceName + ". Docker output: " + status)
+    System.exit(1)
+}
+
+println("END " + variables.get("PA_TASK_NAME"))
+]]>
+          </code>
+        </script>
+      </post>
+    </task>
+  </taskFlow>
+</job>

--- a/Docker/resources/catalog/Resume_Docker.xml
+++ b/Docker/resources/catalog/Resume_Docker.xml
@@ -6,7 +6,7 @@
     name="Resume_Docker" projectName="Cloud Automation - Lifecycle"
     priority="normal"
     onTaskError="continueJobExecution"
-     maxNumberOfExecution="2">
+     maxNumberOfExecution="2">
   <description>
     <![CDATA[ Resume Docker container. ]]>
   </description>

--- a/Docker/resources/catalog/Resume_Docker.xml
+++ b/Docker/resources/catalog/Resume_Docker.xml
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:proactive:jobdescriptor:3.10"
+     xsi:schemaLocation="urn:proactive:jobdescriptor:3.10 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.10/schedulerjob.xsd"
+    name="Resume_Docker" projectName="Cloud Automation - Lifecycle"
+    priority="normal"
+    onTaskError="continueJobExecution"
+     maxNumberOfExecution="2">
+  <description>
+    <![CDATA[ Resume Docker container. ]]>
+  </description>
+  <genericInformation>
+    <info name="bucketName" value="cloud-automation"/>
+    <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+    <info name="group" value="public-objects"/>
+    <info name="pca.service.id" value="Docker"/>
+    <info name="pca.states" value="(STOPPED,RUNNING)(RUNNING,RUNNING)"/>
+    <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/docker.png"/>
+  </genericInformation>
+  <taskFlow>
+    <task name="Resume_Docker"
+    
+    
+    onTaskError="cancelJob" >
+      <description>
+        <![CDATA[ Resume Docker container ]]>
+      </description>
+      <genericInformation>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/docker.png"/>
+        <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+      </genericInformation>
+      <inputFiles>
+        <files  includes="cloud-automation-service-client-8.2.0-SNAPSHOT.jar" accessMode="transferFromGlobalSpace"/>
+      </inputFiles>
+      <forkEnvironment >
+        <additionalClasspath>
+          <pathElement path="cloud-automation-service-client-8.2.0-SNAPSHOT.jar"/>
+        </additionalClasspath>
+      </forkEnvironment>
+      <pre>
+        <script>
+          <code language="groovy">
+            <![CDATA[
+/*********************************************************************************
+* THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS BEING RESUMED              *
+*********************************************************************************/
+
+// Acquire service instance id from synchro channel
+def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def channel = "Service_Instance_" + instanceId
+def instanceName = synchronizationapi.get(channel, "INSTANCE_NAME")
+variables.put("INSTANCE_NAME", instanceName)
+
+// Inform other platforms that service is running through Synchronization API
+synchronizationapi.put(channel, "RUNNING", true)
+synchronizationapi.put(channel, "STOP_LAUNCHED", false)
+]]>
+          </code>
+        </script>
+      </pre>
+      <scriptExecutable>
+        <script>
+          <code language="bash">
+            <![CDATA[
+echo BEGIN  "$variables_PA_TASK_NAME"
+
+INSTANCE_NAME=$variables_INSTANCE_NAME
+
+if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
+ RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)
+ STOPPED=$(docker inspect --format="{{ .State.Status }}" $INSTANCE_NAME 2> /dev/null)
+	if [ "$RUNNING" == "true" ]; then
+   		echo docker container: "$INSTANCE_NAME" is running
+        echo $INSTANCE_NAME > $INSTANCE_NAME"_status"
+	elif [ "$STOPPED" == "exited" ]; then
+		echo Starting docker container: "$INSTANCE_NAME"
+        INSTANCE_STATUS=$(docker start $INSTANCE_NAME 2>&1)
+        echo $INSTANCE_STATUS > $INSTANCE_NAME"_status"
+	fi
+else 
+    echo Error: No such container: "$INSTANCE_NAME" > $INSTANCE_NAME"_status"
+fi
+]]>
+          </code>
+        </script>
+      </scriptExecutable>
+      <post>
+        <script>
+          <code language="groovy">
+            <![CDATA[
+/*********************************************************************************
+* THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS RESUMED                   *
+*********************************************************************************/
+
+import org.ow2.proactive.pca.service.client.ApiClient
+import org.ow2.proactive.pca.service.client.api.ServiceInstanceRestApi
+import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
+
+// Acquire service instance id
+def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceName = variables.get("INSTANCE_NAME")
+    
+def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
+def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
+
+// Connect to Cloud Automation API
+def apiClient = new ApiClient()
+apiClient.setBasePath(pcaUrl)
+def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
+
+// Update service instance data : (status, endpoint)
+def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
+def status = new File(instanceName+"_status").text.trim()
+currentStatus = (!status.equals(instanceName)) ? "ERROR" : "RUNNING"
+serviceInstanceData.setInstanceStatus(currentStatus)
+serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+
+// Print warning or error messages and force job to exit with error if there are any.
+if (!status.equals(instanceName)){
+    println("[ERROR] Could not resume docker container: " + instanceName + ". Docker output: " + status)
+    System.exit(1)
+}
+
+println("END " + variables.get("PA_TASK_NAME"))
+]]>
+          </code>
+        </script>
+      </post>
+    </task>
+    <task name="Loop_Over_Instance_Status">
+      <genericInformation>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/docker.png"/>
+        <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+      </genericInformation>
+      <depends>
+        <task ref="Resume_Docker"/>
+      </depends>
+      <inputFiles>
+        <files  includes="cloud-automation-service-client-8.2.0-SNAPSHOT.jar" accessMode="transferFromGlobalSpace"/>
+      </inputFiles>
+      <forkEnvironment >
+        <additionalClasspath>
+          <pathElement path="cloud-automation-service-client-8.2.0-SNAPSHOT.jar"/>
+        </additionalClasspath>
+      </forkEnvironment>
+      <scriptExecutable>
+        <script>
+          <code language="groovy">
+            <![CDATA[
+import org.ow2.proactive.pca.service.client.ApiClient
+import org.ow2.proactive.pca.service.client.api.ServiceInstanceRestApi
+import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
+
+println("BEGIN " + variables.get("PA_TASK_NAME"))
+
+def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
+def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
+def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceName = variables.get("INSTANCE_NAME")
+
+// Connect to Cloud Automation API
+def apiClient = new ApiClient()
+apiClient.setBasePath(pcaUrl)
+def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
+
+// Inform other platforms that other actions are canceled through Synchronization API
+def channel = "Service_Instance_" + instanceId
+synchronizationapi.put(channel, "DELETE_LAUNCHED", false)
+synchronizationapi.put(channel, "DELETE_INSTANCE", false)
+
+// Loop over service instance status
+def currentStatus = "RUNNING"
+
+while(currentStatus=="RUNNING") {
+    sleep(10000);
+    // Check docker container status
+    def ByteArrayOutputStream sout = new ByteArrayOutputStream();
+    def ByteArrayOutputStream serr = new ByteArrayOutputStream();
+    def proc = ["docker", "inspect", "--format", "{{ .State.Running }}", "${instanceName}"].execute().waitForProcessOutput(sout, serr)
+    def isContainerRunning = new String(sout.toByteArray()).trim().toBoolean()
+
+    if ((!isContainerRunning) && (!synchronizationapi.get(channel, "DELETE_LAUNCHED")) && (!synchronizationapi.get(channel, "STOP_LAUNCHED"))){
+        currentStatus = 'ERROR'
+        println("[ERROR] An internal error occured in docker container: " + instanceName)
+        // Update docker container is not running
+        def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
+        serviceInstanceData.setInstanceStatus(currentStatus)
+        serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+        break
+    }
+    // Check service instance status
+    currentStatus = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId).getInstanceStatus()
+    //println("Current Status: " + currentStatus)
+}
+
+// Allow the Delete workflow to be fulfilled
+synchronizationapi.put(channel, "DELETE_INSTANCE", true)
+
+println("END " + variables.get("PA_TASK_NAME"))
+]]>
+          </code>
+        </script>
+      </scriptExecutable>
+    </task>
+  </taskFlow>
+</job>

--- a/Docker/resources/catalog/Stop_Docker.xml
+++ b/Docker/resources/catalog/Stop_Docker.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:proactive:jobdescriptor:3.10"
+     xsi:schemaLocation="urn:proactive:jobdescriptor:3.10 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.10/schedulerjob.xsd"
+    name="Stop_Docker" projectName="Cloud Automation - Lifecycle"
+    priority="normal"
+    onTaskError="continueJobExecution"
+     maxNumberOfExecution="2">
+  <description>
+    <![CDATA[ Stop Docker container. ]]>
+  </description>
+  <genericInformation>
+    <info name="bucketName" value="cloud-automation"/>
+    <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+    <info name="group" value="public-objects"/>
+    <info name="pca.service.id" value="Docker"/>
+    <info name="pca.states" value="(RUNNING,STOPPED)"/>
+    <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/docker.png"/>
+  </genericInformation>
+  <taskFlow>
+    <task name="Stop_Docker">
+      <description>
+        <![CDATA[ Stop Docker container ]]>
+      </description>
+      <genericInformation>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/docker.png"/>
+        <info name="documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+      </genericInformation>
+      <inputFiles>
+        <files  includes="cloud-automation-service-client-8.2.0-SNAPSHOT.jar" accessMode="transferFromGlobalSpace"/>
+      </inputFiles>
+      <forkEnvironment >
+        <additionalClasspath>
+          <pathElement path="cloud-automation-service-client-8.2.0-SNAPSHOT.jar"/>
+        </additionalClasspath>
+      </forkEnvironment>
+      <pre>
+        <script>
+          <code language="groovy">
+            <![CDATA[
+/*********************************************************************************
+* THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS STOPPED                   *
+*********************************************************************************/
+
+// Acquire service instance id and instance name from synchro channel
+def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def channel = "Service_Instance_" + instanceId
+def instanceName = synchronizationapi.get(channel, "INSTANCE_NAME")
+variables.put("INSTANCE_NAME", instanceName)
+
+// Inform other platforms that service is being stopped through Synchronization API
+synchronizationapi.put(channel, "STOP_LAUNCHED", true)
+]]>
+          </code>
+        </script>
+      </pre>
+      <scriptExecutable>
+        <script>
+          <code language="bash">
+            <![CDATA[
+echo --- BEGIN "$variables_PA_TASK_NAME" ---
+
+echo Stopping docker container: "$variables_INSTANCE_NAME"
+INSTANCE_NAME=$(docker stop $variables_INSTANCE_NAME 2>&1)
+echo $INSTANCE_NAME > $variables_INSTANCE_NAME"_status"
+]]>
+          </code>
+        </script>
+      </scriptExecutable>
+      <post>
+        <script>
+          <code language="groovy">
+            <![CDATA[
+/*********************************************************************************
+* THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS STOPPED                   *
+*********************************************************************************/
+
+import org.ow2.proactive.pca.service.client.ApiClient
+import org.ow2.proactive.pca.service.client.api.ServiceInstanceRestApi
+import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
+
+def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
+def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
+
+// Acquire service instance id and instance name from synchro channel
+def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceName = variables.get("INSTANCE_NAME")
+
+// Connect to Cloud Automation API
+def apiClient = new ApiClient()
+apiClient.setBasePath(pcaUrl)
+def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
+
+// Update service instance data : (status, endpoint)
+def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
+def status = new File(instanceName+"_status").text.trim()
+currentStatus = (!status.equals(instanceName)) ? "ERROR" : "STOPPED"
+serviceInstanceData.setInstanceStatus(currentStatus)
+serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+
+// Print warning or error messages and force job to exit with error if there are any.
+if (!status.equals(instanceName)){
+    println("[ERROR] Could not stop docker container: " + instanceName + ". Docker output: " + status)
+    System.exit(1)
+}
+
+println("END " + variables.get("PA_TASK_NAME"))
+]]>
+          </code>
+        </script>
+      </post>
+    </task>
+  </taskFlow>
+</job>

--- a/Docker/resources/catalog/Stop_Docker.xml
+++ b/Docker/resources/catalog/Stop_Docker.xml
@@ -6,7 +6,7 @@
     name="Stop_Docker" projectName="Cloud Automation - Lifecycle"
     priority="normal"
     onTaskError="continueJobExecution"
-     maxNumberOfExecution="2">
+     maxNumberOfExecution="2">
   <description>
     <![CDATA[ Stop Docker container. ]]>
   </description>

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,7 @@ task zip (type: Zip){
     include 'DataVisualization/**'
     include 'DeepLearning/**'
     include 'DeepLearningWorkflows/**'
+    include 'Docker/**'
     include 'DockerBasics/**'
     include 'DockerSwarm/**'
     include 'Elasticsearch/**'


### PR DESCRIPTION
In this PR, we (@amouhoub &me) push a new and generic refactor of Docker PCA service which is able to manage the life-cycle of any new service.
This refactored version is much more generalized and allows to effortlessly create new services and states.