### PR TITLE
add Cassandra PCA service and client-side workflows

### DIFF
--- a/Cassandra/METADATA.json
+++ b/Cassandra/METADATA.json
@@ -1,0 +1,52 @@
+{
+	"metadata": {
+		"slug": "Cassandra",
+		"name": "Cassandra Service",
+		"short_description": "Lifecycle management workflow of Cassandra service for Cloud Automation",
+		"author": "ActiveEon's Team",
+		"tags": ["Cloud Automation", "Docker", "Cassandra", "Database", "NoSQL"],
+		"version": "1.0"
+	},
+	"dependencies": ["CloudAutomationClient"],
+	"catalog" : {
+		"bucket" : "cloud-automation",
+		"objects" : [
+			{
+				"name" : "Cassandra",
+				"metadata" : {
+					"kind": "Workflow/pca",
+					"commitMessage": "First commit",
+					"contentType": "application/xml"
+				},
+				"file" : "resources/catalog/Cassandra.xml"
+			},
+			{
+				"name" : "Finish_Cassandra",
+				"metadata" : {
+					"kind": "Workflow/pca",
+					"commitMessage": "First commit",
+					"contentType": "application/xml"
+				},
+				"file" : "resources/catalog/Finish_Cassandra.xml"
+			},
+			{
+				"name" : "Resume_Cassandra",
+				"metadata" : {
+					"kind": "Workflow/pca",
+					"commitMessage": "First commit",
+					"contentType": "application/xml"
+				},
+				"file" : "resources/catalog/Resume_Cassandra.xml"
+			},
+			{
+				"name" : "Stop_Cassandra",
+				"metadata" : {
+					"kind": "Workflow/pca",
+					"commitMessage": "First commit",
+					"contentType": "application/xml"
+				},
+				"file" : "resources/catalog/Stop_Cassandra.xml"
+			}
+		]
+	}
+}

