### PR TITLE
Add node source infrastructure and policy examples

### DIFF
--- a/NodeSources/METADATA.json
+++ b/NodeSources/METADATA.json
@@ -108,6 +108,42 @@
 					"contentType": "application/json"
 				},
 				"file" : "resources/catalog/AmazonAWS-Spot.json"
+			},
+			{
+				"name" : "OneLocalNode",
+				"metadata" : {
+					"kind": "InfrastructureNodeSource",
+					"commitMessage": "First commit",
+					"contentType": "application/json"
+				},
+				"file" : "resources/catalog/OneLocalNode.json"
+			},
+			{
+				"name" : "FourLocalNodes",
+				"metadata" : {
+					"kind": "InfrastructureNodeSource",
+					"commitMessage": "First commit",
+					"contentType": "application/json"
+				},
+				"file" : "resources/catalog/FourLocalNodes.json"
+			},
+			{
+				"name" : "TenSecondsRestartDownNodes",
+				"metadata" : {
+					"kind": "PolicyNodeSource",
+					"commitMessage": "First commit",
+					"contentType": "application/json"
+				},
+				"file" : "resources/catalog/TenSecondsRestartDownNodes.json"
+			},
+			{
+				"name" : "FiveMinutesRestartDownNodes",
+				"metadata" : {
+					"kind": "PolicyNodeSource",
+					"commitMessage": "First commit",
+					"contentType": "application/json"
+				},
+				"file" : "resources/catalog/FiveMinutesRestartDownNodes.json"
 			}
 		]
 	}

--- a/NodeSources/resources/catalog/FiveMinutesRestartDownNodes.json
+++ b/NodeSources/resources/catalog/FiveMinutesRestartDownNodes.json
@@ -1,0 +1,34 @@
+{
+	"pluginName": "org.ow2.proactive.resourcemanager.nodesource.policy.RestartDownNodesPolicy",
+	"pluginDescription": "Static nodes acquisition. If node becomes down policy tries to restart it.",
+	"configurableFields": [
+		{
+			"name": "userAccessType",
+			"value": "ALL",
+			"meta": {
+				"type": "NONE",
+				"description": "ME|users=name1,name2;groups=group1,group2;tokens=t1,t2|ALL",
+				"dynamic": false
+			}
+		},
+		{
+			"name": "providerAccessType",
+			"value": "ALL",
+			"meta": {
+				"type": "NONE",
+				"description": "ME|users=name1,name2;groups=group1,group2|ALL",
+				"dynamic": false
+			}
+		},
+		{
+			"name": "checkNodeStateEach",
+			"value": "300000",
+			"meta": {
+				"type": "NONE",
+				"description": "ms (30 mins by default)",
+				"dynamic": true
+			}
+		}
+	],
+	"defaultValues": {}
+}

--- a/NodeSources/resources/catalog/FourLocalNodes.json
+++ b/NodeSources/resources/catalog/FourLocalNodes.json
@@ -1,0 +1,43 @@
+{
+	"pluginName": "org.ow2.proactive.resourcemanager.nodesource.infrastructure.LocalInfrastructure",
+	"pluginDescription": "Deploys nodes on Resource Manager's machine",
+	"configurableFields": [
+		{
+			"name": "credentials",
+			"value": "UlNBCjEwMjQKUlNBL0VDQi9QS0NTMVBhZGRpbmcKdaUX3K5Cx1epYuylbM3ApIbM0C1gsIZWIX6MsFhzfUZxMnB7/BeUvAFQz3lYcTEqSl2E1LWlibBbxHMCxjUMzSoOZXFKsnTxMCieWetgUcP5sCTO/Kg1UukL4xDqOgpLp1iK0FK4dYDSBBkoUn4ePBLZWu2YOb1+mPFEE2G2hxSW0DUVMXginosmRNcG5P2n1GqrDgplizEjD7G6rN6UezDGXv6MthSjP9VbFAzOSY79UTELjOhb0Rz3qfBhl4DNvae2c3ZrHJkKHL3P6GC4Zz0BvY90VKOMQj8Y8LuwdxKthWDgcmFppfSldJ8vwsEIhbwHM9bzsRCBDelMRyDYOD9km24uOMYGAmv6/EqMHRsC2w7drAhByzU/xg4OGtYaDy4xBzlHGzpq2NBCwTdx+xLiSmTFNT7U/MZ1dTTFmCUfJ25fM5ncO1rPNvLqrzdrm2x2NEhnXCTGO1aFVTUhMyLmeNi/0KmXmE51WHPyeoWxZ5/GfQT9HxUMVBei3tE8gCM6f5W4iNTZKY6Et1nVKw==",
+			"meta": {
+				"type": "CREDENTIAL",
+				"description": "Absolute path to credentials file\nused to add the node to the Resource Manager",
+				"dynamic": false
+			}
+		},
+		{
+			"name": "maxNodes",
+			"value": "4",
+			"meta": {
+				"type": "NONE",
+				"description": "Maximum number of nodes to\nbe deployed on Resource Manager machine",
+				"dynamic": false
+			}
+		},
+		{
+			"name": "nodeTimeout",
+			"value": "120000",
+			"meta": {
+				"type": "NONE",
+				"description": "in ms. After this timeout expired\nthe node is considered to be lost",
+				"dynamic": false
+			}
+		},
+		{
+			"name": "paProperties",
+			"value": "",
+			"meta": {
+				"type": "NONE",
+				"description": "Additional ProActive properties",
+				"dynamic": false
+			}
+		}
+	],
+	"defaultValues": {}
+}