--- a/Cassandra/resources/catalog/Cassandra.xml
+++ b/Cassandra/resources/catalog/Cassandra.xml
@@ -1,0 +1,252 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:proactive:jobdescriptor:3.10"
+     xsi:schemaLocation="urn:proactive:jobdescriptor:3.10 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.10/schedulerjob.xsd"
+    name="Cassandra" projectName="Cloud Automation - Deployment"
+    priority="normal"
+    onTaskError="continueJobExecution"
+     maxNumberOfExecution="2">
+  <variables>
+    <variable name="INSTANCE_NAME" value="cassandra-server" />
+    <variable name="ENV_VARS" value="" />
+  </variables>
+  <description>
+    <![CDATA[ Deploy a Cassandra Database server.
+The service can be started using the following variables:
+$INSTANCE_NAME (Required): service instance name.
+$ENV_VARS (Optional): List of the environment variables. ]]>
+  </description>
+  <genericInformation>
+    <info name="bucketName" value="cloud-automation"/>
+    <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png"/>
+    <info name="pca.states" value="(VOID,RUNNING)"/>
+    <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+    <info name="pca.service.id" value="Cassandra"/>
+    <info name="group" value="public-objects"/>
+  </genericInformation>
+  <taskFlow>
+    <task name="Loop_Over_Instance_Status">
+      <genericInformation>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png"/>
+        <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+      </genericInformation>
+      <depends>
+        <task ref="Start_Cassandra"/>
+      </depends>
+      <inputFiles>
+        <files  includes="cloud-automation-service-client-8.2.0-SNAPSHOT.jar" accessMode="transferFromGlobalSpace"/>
+      </inputFiles>
+      <forkEnvironment >
+        <additionalClasspath>
+          <pathElement path="cloud-automation-service-client-8.2.0-SNAPSHOT.jar"/>
+        </additionalClasspath>
+      </forkEnvironment>
+      <scriptExecutable>
+        <script>
+          <code language="groovy">
+            <![CDATA[
+import org.ow2.proactive.pca.service.client.ApiClient
+import org.ow2.proactive.pca.service.client.api.ServiceInstanceRestApi
+import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
+
+println("BEGIN " + variables.get("PA_TASK_NAME"))
+
+def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
+def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
+def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceName = variables.get("INSTANCE_NAME")
+
+println("INSTANCE_NAME="+instanceName)
+
+// Connect to Cloud Automation API
+def apiClient = new ApiClient()
+apiClient.setBasePath(pcaUrl)
+def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
+
+// Inform other platforms that other actions are canceled through Synchronization API
+def channel = "Service_Instance_" + instanceId
+synchronizationapi.put(channel, "DELETE_LAUNCHED", false)
+synchronizationapi.put(channel, "DELETE_INSTANCE", false)
+
+// Loop over service instance status
+def currentStatus = "RUNNING"
+def exitWithError = false
+while(currentStatus=="RUNNING") {
+    sleep(10000);
+    // Check docker container status
+    def ByteArrayOutputStream sout = new ByteArrayOutputStream();
+    def ByteArrayOutputStream serr = new ByteArrayOutputStream();
+    def proc = ["docker", "inspect", "--format", "{{ .State.Running }}", "${instanceName}"].execute().waitForProcessOutput(sout, serr)
+    def isContainerRunning = new String(sout.toByteArray()).trim().toBoolean()
+
+    if ((!isContainerRunning) && (!synchronizationapi.get(channel, "DELETE_LAUNCHED")) && (!synchronizationapi.get(channel, "STOP_LAUNCHED"))){
+        currentStatus = 'ERROR'
+        exitWithError = true
+        println("[ERROR] An internal error occured in docker container: " + instanceName)
+        // Update docker container is not running
+        def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
+        serviceInstanceData.setInstanceStatus(currentStatus)
+        serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+        break
+    }
+    // Check service instance status
+    currentStatus = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId).getInstanceStatus()
+}
+
+// Allow the Delete workflow to be fulfilled
+synchronizationapi.put(channel, "DELETE_INSTANCE", true)
+if (exitWithError){
+    System.exit(1)
+}
+println("END " + variables.get("PA_TASK_NAME"))
+]]>
+          </code>
+        </script>
+      </scriptExecutable>
+    </task>
+    <task name="Start_Cassandra">
+      <description>
+        <![CDATA[ Pull Cassandra image and start a container ]]>
+      </description>
+      <genericInformation>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png"/>
+        <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+      </genericInformation>
+      <inputFiles>
+        <files  includes="cloud-automation-service-client-8.2.0-SNAPSHOT.jar" accessMode="transferFromGlobalSpace"/>
+      </inputFiles>
+      <forkEnvironment >
+        <additionalClasspath>
+          <pathElement path="cloud-automation-service-client-8.2.0-SNAPSHOT.jar"/>
+        </additionalClasspath>
+      </forkEnvironment>
+      <scriptExecutable>
+        <script>
+          <code language="bash">
+            <![CDATA[
+echo BEGIN "$variables_PA_TASK_NAME"
+
+################################################################################
+### THIS PART IS IMAGE SPECIFIC. IF YOU NEED TO MODIFY SOMETHING, DO IT HERE ###
+DOCKER_IMAGE=activeeon/cassandra
+PORT=3306
+ENV_VARS=$variables_ENV_VARS
+################################################################################
+
+echo "Pulling "$variables_PA_JOB_NAME" image"
+docker pull $DOCKER_IMAGE
+
+INSTANCE_NAME=$variables_INSTANCE_NAME
+
+if [ -z "$INSTANCE_NAME" ]; then
+    echo ERROR: The INSTANCE_NAME is not provided by the user. Empty value is not allowed.
+    exit 1
+fi
+
+if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
+    RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)
+    STOPPED=$(docker inspect --format="{{ .State.Status }}" $INSTANCE_NAME 2> /dev/null)
+    if [ "$RUNNING" == "true" ]; then
+        echo "$INSTANCE_NAME" container is running
+        echo $INSTANCE_NAME > $INSTANCE_NAME"_status"
+	elif [ "$STOPPED" == "exited" ]; then
+		echo Starting docker container: "$INSTANCE_NAME"
+        INSTANCE_STATUS=$(docker start $INSTANCE_NAME 2>&1)
+        echo $INSTANCE_STATUS > $INSTANCE_NAME"_status"
+    fi
+else
+    ################################################################################
+    ### THIS PART IS IMAGE SPECIFIC. IF YOU NEED TO MODIFY SOMETHING, DO IT HERE ###
+    echo "Running $INSTANCE_NAME container"
+    if [ -z "$ENV_VARS" ]; then
+        INSTANCE_STATUS=$( eval "docker run --name "$INSTANCE_NAME" -p "$PORT" -d "$DOCKER_IMAGE"" 2>&1)
+    else 
+        INSTANCE_STATUS=$( eval "docker run --name "$INSTANCE_NAME" -p "$PORT" "$ENV_VARS" -d "$DOCKER_IMAGE"" 2>&1)    
+    fi 
+    ################################################################################
+    if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
+        RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)
+        if [ "$RUNNING" == "true" ]; then
+            echo $INSTANCE_NAME > $INSTANCE_NAME"_status"
+        fi
+    else
+        echo $INSTANCE_STATUS > $INSTANCE_NAME"_status"
+    fi
+fi
+
+port=$(docker inspect --format='{{(index (index .NetworkSettings.Ports "'$PORT'/tcp") 0).HostPort}}' $INSTANCE_NAME)
+echo "$port" > $INSTANCE_NAME"_port"
+
+# Endpoint added to the job variables using a groovy post-script
+]]>
+          </code>
+        </script>
+      </scriptExecutable>
+      <post>
+        <script>
+          <code language="groovy">
+            <![CDATA[
+/*********************************************************************************
+* THIS POSTSCRIPT PROPAGATES USEFUL INFORMATION SUCH AS:                         *
+* 1) SERVICE ENDPOINT (PROTOCOL://HOSTNAME:PORT)                                 *
+* 2) CREDENTIALS (IF THERE ARE ANY) BY ADDING THEM TO 3RD PARTY CREDENTIALS      *
+*********************************************************************************/
+
+import org.ow2.proactive.pca.service.client.ApiClient
+import org.ow2.proactive.pca.service.client.api.ServiceInstanceRestApi
+import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
+
+def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
+def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
+// Acquire service instance id and instance name
+def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceName = variables.get("INSTANCE_NAME")
+
+def hostname = new URL(paSchedulerRestUrl).getHost()
+def port = new File(instanceName+"_port").text.trim()
+def endpoint = 'http://'+ hostname + ":" + port
+
+/*********************************************************************************
+* THIS PART IS IMAGE SPECIFIC. IF YOU NEED TO MODIFY SOMETHING, DO IT HERE       *
+/********************************************************************************/
+
+/********************************************************************************/
+
+// Connect to Cloud Automation API
+def apiClient = new ApiClient()
+apiClient.setBasePath(pcaUrl)
+def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
+
+// Inform other platforms that service is running through Synchronization API
+def channel = "Service_Instance_" + instanceId
+synchronizationapi.createChannelIfAbsent(channel, false)
+synchronizationapi.put(channel, "RUNNING", true)
+synchronizationapi.put(channel, "INSTANCE_NAME", instanceName)
+
+// Update service instance data : (status, endpoint)
+def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
+def status = new File(instanceName+"_status").text.trim()
+def currentStatus = (!status.equals(instanceName)) ? "ERROR" : "RUNNING"
+serviceInstanceData.setInstanceStatus(currentStatus)
+serviceInstanceData = serviceInstanceData.putInstanceEndpointsItem(instanceName, endpoint)
+serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+
+// Print warning or error messages and force job to exit with error if there are any.
+if (!status.equals(instanceName)){
+    println("[ERROR] Could not start docker container: " + instanceName + ". Docker output: " + status)
+    System.exit(1)
+}
+
+// LOG OUTPUT
+println(variables.get("PA_JOB_NAME") + "_INSTANCE_ID: " + instanceId)
+println(variables.get("PA_JOB_NAME") + "_ENDPOINT: " + endpoint)
+
+println("END " + variables.get("PA_TASK_NAME"))
+]]>
+          </code>
+        </script>
+      </post>
+    </task>
+  </taskFlow>
+</job>

--- a/Cassandra/resources/catalog/Finish_Cassandra.xml
+++ b/Cassandra/resources/catalog/Finish_Cassandra.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:proactive:jobdescriptor:3.10"
+     xsi:schemaLocation="urn:proactive:jobdescriptor:3.10 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.10/schedulerjob.xsd"
+    name="Finish_Cassandra" projectName="Cloud Automation - Lifecycle"
+    priority="normal"
+    onTaskError="continueJobExecution"
+     maxNumberOfExecution="2">
+  <description>
+    <![CDATA[ Delete Cassandra instance. ]]>
+  </description>
+  <genericInformation>
+    <info name="bucketName" value="cloud-automation"/>
+    <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png"/>
+    <info name="pca.states" value="(RUNNING,FINISHED)(STOPPED,FINISHED)(ERROR,FINISHED)"/>
+    <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+    <info name="pca.service.id" value="Cassandra"/>
+    <info name="group" value="public-objects"/>
+  </genericInformation>
+  <taskFlow>
+    <task name="Finish_Cassandra">
+      <description>
+        <![CDATA[ Finish Cassandra instance and remove its docker container ]]>
+      </description>
+      <genericInformation>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png"/>
+        <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+      </genericInformation>
+      <inputFiles>
+        <files  includes="cloud-automation-service-client-8.2.0-SNAPSHOT.jar" accessMode="transferFromGlobalSpace"/>
+      </inputFiles>
+      <forkEnvironment >
+        <additionalClasspath>
+          <pathElement path="cloud-automation-service-client-8.2.0-SNAPSHOT.jar"/>
+        </additionalClasspath>
+      </forkEnvironment>
+      <pre>
+        <script>
+          <code language="groovy">
+            <![CDATA[
+/*********************************************************************************
+* THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS BEING FINISHED             *
+*********************************************************************************/
+
+// Acquire service instance id and instance name from synchro channel
+def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def channel = "Service_Instance_" + instanceId
+def instanceName = synchronizationapi.get(channel, "INSTANCE_NAME")
+variables.put("INSTANCE_NAME", instanceName)
+
+// Inform other platforms that service is being finished through Synchronization API
+synchronizationapi.put(channel, "DELETE_LAUNCHED", true)
+]]>
+          </code>
+        </script>
+      </pre>
+      <scriptExecutable>
+        <script>
+          <code language="bash">
+            <![CDATA[
+echo --- BEGIN  "$variables_PA_TASK_NAME"  ---
+
+echo Removing docker container: "$variables_INSTANCE_NAME"
+INSTANCE_NAME=$(docker rm -f $variables_INSTANCE_NAME 2>&1)
+echo $INSTANCE_NAME > $variables_INSTANCE_NAME"_status"
+]]>
+          </code>
+        </script>
+      </scriptExecutable>
+      <post>
+        <script>
+          <code language="groovy">
+            <![CDATA[
+/*********************************************************************************
+* THIS POSTSCRIPT INFORMS PLATFORM THAT PCA SERVICE IS DELETED                   *
+*********************************************************************************/
+
+import org.ow2.proactive.pca.service.client.ApiClient
+import org.ow2.proactive.pca.service.client.api.ServiceInstanceRestApi
+import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
+
+def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
+def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
+def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceName = variables.get("INSTANCE_NAME")
+    
+def ALREADY_REMOVED_MESSAGE = "Error: No such container: " + instanceName
+
+// Connect to Cloud Automation API
+def apiClient = new ApiClient()
+apiClient.setBasePath(pcaUrl)
+def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
+
+// Update service instance data : (status, endpoint)
+def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
+def status = new File(instanceName+"_status").text.trim()
+def currentStatus = (!status.equals(ALREADY_REMOVED_MESSAGE) && !status.equals(instanceName)) ? "ERROR" : "FINISHED"
+serviceInstanceData.setInstanceStatus(currentStatus)
+serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+
+// Delete synchro channel
+def channel = "Service_Instance_" + instanceId
+synchronizationapi.waitUntil(channel, "DELETE_INSTANCE", "{k,x -> x == true}")
+synchronizationapi.deleteChannel(channel)
+
+// Print warning or error messages and force job to exit with error if there are any.
+if (status.equals(ALREADY_REMOVED_MESSAGE)){
+    println("[WARNING] docker container: " + instanceName + " is already removed.")
+} else if (!status.equals(instanceName)){
+    println("[ERROR] Could not remove docker container: " + instanceName + ". Docker output: " + status)
+    System.exit(1)
+}
+
+println("END " + variables.get("PA_TASK_NAME"))
+]]>
+          </code>
+        </script>
+      </post>
+    </task>
+  </taskFlow>
+</job>