--- a/NodeSources/resources/catalog/OneLocalNode.json
+++ b/NodeSources/resources/catalog/OneLocalNode.json
@@ -1,0 +1,43 @@
+{
+	"pluginName": "org.ow2.proactive.resourcemanager.nodesource.infrastructure.LocalInfrastructure",
+	"pluginDescription": "Deploys nodes on Resource Manager's machine",
+	"configurableFields": [
+		{
+			"name": "credentials",
+			"value": "UlNBCjEwMjQKUlNBL0VDQi9QS0NTMVBhZGRpbmcKdaUX3K5Cx1epYuylbM3ApIbM0C1gsIZWIX6MsFhzfUZxMnB7/BeUvAFQz3lYcTEqSl2E1LWlibBbxHMCxjUMzSoOZXFKsnTxMCieWetgUcP5sCTO/Kg1UukL4xDqOgpLp1iK0FK4dYDSBBkoUn4ePBLZWu2YOb1+mPFEE2G2hxSW0DUVMXginosmRNcG5P2n1GqrDgplizEjD7G6rN6UezDGXv6MthSjP9VbFAzOSY79UTELjOhb0Rz3qfBhl4DNvae2c3ZrHJkKHL3P6GC4Zz0BvY90VKOMQj8Y8LuwdxKthWDgcmFppfSldJ8vwsEIhbwHM9bzsRCBDelMRyDYOD9km24uOMYGAmv6/EqMHRsC2w7drAhByzU/xg4OGtYaDy4xBzlHGzpq2NBCwTdx+xLiSmTFNT7U/MZ1dTTFmCUfJ25fM5ncO1rPNvLqrzdrm2x2NEhnXCTGO1aFVTUhMyLmeNi/0KmXmE51WHPyeoWxZ5/GfQT9HxUMVBei3tE8gCM6f5W4iNTZKY6Et1nVKw==",
+			"meta": {
+				"type": "CREDENTIAL",
+				"description": "Absolute path to credentials file\nused to add the node to the Resource Manager",
+				"dynamic": false
+			}
+		},
+		{
+			"name": "maxNodes",
+			"value": "1",
+			"meta": {
+				"type": "NONE",
+				"description": "Maximum number of nodes to\nbe deployed on Resource Manager machine",
+				"dynamic": false
+			}
+		},
+		{
+			"name": "nodeTimeout",
+			"value": "120000",
+			"meta": {
+				"type": "NONE",
+				"description": "in ms. After this timeout expired\nthe node is considered to be lost",
+				"dynamic": false
+			}
+		},
+		{
+			"name": "paProperties",
+			"value": "",
+			"meta": {
+				"type": "NONE",
+				"description": "Additional ProActive properties",
+				"dynamic": false
+			}
+		}
+	],
+	"defaultValues": {}
+}

--- a/NodeSources/resources/catalog/TenSecondsRestartDownNodes.json
+++ b/NodeSources/resources/catalog/TenSecondsRestartDownNodes.json
@@ -1,0 +1,34 @@
+{
+	"pluginName": "org.ow2.proactive.resourcemanager.nodesource.policy.RestartDownNodesPolicy",
+	"pluginDescription": "Static nodes acquisition. If node becomes down policy tries to restart it.",
+	"configurableFields": [
+		{
+			"name": "userAccessType",
+			"value": "ALL",
+			"meta": {
+				"type": "NONE",
+				"description": "ME|users=name1,name2;groups=group1,group2;tokens=t1,t2|ALL",
+				"dynamic": false
+			}
+		},
+		{
+			"name": "providerAccessType",
+			"value": "ALL",
+			"meta": {
+				"type": "NONE",
+				"description": "ME|users=name1,name2;groups=group1,group2|ALL",
+				"dynamic": false
+			}
+		},
+		{
+			"name": "checkNodeStateEach",
+			"value": "10000",
+			"meta": {
+				"type": "NONE",
+				"description": "ms (30 mins by default)",
+				"dynamic": true
+			}
+		}
+	],
+	"defaultValues": {}
+}


### PR DESCRIPTION
- two local infrastructures with different number of nodes
- two different policies to restart down nodes at different time intervals