--- a/Cassandra/resources/catalog/Resume_Cassandra.xml
+++ b/Cassandra/resources/catalog/Resume_Cassandra.xml
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:proactive:jobdescriptor:3.10"
+     xsi:schemaLocation="urn:proactive:jobdescriptor:3.10 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.10/schedulerjob.xsd"
+    name="Resume_Cassandra" projectName="Cloud Automation - Lifecycle"
+    priority="normal"
+    onTaskError="continueJobExecution"
+     maxNumberOfExecution="2">
+  <description>
+    <![CDATA[ Resume Cassandra instance. ]]>
+  </description>
+  <genericInformation>
+    <info name="bucketName" value="cloud-automation"/>
+    <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png"/>
+    <info name="pca.states" value="(STOPPED,RUNNING)(RUNNING,RUNNING)"/>
+    <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+    <info name="pca.service.id" value="Cassandra"/>
+    <info name="group" value="public-objects"/>
+  </genericInformation>
+  <taskFlow>
+    <task name="Resume_Cassandra">
+      <description>
+        <![CDATA[ Resume Cassandra instance ]]>
+      </description>
+      <genericInformation>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png"/>
+        <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+      </genericInformation>
+      <inputFiles>
+        <files  includes="cloud-automation-service-client-8.2.0-SNAPSHOT.jar" accessMode="transferFromGlobalSpace"/>
+      </inputFiles>
+      <forkEnvironment >
+        <additionalClasspath>
+          <pathElement path="cloud-automation-service-client-8.2.0-SNAPSHOT.jar"/>
+        </additionalClasspath>
+      </forkEnvironment>
+      <pre>
+        <script>
+          <code language="groovy">
+            <![CDATA[
+/*********************************************************************************
+* THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS BEING RESUMED              *
+*********************************************************************************/
+
+// Acquire service instance id and instance name from synchro channel
+def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def channel = "Service_Instance_" + instanceId
+
+// Inform other platforms that service is running through Synchronization API
+synchronizationapi.put(channel, "RUNNING", true)
+synchronizationapi.put(channel, "STOP_LAUNCHED", false)
+]]>
+          </code>
+        </script>
+      </pre>
+      <scriptExecutable>
+        <script>
+          <code language="bash">
+            <![CDATA[
+echo BEGIN  "$variables_PA_TASK_NAME"
+
+INSTANCE_NAME=$variables_INSTANCE_NAME
+
+if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
+ RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)
+ STOPPED=$(docker inspect --format="{{ .State.Status }}" $INSTANCE_NAME 2> /dev/null)
+	if [ "$RUNNING" == "true" ]; then
+   		echo docker container: "$INSTANCE_NAME" is running
+        echo $INSTANCE_NAME > $INSTANCE_NAME"_status"
+	elif [ "$STOPPED" == "exited" ]; then
+		echo Starting docker container: "$INSTANCE_NAME"
+        INSTANCE_STATUS=$(docker start $INSTANCE_NAME 2>&1)
+        echo $INSTANCE_STATUS > $INSTANCE_NAME"_status"
+	fi
+else 
+    echo Error: No such container: "$INSTANCE_NAME" > $INSTANCE_NAME"_status"
+fi
+]]>
+          </code>
+        </script>
+      </scriptExecutable>
+      <post>
+        <script>
+          <code language="groovy">
+            <![CDATA[
+/*********************************************************************************
+* THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS RESUMED                   *
+*********************************************************************************/
+
+import org.ow2.proactive.pca.service.client.ApiClient
+import org.ow2.proactive.pca.service.client.api.ServiceInstanceRestApi
+import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
+
+// Acquire service instance id
+def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceName = variables.get("INSTANCE_NAME")
+    
+def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
+def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
+
+// Connect to Cloud Automation API
+def apiClient = new ApiClient()
+apiClient.setBasePath(pcaUrl)
+def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
+
+// Update service instance data : (status, endpoint)
+def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
+def status = new File(instanceName+"_status").text.trim()
+def currentStatus = (!status.equals(instanceName)) ? "ERROR" : "RUNNING"
+serviceInstanceData.setInstanceStatus(currentStatus)
+serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+
+// Print warning or error messages and force job to exit with error if there are any.
+if (!status.equals(instanceName)){
+    println("[ERROR] Could not resume docker container: " + instanceName + ". Docker output: " + status)
+    System.exit(1)
+}
+
+println("END " + variables.get("PA_TASK_NAME"))
+]]>
+          </code>
+        </script>
+      </post>
+    </task>
+    <task name="Loop_Over_Instance_Status">
+      <genericInformation>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png"/>
+        <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+      </genericInformation>
+      <depends>
+        <task ref="Resume_Cassandra"/>
+      </depends>
+      <inputFiles>
+        <files  includes="cloud-automation-service-client-8.2.0-SNAPSHOT.jar" accessMode="transferFromGlobalSpace"/>
+      </inputFiles>
+      <forkEnvironment >
+        <additionalClasspath>
+          <pathElement path="cloud-automation-service-client-8.2.0-SNAPSHOT.jar"/>
+        </additionalClasspath>
+      </forkEnvironment>
+      <scriptExecutable>
+        <script>
+          <code language="groovy">
+            <![CDATA[
+import org.ow2.proactive.pca.service.client.ApiClient
+import org.ow2.proactive.pca.service.client.api.ServiceInstanceRestApi
+import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
+
+println("BEGIN " + variables.get("PA_TASK_NAME"))
+
+def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
+def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
+def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceName = variables.get("INSTANCE_NAME")
+
+// Connect to Cloud Automation API
+def apiClient = new ApiClient()
+apiClient.setBasePath(pcaUrl)
+def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
+
+// Inform other platforms that other actions are canceled through Synchronization API
+def channel = "Service_Instance_" + instanceId
+synchronizationapi.put(channel, "DELETE_LAUNCHED", false)
+synchronizationapi.put(channel, "DELETE_INSTANCE", false)
+
+// Loop over service instance status
+def currentStatus = "RUNNING"
+
+while(currentStatus=="RUNNING") {
+    sleep(10000);
+    // Check docker container status
+    def ByteArrayOutputStream sout = new ByteArrayOutputStream();
+    def ByteArrayOutputStream serr = new ByteArrayOutputStream();
+    def proc = ["docker", "inspect", "--format", "{{ .State.Running }}", "${instanceName}"].execute().waitForProcessOutput(sout, serr)
+    def isContainerRunning = new String(sout.toByteArray()).trim().toBoolean()
+
+    if ((!isContainerRunning) && (!synchronizationapi.get(channel, "DELETE_LAUNCHED")) && (!synchronizationapi.get(channel, "STOP_LAUNCHED"))){
+        currentStatus = 'ERROR'
+        println("[ERROR] An internal error occured in docker container: " + instanceName)
+        // Update docker container is not running
+        def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
+        serviceInstanceData.setInstanceStatus(currentStatus)
+        serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+        break
+    }
+    // Check service instance status
+    currentStatus = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId).getInstanceStatus()
+}
+
+// Allow the Delete workflow to be fulfilled
+synchronizationapi.put(channel, "DELETE_INSTANCE", true)
+
+println("END " + variables.get("PA_TASK_NAME"))
+]]>
+          </code>
+        </script>
+      </scriptExecutable>
+    </task>
+  </taskFlow>
+</job>

--- a/Cassandra/resources/catalog/Stop_Cassandra.xml
+++ b/Cassandra/resources/catalog/Stop_Cassandra.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:proactive:jobdescriptor:3.10"
+     xsi:schemaLocation="urn:proactive:jobdescriptor:3.10 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.10/schedulerjob.xsd"
+    name="Stop_Cassandra" projectName="Cloud Automation - Lifecycle"
+    priority="normal"
+    onTaskError="continueJobExecution"
+     maxNumberOfExecution="2">
+  <description>
+    <![CDATA[ Stop Cassandra instance. ]]>
+  </description>
+  <genericInformation>
+    <info name="bucketName" value="cloud-automation"/>
+    <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png"/>
+    <info name="pca.states" value="(RUNNING,STOPPED)"/>
+    <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+    <info name="pca.service.id" value="Cassandra"/>
+    <info name="group" value="public-objects"/>
+  </genericInformation>
+  <taskFlow>
+    <task name="Stop_Cassandra">
+      <description>
+        <![CDATA[ Stop Cassandra instance ]]>
+      </description>
+      <genericInformation>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png"/>
+        <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+      </genericInformation>
+      <inputFiles>
+        <files  includes="cloud-automation-service-client-8.2.0-SNAPSHOT.jar" accessMode="transferFromGlobalSpace"/>
+      </inputFiles>
+      <forkEnvironment >
+        <additionalClasspath>
+          <pathElement path="cloud-automation-service-client-8.2.0-SNAPSHOT.jar"/>
+        </additionalClasspath>
+      </forkEnvironment>
+      <pre>
+        <script>
+          <code language="groovy">
+            <![CDATA[
+/*********************************************************************************
+* THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS STOPPED                   *
+*********************************************************************************/
+
+// Acquire service instance id and instance name from synchro channel
+def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def channel = "Service_Instance_" + instanceId
+
+// Inform other platforms that service is being stopped through Synchronization API
+synchronizationapi.put(channel, "STOP_LAUNCHED", true)
+]]>
+          </code>
+        </script>
+      </pre>
+      <scriptExecutable>
+        <script>
+          <code language="bash">
+            <![CDATA[
+echo --- BEGIN "$variables_PA_TASK_NAME" ---
+
+echo Stopping docker container: "$variables_INSTANCE_NAME"
+INSTANCE_NAME=$(docker stop $variables_INSTANCE_NAME 2>&1)
+echo $INSTANCE_NAME > $variables_INSTANCE_NAME"_status"
+]]>
+          </code>
+        </script>
+      </scriptExecutable>
+      <post>
+        <script>
+          <code language="groovy">
+            <![CDATA[
+/*********************************************************************************
+* THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS STOPPED                   *
+*********************************************************************************/
+
+import org.ow2.proactive.pca.service.client.ApiClient
+import org.ow2.proactive.pca.service.client.api.ServiceInstanceRestApi
+import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
+
+def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
+def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
+
+// Acquire service instance id and instance name from synchro channel
+def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceName = variables.get("INSTANCE_NAME")
+
+// Connect to Cloud Automation API
+def apiClient = new ApiClient()
+apiClient.setBasePath(pcaUrl)
+def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
+
+// Update service instance data : (status, endpoint)
+def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
+def status = new File(instanceName+"_status").text.trim()
+def currentStatus = (!status.equals(instanceName)) ? "ERROR" : "STOPPED"
+serviceInstanceData.setInstanceStatus(currentStatus)
+serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+
+// Print warning or error messages and force job to exit with error if there are any.
+if (!status.equals(instanceName)){
+    println("[ERROR] Could not stop docker container: " + instanceName + ". Docker output: " + status)
+    System.exit(1)
+}
+
+println("END " + variables.get("PA_TASK_NAME"))
+]]>
+          </code>
+        </script>
+      </post>
+    </task>
+  </taskFlow>
+</job>

--- a/DatabaseServices/METADATA.json
+++ b/DatabaseServices/METADATA.json
@@ -9,6 +9,8 @@
       "MySQL",
       "PostgreSQL",
       "MongoDB",
+      "Cassandra",
+      "Elasticsearch",
       "Database",
       "SQL",
       "NoSQL"
@@ -133,6 +135,24 @@
           "contentType": "application/xml"
         },
         "file": "resources/catalog/Elasticsearch_Service_Actions.xml"
+      },
+      {
+        "name": "Cassandra_Service_Start",
+        "metadata": {
+          "kind": "Workflow/standard",
+          "commitMessage": "First commit",
+          "contentType": "application/xml"
+        },
+        "file": "resources/catalog/Cassandra_Service_Start.xml"
+      },
+      {
+        "name": "Cassandra_Service_Actions",
+        "metadata": {
+          "kind": "Workflow/standard",
+          "commitMessage": "First commit",
+          "contentType": "application/xml"
+        },
+        "file": "resources/catalog/Cassandra_Service_Actions.xml"
       }
     ]
   }

--- a/DatabaseServices/resources/catalog/Cassandra_Service_Actions.xml
+++ b/DatabaseServices/resources/catalog/Cassandra_Service_Actions.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:proactive:jobdescriptor:3.10"
+     xsi:schemaLocation="urn:proactive:jobdescriptor:3.10 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.10/schedulerjob.xsd"
+    name="Cassandra_Service_Actions" projectName="Cassandra"
+    priority="normal"
+    onTaskError="continueJobExecution"
+     maxNumberOfExecution="2">
+  <variables>
+    <variable name="ACTION" value="Finish_Cassandra" model="PA:LIST(Stop_Cassandra, Resume_Cassandra, Finish_Cassandra)"/>
+  </variables>
+  <description>
+    <![CDATA[ This workflow manages the life-cycle of Cassandra PCA service. It allows to trigger three possible actions: Stop_PostgreSQL, Resume_PostgreSQL and Finish_PostgreSQL. ]]>
+  </description>
+  <genericInformation>
+    <info name="bucketName" value="database-services"/>
+    <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png"/>
+    <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+    <info name="group" value="public-objects"/>
+  </genericInformation>
+  <taskFlow>
+    <task name="Cassandra_Service_Action"
+    
+    
+    onTaskError="cancelJob" >
+      <variables>
+        <variable name="INSTANCE_ID" value="" inherited="true" />
+      </variables>
+      <genericInformation>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png"/>
+        <info name="task.documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+      </genericInformation>
+      <inputFiles>
+        <files  includes="cloud-automation-service-client-8.2.0-SNAPSHOT.jar" accessMode="transferFromGlobalSpace"/>
+      </inputFiles>
+      <forkEnvironment >
+        <additionalClasspath>
+          <pathElement path="cloud-automation-service-client-8.2.0-SNAPSHOT.jar"/>
+        </additionalClasspath>
+      </forkEnvironment>
+      <scriptExecutable>
+        <script>
+          <code language="groovy">
+            <![CDATA[
+println("--- BEGIN " + variables.get("PA_TASK_NAME") + " ---")
+
+import org.ow2.proactive.pca.service.client.ApiClient
+import org.ow2.proactive.pca.service.client.api.ServiceInstanceRestApi
+import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
+import org.ow2.proactive.pca.service.client.model.ServiceDescription
+
+// Get schedulerapi access
+schedulerapi.connect()
+
+// Acquire session id
+def sessionId = schedulerapi.getSession()
+
+// Define PCA URL
+def schedulerRestUrl = variables.get("PA_SCHEDULER_REST_URL")
+def pcaUrl = schedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
+
+// Connect to APIs
+def apiClient = new ApiClient()
+apiClient.setBasePath(pcaUrl)
+//apiClient.setDebugging(true)
+def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
+
+def instanceId = variables.get("INSTANCE_ID") as int
+println("INSTANCE_ID: " + instanceId)
+assert instanceId != null
+
+// Stop service
+ServiceDescription service = new ServiceDescription()
+service.setBucketName("cloud-automation")
+service.setWorkflowName(variables.get("ACTION"))
+serviceInstanceRestApi.launchServiceInstanceActionUsingPUT(sessionId, instanceId, service)
+
+println("--- END " + variables.get("PA_TASK_NAME") + " ---")
+]]>
+          </code>
+        </script>
+      </scriptExecutable>
+      <controlFlow block="none"></controlFlow>
+    </task>
+  </taskFlow>
+</job>

--- a/DatabaseServices/resources/catalog/Cassandra_Service_Start.xml
+++ b/DatabaseServices/resources/catalog/Cassandra_Service_Start.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:proactive:jobdescriptor:3.10"
+     xsi:schemaLocation="urn:proactive:jobdescriptor:3.10 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.10/schedulerjob.xsd"
+    name="Cassandra_Service_Start" projectName="Cassandra"
+    priority="normal"
+    onTaskError="continueJobExecution"
+     maxNumberOfExecution="2">
+  <variables>
+    <variable name="CASSANDRA_INSTANCE_NAME" value="cassandra-server" />
+    <variable name="CASSANDRA_ENV_VARS" value="" />
+  </variables>
+  <description>
+    <![CDATA[ Start the Cassandra server as a service. ]]>
+  </description>
+  <genericInformation>
+    <info name="bucketName" value="database-services"/>
+    <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png"/>
+    <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+    <info name="group" value="public-objects"/>
+  </genericInformation>
+  <taskFlow>
+    <task name="Start_Cassandra"
+    
+    
+    onTaskError="cancelJob" >
+      <description>
+        <![CDATA[ Start the Cassandra server as a service. ]]>
+      </description>
+      <variables>
+        <variable name="SERVICE_ID" value="Cassandra" inherited="false" />
+      </variables>
+      <genericInformation>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png"/>
+        <info name="task.documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+      </genericInformation>
+      <inputFiles>
+        <files  includes="cloud-automation-service-client-8.2.0-SNAPSHOT.jar" accessMode="transferFromGlobalSpace"/>
+      </inputFiles>
+      <forkEnvironment >
+        <additionalClasspath>
+          <pathElement path="cloud-automation-service-client-8.2.0-SNAPSHOT.jar"/>
+        </additionalClasspath>
+      </forkEnvironment>
+      <pre>
+        <script>
+          <code language="groovy">
+            <![CDATA[
+/*********************************************************************************
+* THIS PRESCRIPT MAPS THE SERVICE SPECIFIC VARIABLES WITH GENERIC VARIABLE NAMES *
+* THIS AVOIDS YOU FROM CHANGING THE WHOLE PCA WORKFLOWS IMPLEMENTATIONS          *
+*********************************************************************************/
+
+variables.put("INSTANCE_NAME", variables.get("CASSANDRA_INSTANCE_NAME"))
+variables.put("ENV_VARS", variables.get("CASSANDRA_ENV_VARS"))
+]]>
+          </code>
+        </script>
+      </pre>
+      <scriptExecutable>
+        <script>
+          <code language="groovy">
+            <![CDATA[
+import org.ow2.proactive.pca.service.client.ApiClient
+import org.ow2.proactive.pca.service.client.api.ServiceInstanceRestApi
+import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
+import org.ow2.proactive.pca.service.client.model.ServiceDescription
+
+println("BEGIN " + variables.get("PA_TASK_NAME"))
+
+/*********************************************************************************
+* THIS PART IS IMAGE SPECIFIC. IF YOU NEED TO MODIFY SOMETHING, DO IT HERE       *
+/********************************************************************************/
+def envVars = variables.get("ENV_VARS")
+/********************************************************************************/
+
+// Get schedulerapi access
+schedulerapi.connect()
+
+// Acquire session id
+def sessionId = schedulerapi.getSession()
+
+// Define PCA URL
+def scheduler_rest_url = variables.get("PA_SCHEDULER_REST_URL")
+def pcaUrl = scheduler_rest_url.replaceAll("/rest\\z", "/cloud-automation-service")
+
+// Connect to APIs
+def apiClient = new ApiClient()
+apiClient.setBasePath(pcaUrl)
+//apiClient.setDebugging(true)
+def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
+
+def serviceId = variables.get("SERVICE_ID")
+def instanceName = variables.get("INSTANCE_NAME")
+println("SERVICE_ID:    " + serviceId)
+println("INSTANCE_NAME: " + instanceName)
+
+// Check existing service instances
+boolean instance_exists = false
+List<ServiceInstanceData> service_instances = serviceInstanceRestApi.getServiceInstancesUsingGET()
+
+for (ServiceInstanceData serviceInstanceData : service_instances) {
+    if ( (serviceInstanceData.getServiceId() == serviceId) && (serviceInstanceData.getInstanceStatus()  == "RUNNING")){
+        if (serviceInstanceData.getVariables().get("INSTANCE_NAME") == instanceName) {
+            instance_exists = true
+            def instanceId = serviceInstanceData.getInstanceId()
+            endpoint = serviceInstanceData.getInstanceEndpoints().entrySet().iterator().next().getValue()
+            println("INSTANCE_ID: " + instanceId)
+            println("ENDPOINT:    " + endpoint)
+            variables.put("INSTANCE_ID", instanceId)
+            variables.put("ENDPOINT", endpoint)
+            break
+        }
+  	}
+}
+
+println("INSTANCE_EXISTS ? " + instance_exists)
+
+if (!instance_exists){
+    // Prepare service description
+    ServiceDescription serviceDescription = new ServiceDescription()
+    serviceDescription.setBucketName("cloud-automation")
+    serviceDescription.setWorkflowName(serviceId)
+    serviceDescription.putVariablesItem("INSTANCE_NAME", instanceName)
+
+/*********************************************************************************
+* THIS PART IS IMAGE SPECIFIC. IF YOU NEED TO MODIFY SOMETHING, DO IT HERE       *
+/********************************************************************************/
+    serviceDescription.putVariablesItem("ENV_VARS", envVars)
+/********************************************************************************/
+    // Run service
+    def serviceInstanceData = serviceInstanceRestApi.createRunningServiceInstanceUsingPOST(sessionId, serviceDescription)
+
+    // Acquire service Instance ID
+    def serviceInstanceId = serviceInstanceData.getInstanceId()
+
+    // Create synchro channel
+    def channel = "Service_Instance_" + serviceInstanceId
+    println("CHANNEL: " + channel)
+    synchronizationapi.createChannelIfAbsent(channel, false)
+    synchronizationapi.waitUntil(channel, "RUNNING", "{k,x -> x == true}")
+
+    // Acquire service endpoint
+    serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(serviceInstanceId)
+    def instanceId = serviceInstanceData.getInstanceId()
+    endpoint = serviceInstanceData.getInstanceEndpoints().entrySet().iterator().next().getValue()
+
+    println("INSTANCE_ID: " + instanceId)
+    println("ENDPOINT: " + endpoint)
+
+    variables.put("INSTANCE_ID", instanceId)
+    variables.put("ENDPOINT", endpoint)
+}
+
+println("END " + variables.get("PA_TASK_NAME"))
+]]>
+          </code>
+        </script>
+      </scriptExecutable>
+      <controlFlow block="none"></controlFlow>
+    </task>
+  </taskFlow>
+</job>


### PR DESCRIPTION
In this PR, we:
1/ Add a new Cassandra PCA service composed of three states (Started, Stopped and Finished)
2/ Add two workflows to the database-services bucket showing how to use this service from the client-side