### PR TITLE
Fix PCA collision and add logs feature

### DIFF
--- a/Cassandra/METADATA.json
+++ b/Cassandra/METADATA.json
@@ -39,13 +39,13 @@
 				"file" : "resources/catalog/Resume_Cassandra.xml"
 			},
 			{
-				"name" : "Stop_Cassandra",
+				"name" : "Pause_Cassandra",
 				"metadata" : {
 					"kind": "Workflow/pca",
 					"commitMessage": "First commit",
 					"contentType": "application/xml"
 				},
-				"file" : "resources/catalog/Stop_Cassandra.xml"
+				"file" : "resources/catalog/Pause_Cassandra.xml"
 			}
 		]
 	}

--- a/Cassandra/resources/catalog/Cassandra.xml
+++ b/Cassandra/resources/catalog/Cassandra.xml
@@ -26,86 +26,7 @@ $ENV_VARS (Optional): List of the environment variables. Each environment variab
     <info name="group" value="public-objects"/>
   </genericInformation>
   <taskFlow>
-    <task name="Loop_Over_Instance_Status">
-      <genericInformation>
-        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png"/>
-        <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
-      </genericInformation>
-      <depends>
-        <task ref="Start_Cassandra"/>
-      </depends>
-      <inputFiles>
-        <files  includes="cloud-automation-service-client-8.2.0-SNAPSHOT.jar" accessMode="transferFromGlobalSpace"/>
-      </inputFiles>
-      <forkEnvironment >
-        <additionalClasspath>
-          <pathElement path="cloud-automation-service-client-8.2.0-SNAPSHOT.jar"/>
-        </additionalClasspath>
-      </forkEnvironment>
-      <scriptExecutable>
-        <script>
-          <code language="groovy">
-            <![CDATA[
-import org.ow2.proactive.pca.service.client.ApiClient
-import org.ow2.proactive.pca.service.client.api.ServiceInstanceRestApi
-import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
-
-println("BEGIN " + variables.get("PA_TASK_NAME"))
-
-def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
-def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
-def instanceName = variables.get("INSTANCE_NAME")
-
-println("INSTANCE_NAME="+instanceName)
-
-// Connect to Cloud Automation API
-def apiClient = new ApiClient()
-apiClient.setBasePath(pcaUrl)
-def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
-
-// Inform other platforms that other actions are canceled through Synchronization API
-def channel = "Service_Instance_" + instanceId
-synchronizationapi.put(channel, "DELETE_LAUNCHED", false)
-synchronizationapi.put(channel, "DELETE_INSTANCE", false)
-
-// Loop over service instance status
-def currentStatus = "RUNNING"
-def exitWithError = false
-while(currentStatus=="RUNNING") {
-    sleep(10000);
-    // Check docker container status
-    def ByteArrayOutputStream sout = new ByteArrayOutputStream();
-    def ByteArrayOutputStream serr = new ByteArrayOutputStream();
-    def proc = ["docker", "inspect", "--format", "{{ .State.Running }}", "${instanceName}"].execute().waitForProcessOutput(sout, serr)
-    def isContainerRunning = new String(sout.toByteArray()).trim().toBoolean()
-
-    if ((!isContainerRunning) && (!synchronizationapi.get(channel, "DELETE_LAUNCHED")) && (!synchronizationapi.get(channel, "STOP_LAUNCHED"))){
-        currentStatus = 'ERROR'
-        exitWithError = true
-        println("[ERROR] An internal error occured in docker container: " + instanceName)
-        // Update docker container is not running
-        def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
-        serviceInstanceData.setInstanceStatus(currentStatus)
-        serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
-        break
-    }
-    // Check service instance status
-    currentStatus = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId).getInstanceStatus()
-}
-
-// Allow the Delete workflow to be fulfilled
-synchronizationapi.put(channel, "DELETE_INSTANCE", true)
-if (exitWithError){
-    System.exit(1)
-}
-println("END " + variables.get("PA_TASK_NAME"))
-]]>
-          </code>
-        </script>
-      </scriptExecutable>
-    </task>
-    <task name="Start_Cassandra">
+    <task name="Start_Cassandra" >
       <description>
         <![CDATA[ Pull Cassandra image and start a container ]]>
       </description>
@@ -161,9 +82,9 @@ else
     echo "Running $INSTANCE_NAME container"
     if [ -z "$ENV_VARS" ]; then
         INSTANCE_STATUS=$( eval "docker run --name "$INSTANCE_NAME" -p "$PORT" -d "$DOCKER_IMAGE"" 2>&1)
-    else 
-        INSTANCE_STATUS=$( eval "docker run --name "$INSTANCE_NAME" -p "$PORT" "$ENV_VARS" -d "$DOCKER_IMAGE"" 2>&1)    
-    fi 
+    else
+        INSTANCE_STATUS=$( eval "docker run --name "$INSTANCE_NAME" -p "$PORT" "$ENV_VARS" -d "$DOCKER_IMAGE"" 2>&1)
+    fi
     ################################################################################
     if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
         RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)
@@ -200,7 +121,7 @@ import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
 def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
 def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
 // Acquire service instance id and instance name
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def instanceName = variables.get("INSTANCE_NAME")
 
 def hostname = new URL(paSchedulerRestUrl).getHost()
@@ -247,6 +168,92 @@ println("END " + variables.get("PA_TASK_NAME"))
           </code>
         </script>
       </post>
+    </task>
+    <task name="Loop_Over_Instance_Status" >
+      <description>
+        <![CDATA[ Loop over service instance status and fetch docker container logs.
+It will run every minute. ]]>
+      </description>
+      <genericInformation>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png"/>
+        <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+      </genericInformation>
+      <depends>
+        <task ref="Start_Cassandra"/>
+      </depends>
+      <inputFiles>
+        <files  includes="cloud-automation-service-client-8.2.0-SNAPSHOT.jar" accessMode="transferFromGlobalSpace"/>
+      </inputFiles>
+      <forkEnvironment >
+        <additionalClasspath>
+          <pathElement path="cloud-automation-service-client-8.2.0-SNAPSHOT.jar"/>
+        </additionalClasspath>
+      </forkEnvironment>
+      <scriptExecutable>
+        <script>
+          <code language="groovy">
+            <![CDATA[
+import org.ow2.proactive.pca.service.client.ApiClient
+import org.ow2.proactive.pca.service.client.api.ServiceInstanceRestApi
+import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
+
+def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
+def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
+def instanceName = variables.get("INSTANCE_NAME")
+def channel = "Service_Instance_" + instanceId
+
+// Connect to Cloud Automation API
+def serviceInstanceRestApi = new ServiceInstanceRestApi(new ApiClient().setBasePath(pcaUrl))
+
+// If service instance is FINISHED or PAUSED then stop this loop and job and delete the sync channel
+def currentStatus = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId).getInstanceStatus()
+if (currentStatus.equals("FINISHED") || currentStatus.equals("PAUSED") || synchronizationapi.get(channel, "RESUMED")){
+    variables.put("IS_FINISHED",true)
+    if (currentStatus.equals("FINISHED")){
+        synchronizationapi.deleteChannel(channel)
+    }
+} else {
+    // Check if container has been stopped abnormally
+    def isContainerRunning = ["docker", "inspect", "--format", "{{ .State.Running }}", "${instanceName}"].execute().getText().trim().toBoolean()
+    if ((!isContainerRunning) && (!synchronizationapi.get(channel, "FINISH_LAUNCHED")) && (!synchronizationapi.get(channel, "PAUSE_LAUNCHED"))){
+        currentStatus = 'ERROR'
+        println("[ERROR] An internal error occured in docker container: " + instanceName)
+        // Update docker container is not running
+        def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
+        serviceInstanceData.setInstanceStatus(currentStatus)
+        serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+        // Tell the CRON loop to stop
+        variables.put("IS_FINISHED",true)
+        // Exit with error
+        System.exit(1)
+    } else {
+        // Fetch all logs or only new logs since last fetch time mark
+        def lastTime=variables.get('LAST_TIME_MARKER')
+        def fetchLogsCmd = lastTime ? ["docker", "logs", "--since", lastTime, instanceName] : ["docker", "logs", instanceName]
+        fetchLogsCmd.execute().waitForProcessOutput(System.out, System.err)
+    }
+}
+]]>
+          </code>
+        </script>
+      </scriptExecutable>
+      <controlFlow >
+        <loop target="Loop_Over_Instance_Status">
+          <script>
+            <code language="groovy">
+              <![CDATA[
+// Check if loop task has ordered to finish the loop
+def isFinished = variables.get('IS_FINISHED') as boolean
+loop = isFinished ? false : '*/1 * * * *'
+
+// Set a time marker to fetch logs since this marker.
+variables.put("LAST_TIME_MARKER",new Date().format("yyyy-MM-dd'T'HH:mm:ssXXX"))
+]]>
+            </code>
+          </script>
+        </loop>
+      </controlFlow>
     </task>
   </taskFlow>
 </job>

--- a/Cassandra/resources/catalog/Finish_Cassandra.xml
+++ b/Cassandra/resources/catalog/Finish_Cassandra.xml
@@ -13,7 +13,7 @@
   <genericInformation>
     <info name="bucketName" value="cloud-automation"/>
     <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png"/>
-    <info name="pca.states" value="(RUNNING,FINISHED)(STOPPED,FINISHED)(ERROR,FINISHED)"/>
+    <info name="pca.states" value="(RUNNING,FINISHED)(PAUSED,FINISHED)(ERROR,FINISHED)"/>
     <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
     <info name="pca.service.id" value="Cassandra"/>
     <info name="group" value="public-objects"/>
@@ -43,14 +43,16 @@
 * THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS BEING FINISHED             *
 *********************************************************************************/
 
+println("BEGIN " + variables.get("PA_TASK_NAME"))
+
 // Acquire service instance id and instance name from synchro channel
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def channel = "Service_Instance_" + instanceId
 def instanceName = synchronizationapi.get(channel, "INSTANCE_NAME")
 variables.put("INSTANCE_NAME", instanceName)
 
 // Inform other platforms that service is being finished through Synchronization API
-synchronizationapi.put(channel, "DELETE_LAUNCHED", true)
+synchronizationapi.put(channel, "FINISH_LAUNCHED", true)
 ]]>
           </code>
         </script>
@@ -59,8 +61,6 @@ synchronizationapi.put(channel, "DELETE_LAUNCHED", true)
         <script>
           <code language="bash">
             <![CDATA[
-echo --- BEGIN  "$variables_PA_TASK_NAME"  ---
-
 echo Removing docker container: "$variables_INSTANCE_NAME"
 INSTANCE_NAME=$(docker rm -f $variables_INSTANCE_NAME 2>&1)
 echo $INSTANCE_NAME > $variables_INSTANCE_NAME"_status"
@@ -82,27 +82,24 @@ import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
 
 def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
 def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def instanceName = variables.get("INSTANCE_NAME")
-    
+
 def ALREADY_REMOVED_MESSAGE = "Error: No such container: " + instanceName
 
 // Connect to Cloud Automation API
-def apiClient = new ApiClient()
-apiClient.setBasePath(pcaUrl)
-def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
+def serviceInstanceRestApi = new ServiceInstanceRestApi(new ApiClient().setBasePath(pcaUrl))
 
 // Update service instance data : (status, endpoint)
-def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
 def status = new File(instanceName+"_status").text.trim()
 def currentStatus = (!status.equals(ALREADY_REMOVED_MESSAGE) && !status.equals(instanceName)) ? "ERROR" : "FINISHED"
+def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
 serviceInstanceData.setInstanceStatus(currentStatus)
-serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
 
-// Delete synchro channel
+// Inform other jobs that the service is finished and deleted.
 def channel = "Service_Instance_" + instanceId
-synchronizationapi.waitUntil(channel, "DELETE_INSTANCE", "{k,x -> x == true}")
-synchronizationapi.deleteChannel(channel)
+synchronizationapi.put(channel, "FINISH_DONE", true)
 
 // Print warning or error messages and force job to exit with error if there are any.
 if (status.equals(ALREADY_REMOVED_MESSAGE)){

--- a/Cassandra/resources/catalog/Pause_Cassandra.xml
+++ b/Cassandra/resources/catalog/Pause_Cassandra.xml
@@ -3,29 +3,29 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="urn:proactive:jobdescriptor:3.10"
      xsi:schemaLocation="urn:proactive:jobdescriptor:3.10 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.10/schedulerjob.xsd"
-    name="Stop_PostgreSQL" projectName="Cloud Automation - Lifecycle"
+    name="Pause_Cassandra" projectName="Cloud Automation - Lifecycle"
     priority="normal"
     onTaskError="continueJobExecution"
      maxNumberOfExecution="2">
   <description>
-    <![CDATA[ Stop PostgreSQL instance. ]]>
+    <![CDATA[ Pause Cassandra instance. ]]>
   </description>
   <genericInformation>
     <info name="bucketName" value="cloud-automation"/>
-    <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/postgresql.png"/>
-    <info name="pca.states" value="(RUNNING,STOPPED)"/>
+    <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png"/>
+    <info name="pca.states" value="(RUNNING,PAUSED)"/>
     <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
-    <info name="pca.service.id" value="PostgreSQL"/>
+    <info name="pca.service.id" value="Cassandra"/>
     <info name="group" value="public-objects"/>
   </genericInformation>
   <taskFlow>
-    <task name="Stop_PostgreSQL">
+    <task name="Pause_Cassandra">
       <description>
-        <![CDATA[ Stop PostgreSQL instance ]]>
+        <![CDATA[ Pause Cassandra instance ]]>
       </description>
       <genericInformation>
-        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/postgresql.png"/>
-        <info name="documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png"/>
+        <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
       </genericInformation>
       <inputFiles>
         <files  includes="cloud-automation-service-client-8.2.0-SNAPSHOT.jar" accessMode="transferFromGlobalSpace"/>
@@ -40,17 +40,17 @@
           <code language="groovy">
             <![CDATA[
 /*********************************************************************************
-* THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS STOPPED                   *
+* THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS PAUSED                   *
 *********************************************************************************/
 
-// Acquire service instance id and instance name from synchro channel
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
-def channel = "Service_Instance_" + instanceId
-def instanceName = synchronizationapi.get(channel, "INSTANCE_NAME")
-variables.put("INSTANCE_NAME", instanceName)
+println("BEGIN " + variables.get("PA_TASK_NAME"))
 
-// Inform other platforms that service is being stopped through Synchronization API
-synchronizationapi.put(channel, "STOP_LAUNCHED", true)
+// Acquire service instance id and instance name from synchro channel
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
+def channel = "Service_Instance_" + instanceId
+
+// Inform other platforms that service is being paused through Synchronization API
+synchronizationapi.put(channel, "PAUSE_LAUNCHED", true)
 ]]>
           </code>
         </script>
@@ -59,8 +59,6 @@ synchronizationapi.put(channel, "STOP_LAUNCHED", true)
         <script>
           <code language="bash">
             <![CDATA[
-echo --- BEGIN "$variables_PA_TASK_NAME" ---
-
 echo Stopping docker container: "$variables_INSTANCE_NAME"
 INSTANCE_NAME=$(docker stop $variables_INSTANCE_NAME 2>&1)
 echo $INSTANCE_NAME > $variables_INSTANCE_NAME"_status"
@@ -73,7 +71,7 @@ echo $INSTANCE_NAME > $variables_INSTANCE_NAME"_status"
           <code language="groovy">
             <![CDATA[
 /*********************************************************************************
-* THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS STOPPED                   *
+* THIS POSTSCRIPT INFORMS PLATFORM THAT PCA SERVICE IS PAUSED                   *
 *********************************************************************************/
 
 import org.ow2.proactive.pca.service.client.ApiClient
@@ -82,22 +80,18 @@ import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
 
 def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
 def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
-
-// Acquire service instance id and instance name from synchro channel
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def instanceName = variables.get("INSTANCE_NAME")
 
 // Connect to Cloud Automation API
-def apiClient = new ApiClient()
-apiClient.setBasePath(pcaUrl)
-def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
+def serviceInstanceRestApi = new ServiceInstanceRestApi(new ApiClient().setBasePath(pcaUrl))
 
 // Update service instance data : (status, endpoint)
-def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
 def status = new File(instanceName+"_status").text.trim()
-def currentStatus = (!status.equals(instanceName)) ? "ERROR" : "STOPPED"
+def currentStatus = (!status.equals(instanceName)) ? "ERROR" : "PAUSED"
+def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
 serviceInstanceData.setInstanceStatus(currentStatus)
-serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
 
 // Print warning or error messages and force job to exit with error if there are any.
 if (!status.equals(instanceName)){

--- a/Cassandra/resources/catalog/Resume_Cassandra.xml
+++ b/Cassandra/resources/catalog/Resume_Cassandra.xml
@@ -13,13 +13,105 @@
   <genericInformation>
     <info name="bucketName" value="cloud-automation"/>
     <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png"/>
-    <info name="pca.states" value="(STOPPED,RUNNING)(RUNNING,RUNNING)"/>
+    <info name="pca.states" value="(PAUSED,RUNNING)(RUNNING,RUNNING)"/>
     <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
     <info name="pca.service.id" value="Cassandra"/>
     <info name="group" value="public-objects"/>
   </genericInformation>
   <taskFlow>
-    <task name="Resume_Cassandra">
+    <task name="Loop_Over_Instance_Status" >
+      <description>
+        <![CDATA[ Loop over service instance status and fetch docker container logs.
+It will run every minute. ]]>
+      </description>
+      <genericInformation>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png"/>
+        <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+      </genericInformation>
+      <depends>
+        <task ref="Resume_Cassandra"/>
+      </depends>
+      <inputFiles>
+        <files  includes="cloud-automation-service-client-8.2.0-SNAPSHOT.jar" accessMode="transferFromGlobalSpace"/>
+      </inputFiles>
+      <forkEnvironment >
+        <additionalClasspath>
+          <pathElement path="cloud-automation-service-client-8.2.0-SNAPSHOT.jar"/>
+        </additionalClasspath>
+      </forkEnvironment>
+      <scriptExecutable>
+        <script>
+          <code language="groovy">
+            <![CDATA[
+import org.ow2.proactive.pca.service.client.ApiClient
+import org.ow2.proactive.pca.service.client.api.ServiceInstanceRestApi
+import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
+
+def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
+def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
+def instanceName = variables.get("INSTANCE_NAME")
+def channel = "Service_Instance_" + instanceId
+
+// Connect to Cloud Automation API
+def serviceInstanceRestApi = new ServiceInstanceRestApi(new ApiClient().setBasePath(pcaUrl))
+
+// If service instance is FINISHED or PAUSED then stop this loop and job and delete the sync channel
+def currentStatus = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId).getInstanceStatus()
+if (currentStatus.equals("FINISHED") || currentStatus.equals("PAUSED")){
+    variables.put("IS_FINISHED",true)
+    synchronizationapi.deleteChannel(channel)
+} else {
+    // Check if container has been stopped abnormally
+    def isContainerRunning = ["docker", "inspect", "--format", "{{ .State.Running }}", "${instanceName}"].execute().getText().trim().toBoolean()
+    if ((!isContainerRunning) && (!synchronizationapi.get(channel, "FINISH_LAUNCHED")) && (!synchronizationapi.get(channel, "PAUSE_LAUNCHED"))){
+        currentStatus = 'ERROR'
+        println("[ERROR] An internal error occured in docker container: " + instanceName)
+        // Update docker container is not running
+        def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
+        serviceInstanceData.setInstanceStatus(currentStatus)
+        serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+        // Tell the CRON loop to stop
+        variables.put("IS_FINISHED",true)
+        // Exit with error
+        System.exit(1)
+    } else {
+        // Fetch all logs or only new logs since last fetch time mark
+        def lastTime=variables.get('LAST_TIME_MARKER')
+        def fetchLogsCmd = lastTime ? ["docker", "logs", "--since", lastTime, instanceName] : ["docker", "logs", instanceName]
+        fetchLogsCmd.execute().waitForProcessOutput(System.out, System.err)
+    }
+}
+]]>
+          </code>
+        </script>
+      </scriptExecutable>
+      <controlFlow >
+        <loop target="Loop_Over_Instance_Status">
+          <script>
+            <code language="groovy">
+              <![CDATA[
+// Check if loop task has ordered to finish the loop
+def isFinished = variables.get('IS_FINISHED') as boolean
+loop = isFinished ? false : '*/1 * * * *'
+
+// Set a time marker to fetch logs since this marker.
+variables.put("LAST_TIME_MARKER",new Date().format("yyyy-MM-dd'T'HH:mm:ssXXX"))
+]]>
+            </code>
+          </script>
+        </loop>
+      </controlFlow>
+      <metadata>
+        <positionTop>
+          523.5
+        </positionTop>
+        <positionLeft>
+          931.75
+        </positionLeft>
+      </metadata>
+    </task>
+    <task name="Resume_Cassandra" >
       <description>
         <![CDATA[ Resume Cassandra instance ]]>
       </description>
@@ -43,13 +135,16 @@
 * THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS BEING RESUMED              *
 *********************************************************************************/
 
+println("BEGIN " + variables.get("PA_TASK_NAME"))
+
 // Acquire service instance id and instance name from synchro channel
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def channel = "Service_Instance_" + instanceId
 
 // Inform other platforms that service is running through Synchronization API
 synchronizationapi.put(channel, "RUNNING", true)
-synchronizationapi.put(channel, "STOP_LAUNCHED", false)
+synchronizationapi.put(channel, "RESUMED", true)
+synchronizationapi.put(channel, "PAUSE_LAUNCHED", false)
 ]]>
           </code>
         </script>
@@ -73,7 +168,7 @@ if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
         INSTANCE_STATUS=$(docker start $INSTANCE_NAME 2>&1)
         echo $INSTANCE_STATUS > $INSTANCE_NAME"_status"
 	fi
-else 
+else
     echo Error: No such container: "$INSTANCE_NAME" > $INSTANCE_NAME"_status"
 fi
 ]]>
@@ -85,7 +180,7 @@ fi
           <code language="groovy">
             <![CDATA[
 /*********************************************************************************
-* THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS RESUMED                   *
+* THIS POSTSCRIPT INFORMS PLATFORM THAT PCA SERVICE IS RESUMED                   *
 *********************************************************************************/
 
 import org.ow2.proactive.pca.service.client.ApiClient
@@ -93,9 +188,9 @@ import org.ow2.proactive.pca.service.client.api.ServiceInstanceRestApi
 import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
 
 // Acquire service instance id
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def instanceName = variables.get("INSTANCE_NAME")
-    
+
 def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
 def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
 
@@ -122,80 +217,6 @@ println("END " + variables.get("PA_TASK_NAME"))
           </code>
         </script>
       </post>
-    </task>
-    <task name="Loop_Over_Instance_Status">
-      <genericInformation>
-        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png"/>
-        <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
-      </genericInformation>
-      <depends>
-        <task ref="Resume_Cassandra"/>
-      </depends>
-      <inputFiles>
-        <files  includes="cloud-automation-service-client-8.2.0-SNAPSHOT.jar" accessMode="transferFromGlobalSpace"/>
-      </inputFiles>
-      <forkEnvironment >
-        <additionalClasspath>
-          <pathElement path="cloud-automation-service-client-8.2.0-SNAPSHOT.jar"/>
-        </additionalClasspath>
-      </forkEnvironment>
-      <scriptExecutable>
-        <script>
-          <code language="groovy">
-            <![CDATA[
-import org.ow2.proactive.pca.service.client.ApiClient
-import org.ow2.proactive.pca.service.client.api.ServiceInstanceRestApi
-import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
-
-println("BEGIN " + variables.get("PA_TASK_NAME"))
-
-def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
-def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
-def instanceName = variables.get("INSTANCE_NAME")
-
-// Connect to Cloud Automation API
-def apiClient = new ApiClient()
-apiClient.setBasePath(pcaUrl)
-def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
-
-// Inform other platforms that other actions are canceled through Synchronization API
-def channel = "Service_Instance_" + instanceId
-synchronizationapi.put(channel, "DELETE_LAUNCHED", false)
-synchronizationapi.put(channel, "DELETE_INSTANCE", false)
-
-// Loop over service instance status
-def currentStatus = "RUNNING"
-
-while(currentStatus=="RUNNING") {
-    sleep(10000);
-    // Check docker container status
-    def ByteArrayOutputStream sout = new ByteArrayOutputStream();
-    def ByteArrayOutputStream serr = new ByteArrayOutputStream();
-    def proc = ["docker", "inspect", "--format", "{{ .State.Running }}", "${instanceName}"].execute().waitForProcessOutput(sout, serr)
-    def isContainerRunning = new String(sout.toByteArray()).trim().toBoolean()
-
-    if ((!isContainerRunning) && (!synchronizationapi.get(channel, "DELETE_LAUNCHED")) && (!synchronizationapi.get(channel, "STOP_LAUNCHED"))){
-        currentStatus = 'ERROR'
-        println("[ERROR] An internal error occured in docker container: " + instanceName)
-        // Update docker container is not running
-        def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
-        serviceInstanceData.setInstanceStatus(currentStatus)
-        serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
-        break
-    }
-    // Check service instance status
-    currentStatus = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId).getInstanceStatus()
-}
-
-// Allow the Delete workflow to be fulfilled
-synchronizationapi.put(channel, "DELETE_INSTANCE", true)
-
-println("END " + variables.get("PA_TASK_NAME"))
-]]>
-          </code>
-        </script>
-      </scriptExecutable>
     </task>
   </taskFlow>
 </job>

--- a/Cassandra/resources/catalog/Resume_Cassandra.xml
+++ b/Cassandra/resources/catalog/Resume_Cassandra.xml
@@ -102,14 +102,6 @@ variables.put("LAST_TIME_MARKER",new Date().format("yyyy-MM-dd'T'HH:mm:ssXXX"))
           </script>
         </loop>
       </controlFlow>
-      <metadata>
-        <positionTop>
-          523.5
-        </positionTop>
-        <positionLeft>
-          931.75
-        </positionLeft>
-      </metadata>
     </task>
     <task name="Resume_Cassandra" >
       <description>

--- a/Docker/METADATA.json
+++ b/Docker/METADATA.json
@@ -39,13 +39,13 @@
 				"file" : "resources/catalog/Resume_Docker.xml"
 			},
 			{
-				"name" : "Stop_Docker",
+				"name" : "Pause_Docker",
 				"metadata" : {
 					"kind": "Workflow/pca",
 					"commitMessage": "First commit",
 					"contentType": "application/xml"
 				},
-				"file" : "resources/catalog/Stop_Docker.xml"
+				"file" : "resources/catalog/Pause_Docker.xml"
 			}
 		]
 	}

--- a/Docker/resources/catalog/Docker.xml
+++ b/Docker/resources/catalog/Docker.xml
@@ -177,7 +177,7 @@ import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
 def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
 def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
 // Acquire service instance id and instance name
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def instanceName = variables.get("INSTANCE_NAME")
 
 def hostname = new URL(paSchedulerRestUrl).getHost()
@@ -254,52 +254,40 @@ import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
 
 def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
 def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def instanceName = variables.get("INSTANCE_NAME")
-
-// Connect to Cloud Automation API
-def apiClient = new ApiClient()
-apiClient.setBasePath(pcaUrl)
-def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
-
-// Inform other platforms that other actions are canceled through Synchronization API
 def channel = "Service_Instance_" + instanceId
 
-// Check docker container status
-def ByteArrayOutputStream sout = new ByteArrayOutputStream();
-def ByteArrayOutputStream serr = new ByteArrayOutputStream();
-def proc = ["docker", "inspect", "--format", "{{ .State.Running }}", "${instanceName}"].execute().waitForProcessOutput(sout, serr)
-def isContainerRunning = new String(sout.toByteArray()).trim().toBoolean()
+// Connect to Cloud Automation API
+def serviceInstanceRestApi = new ServiceInstanceRestApi(new ApiClient().setBasePath(pcaUrl))
 
-if ((!isContainerRunning) && (!synchronizationapi.get(channel, "DELETE_LAUNCHED")) && (!synchronizationapi.get(channel, "STOP_LAUNCHED"))){
-    currentStatus = 'ERROR'
-    println("[ERROR] An internal error occured in docker container: " + instanceName)
-    // Update docker container is not running
-    def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
-    serviceInstanceData.setInstanceStatus(currentStatus)
-    serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
-    // Tell the CRON loop to stop
-    variables.put("IS_FINISHED",true)
-    // Exit with error
-    System.exit(1)
-} else {
-    def lastTime=variables.get('LAST_TIME_MARK')
-    // Fetch new logs since last fetch time mark.
-    def fetchLogsCmd = ["docker", "logs", "--since", lastTime, instanceName]
-    if(!lastTime){
-        // Fetch all logs from docker container
-        fetchLogsCmd = ["docker", "logs", instanceName]
-    }
-    fetchLogsCmd.execute().consumeProcessOutput(System.out, System.err)
-}
-
-// Check service instance status
+// If service instance is FINISHED or PAUSED then stop this loop and job and delete the sync channel
 def currentStatus = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId).getInstanceStatus()
-if(!currentStatus.equals("RUNNING")){
-    // Allow the Delete workflow to be fulfilled
-    synchronizationapi.put(channel, "DELETE_INSTANCE", true)
-    // Tell the CRON loop to stop
+if (currentStatus.equals("FINISHED") || currentStatus.equals("PAUSED") || synchronizationapi.get(channel, "RESUMED")){
     variables.put("IS_FINISHED",true)
+    if (currentStatus.equals("FINISHED")){
+        synchronizationapi.deleteChannel(channel)
+    }
+} else {
+    // Check if container has been stopped abnormally
+    def isContainerRunning = ["docker", "inspect", "--format", "{{ .State.Running }}", "${instanceName}"].execute().getText().trim().toBoolean()
+    if ((!isContainerRunning) && (!synchronizationapi.get(channel, "FINISH_LAUNCHED")) && (!synchronizationapi.get(channel, "PAUSE_LAUNCHED"))){
+        currentStatus = 'ERROR'
+        println("[ERROR] An internal error occured in docker container: " + instanceName)
+        // Update docker container is not running
+        def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
+        serviceInstanceData.setInstanceStatus(currentStatus)
+        serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+        // Tell the CRON loop to stop
+        variables.put("IS_FINISHED",true)
+        // Exit with error
+        System.exit(1)
+    } else {
+        // Fetch all logs or only new logs since last fetch time mark
+        def lastTime=variables.get('LAST_TIME_MARKER')
+        def fetchLogsCmd = lastTime ? ["docker", "logs", "--since", lastTime, instanceName] : ["docker", "logs", instanceName]
+        fetchLogsCmd.execute().waitForProcessOutput(System.out, System.err)
+    }
 }
 ]]>
           </code>
@@ -310,13 +298,12 @@ if(!currentStatus.equals("RUNNING")){
           <script>
             <code language="groovy">
               <![CDATA[
+// Check if loop task has ordered to finish the loop
 def isFinished = variables.get('IS_FINISHED') as boolean
-if(!isFinished){
-    variables.put("LAST_TIME_MARK",new Date().format("yyyy-MM-dd'T'HH:mm:ssXXX"))
-	loop = '*/1 * * * *'
-} else{
-    loop = false
-}
+loop = isFinished ? false : '*/1 * * * *'
+
+// Set a time marker to fetch logs since this marker.
+variables.put("LAST_TIME_MARKER",new Date().format("yyyy-MM-dd'T'HH:mm:ssXXX"))
 ]]>
             </code>
           </script>

--- a/Docker/resources/catalog/Finish_Docker.xml
+++ b/Docker/resources/catalog/Finish_Docker.xml
@@ -15,7 +15,7 @@
     <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
     <info name="group" value="public-objects"/>
     <info name="pca.service.id" value="Docker"/>
-    <info name="pca.states" value="(RUNNING,FINISHED)(STOPPED,FINISHED)(ERROR,FINISHED)"/>
+    <info name="pca.states" value="(RUNNING,FINISHED)(PAUSED,FINISHED)(ERROR,FINISHED)"/>
     <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/docker.png"/>
   </genericInformation>
   <taskFlow>
@@ -43,14 +43,16 @@
 * THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS BEING FINISHED             *
 *********************************************************************************/
 
+println("BEGIN " + variables.get("PA_TASK_NAME"))
+
 // Acquire service instance id and instance name from synchro channel
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def channel = "Service_Instance_" + instanceId
 def instanceName = synchronizationapi.get(channel, "INSTANCE_NAME")
 variables.put("INSTANCE_NAME", instanceName)
 
 // Inform other platforms that service is being finished through Synchronization API
-synchronizationapi.put(channel, "DELETE_LAUNCHED", true)
+synchronizationapi.put(channel, "FINISH_LAUNCHED", true)
 ]]>
           </code>
         </script>
@@ -59,8 +61,6 @@ synchronizationapi.put(channel, "DELETE_LAUNCHED", true)
         <script>
           <code language="bash">
             <![CDATA[
-echo --- BEGIN  "$variables_PA_TASK_NAME"  ---
-
 echo Removing docker container: "$variables_INSTANCE_NAME"
 INSTANCE_NAME=$(docker rm -f $variables_INSTANCE_NAME 2>&1)
 echo $INSTANCE_NAME > $variables_INSTANCE_NAME"_status"
@@ -82,27 +82,24 @@ import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
 
 def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
 def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def instanceName = variables.get("INSTANCE_NAME")
-    
+
 def ALREADY_REMOVED_MESSAGE = "Error: No such container: " + instanceName
 
 // Connect to Cloud Automation API
-def apiClient = new ApiClient()
-apiClient.setBasePath(pcaUrl)
-def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
+def serviceInstanceRestApi = new ServiceInstanceRestApi(new ApiClient().setBasePath(pcaUrl))
 
 // Update service instance data : (status, endpoint)
-def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
 def status = new File(instanceName+"_status").text.trim()
 def currentStatus = (!status.equals(ALREADY_REMOVED_MESSAGE) && !status.equals(instanceName)) ? "ERROR" : "FINISHED"
+def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
 serviceInstanceData.setInstanceStatus(currentStatus)
-serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
 
-// Delete synchro channel
+// Inform other jobs that the service is finished and deleted.
 def channel = "Service_Instance_" + instanceId
-synchronizationapi.waitUntil(channel, "DELETE_INSTANCE", "{k,x -> x == true}")
-synchronizationapi.deleteChannel(channel)
+synchronizationapi.put(channel, "FINISH_DONE", true)
 
 // Print warning or error messages and force job to exit with error if there are any.
 if (status.equals(ALREADY_REMOVED_MESSAGE)){

--- a/Docker/resources/catalog/Pause_Docker.xml
+++ b/Docker/resources/catalog/Pause_Docker.xml
@@ -3,29 +3,29 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="urn:proactive:jobdescriptor:3.10"
      xsi:schemaLocation="urn:proactive:jobdescriptor:3.10 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.10/schedulerjob.xsd"
-    name="Stop_Elasticsearch" projectName="Cloud Automation - Lifecycle"
+    name="Pause_Docker" projectName="Cloud Automation - Lifecycle"
     priority="normal"
     onTaskError="continueJobExecution"
      maxNumberOfExecution="2">
   <description>
-    <![CDATA[ Stop Elasticsearch instance. ]]>
+    <![CDATA[ Pause Docker container. ]]>
   </description>
   <genericInformation>
     <info name="bucketName" value="cloud-automation"/>
-    <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/elasticsearch.png"/>
-    <info name="pca.states" value="(RUNNING,STOPPED)"/>
     <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
-    <info name="pca.service.id" value="Elasticsearch"/>
     <info name="group" value="public-objects"/>
+    <info name="pca.service.id" value="Docker"/>
+    <info name="pca.states" value="(RUNNING,PAUSED)"/>
+    <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/docker.png"/>
   </genericInformation>
   <taskFlow>
-    <task name="Stop_Elasticsearch">
+    <task name="Pause_Docker">
       <description>
-        <![CDATA[ Stop Elasticsearch instance ]]>
+        <![CDATA[ Pause Docker container ]]>
       </description>
       <genericInformation>
-        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/elasticsearch.png"/>
-        <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/docker.png"/>
+        <info name="documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
       </genericInformation>
       <inputFiles>
         <files  includes="cloud-automation-service-client-8.2.0-SNAPSHOT.jar" accessMode="transferFromGlobalSpace"/>
@@ -40,15 +40,17 @@
           <code language="groovy">
             <![CDATA[
 /*********************************************************************************
-* THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS STOPPED                   *
+* THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS PAUSED                   *
 *********************************************************************************/
 
+println("BEGIN " + variables.get("PA_TASK_NAME"))
+
 // Acquire service instance id and instance name from synchro channel
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def channel = "Service_Instance_" + instanceId
 
-// Inform other platforms that service is being stopped through Synchronization API
-synchronizationapi.put(channel, "STOP_LAUNCHED", true)
+// Inform other platforms that service is being paused through Synchronization API
+synchronizationapi.put(channel, "PAUSE_LAUNCHED", true)
 ]]>
           </code>
         </script>
@@ -71,7 +73,7 @@ echo $INSTANCE_NAME > $variables_INSTANCE_NAME"_status"
           <code language="groovy">
             <![CDATA[
 /*********************************************************************************
-* THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS STOPPED                   *
+* THIS POSTSCRIPT INFORMS PLATFORM THAT PCA SERVICE IS PAUSED                   *
 *********************************************************************************/
 
 import org.ow2.proactive.pca.service.client.ApiClient
@@ -80,22 +82,18 @@ import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
 
 def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
 def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
-
-// Acquire service instance id and instance name from synchro channel
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def instanceName = variables.get("INSTANCE_NAME")
 
 // Connect to Cloud Automation API
-def apiClient = new ApiClient()
-apiClient.setBasePath(pcaUrl)
-def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
+def serviceInstanceRestApi = new ServiceInstanceRestApi(new ApiClient().setBasePath(pcaUrl))
 
 // Update service instance data : (status, endpoint)
-def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
 def status = new File(instanceName+"_status").text.trim()
-def currentStatus = (!status.equals(instanceName)) ? "ERROR" : "STOPPED"
+def currentStatus = (!status.equals(instanceName)) ? "ERROR" : "PAUSED"
+def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
 serviceInstanceData.setInstanceStatus(currentStatus)
-serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
 
 // Print warning or error messages and force job to exit with error if there are any.
 if (!status.equals(instanceName)){

--- a/Docker/resources/catalog/Resume_Docker.xml
+++ b/Docker/resources/catalog/Resume_Docker.xml
@@ -15,7 +15,7 @@
     <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
     <info name="group" value="public-objects"/>
     <info name="pca.service.id" value="Docker"/>
-    <info name="pca.states" value="(STOPPED,RUNNING)(RUNNING,RUNNING)"/>
+    <info name="pca.states" value="(PAUSED,RUNNING)(RUNNING,RUNNING)"/>
     <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/docker.png"/>
   </genericInformation>
   <taskFlow>
@@ -46,15 +46,18 @@
 * THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS BEING RESUMED              *
 *********************************************************************************/
 
-// Acquire service instance id from synchro channel
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+println("BEGIN " + variables.get("PA_TASK_NAME"))
+
+// Acquire service instance id and instance name from synchro channel
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def channel = "Service_Instance_" + instanceId
 def instanceName = synchronizationapi.get(channel, "INSTANCE_NAME")
 variables.put("INSTANCE_NAME", instanceName)
 
 // Inform other platforms that service is running through Synchronization API
 synchronizationapi.put(channel, "RUNNING", true)
-synchronizationapi.put(channel, "STOP_LAUNCHED", false)
+synchronizationapi.put(channel, "RESUMED", true)
+synchronizationapi.put(channel, "PAUSE_LAUNCHED", false)
 ]]>
           </code>
         </script>
@@ -63,8 +66,6 @@ synchronizationapi.put(channel, "STOP_LAUNCHED", false)
         <script>
           <code language="bash">
             <![CDATA[
-echo BEGIN  "$variables_PA_TASK_NAME"
-
 INSTANCE_NAME=$variables_INSTANCE_NAME
 
 if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
@@ -90,7 +91,7 @@ fi
           <code language="groovy">
             <![CDATA[
 /*********************************************************************************
-* THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS RESUMED                   *
+* THIS POSTSCRIPT INFORMS PLATFORM THAT PCA SERVICE IS RESUMED                   *
 *********************************************************************************/
 
 import org.ow2.proactive.pca.service.client.ApiClient
@@ -98,7 +99,7 @@ import org.ow2.proactive.pca.service.client.api.ServiceInstanceRestApi
 import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
 
 // Acquire service instance id
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def instanceName = variables.get("INSTANCE_NAME")
 
 def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
@@ -158,52 +159,38 @@ import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
 
 def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
 def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def instanceName = variables.get("INSTANCE_NAME")
-
-// Connect to Cloud Automation API
-def apiClient = new ApiClient()
-apiClient.setBasePath(pcaUrl)
-def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
-
-// Inform other platforms that other actions are canceled through Synchronization API
 def channel = "Service_Instance_" + instanceId
 
-// Check docker container status
-def ByteArrayOutputStream sout = new ByteArrayOutputStream();
-def ByteArrayOutputStream serr = new ByteArrayOutputStream();
-def proc = ["docker", "inspect", "--format", "{{ .State.Running }}", "${instanceName}"].execute().waitForProcessOutput(sout, serr)
-def isContainerRunning = new String(sout.toByteArray()).trim().toBoolean()
+// Connect to Cloud Automation API
+def serviceInstanceRestApi = new ServiceInstanceRestApi(new ApiClient().setBasePath(pcaUrl))
 
-if ((!isContainerRunning) && (!synchronizationapi.get(channel, "DELETE_LAUNCHED")) && (!synchronizationapi.get(channel, "STOP_LAUNCHED"))){
-    currentStatus = 'ERROR'
-    println("[ERROR] An internal error occured in docker container: " + instanceName)
-    // Update docker container is not running
-    def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
-    serviceInstanceData.setInstanceStatus(currentStatus)
-    serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
-    // Tell the CRON loop to stop
-    variables.put("IS_FINISHED",true)
-    // Exit with error
-    System.exit(1)
-} else {
-    def lastTime=variables.get('LAST_TIME_MARK')
-    // Fetch new logs since last fetch time mark.
-    def fetchLogsCmd = ["docker", "logs", "--since", lastTime, instanceName]
-    if(!lastTime){
-        // Fetch all logs from docker container
-        fetchLogsCmd = ["docker", "logs", instanceName]
-    }
-    fetchLogsCmd.execute().consumeProcessOutput(System.out, System.err)
-}
-
-// Check service instance status
+// If service instance is FINISHED or PAUSED then stop this loop and job and delete the sync channel
 def currentStatus = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId).getInstanceStatus()
-if(!currentStatus.equals("RUNNING")){
-    // Allow the Delete workflow to be fulfilled
-    synchronizationapi.put(channel, "DELETE_INSTANCE", true)
-    // Tell the CRON loop to stop
+if (currentStatus.equals("FINISHED") || currentStatus.equals("PAUSED")){
     variables.put("IS_FINISHED",true)
+    synchronizationapi.deleteChannel(channel)
+} else {
+    // Check if container has been stopped abnormally
+    def isContainerRunning = ["docker", "inspect", "--format", "{{ .State.Running }}", "${instanceName}"].execute().getText().trim().toBoolean()
+    if ((!isContainerRunning) && (!synchronizationapi.get(channel, "FINISH_LAUNCHED")) && (!synchronizationapi.get(channel, "PAUSE_LAUNCHED"))){
+        currentStatus = 'ERROR'
+        println("[ERROR] An internal error occured in docker container: " + instanceName)
+        // Update docker container is not running
+        def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
+        serviceInstanceData.setInstanceStatus(currentStatus)
+        serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+        // Tell the CRON loop to stop
+        variables.put("IS_FINISHED",true)
+        // Exit with error
+        System.exit(1)
+    } else {
+        // Fetch all logs or only new logs since last fetch time mark
+        def lastTime=variables.get('LAST_TIME_MARKER')
+        def fetchLogsCmd = lastTime ? ["docker", "logs", "--since", lastTime, instanceName] : ["docker", "logs", instanceName]
+        fetchLogsCmd.execute().waitForProcessOutput(System.out, System.err)
+    }
 }
 ]]>
           </code>
@@ -214,13 +201,12 @@ if(!currentStatus.equals("RUNNING")){
           <script>
             <code language="groovy">
               <![CDATA[
+// Check if loop task has ordered to finish the loop
 def isFinished = variables.get('IS_FINISHED') as boolean
-if(!isFinished){
-    variables.put("LAST_TIME_MARK",new Date().format("yyyy-MM-dd'T'HH:mm:ssXXX"))
-	loop = '*/1 * * * *'
-} else{
-    loop = false
-}
+loop = isFinished ? false : '*/1 * * * *'
+
+// Set a time marker to fetch logs since this marker.
+variables.put("LAST_TIME_MARKER",new Date().format("yyyy-MM-dd'T'HH:mm:ssXXX"))
 ]]>
             </code>
           </script>

--- a/Elasticsearch/METADATA.json
+++ b/Elasticsearch/METADATA.json
@@ -39,13 +39,13 @@
         "file" : "resources/catalog/Resume_Elasticsearch.xml"
       },
       {
-        "name" : "Stop_Elasticsearch",
+        "name" : "Pause_Elasticsearch",
         "metadata" : {
         "kind": "Workflow/pca",
         "commitMessage": "First commit",
         "contentType": "application/xml"
         },
-        "file" : "resources/catalog/Stop_Elasticsearch.xml"
+        "file" : "resources/catalog/Pause_Elasticsearch.xml"
       }
     ]
   }

--- a/Elasticsearch/resources/catalog/Elasticsearch.xml
+++ b/Elasticsearch/resources/catalog/Elasticsearch.xml
@@ -106,7 +106,7 @@ import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
 def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
 def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
 // Acquire service instance id and instance name
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def instanceName = variables.get("INSTANCE_NAME")
 
 def hostname = new URL(paSchedulerRestUrl).getHost()
@@ -174,52 +174,40 @@ import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
 
 def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
 def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def instanceName = variables.get("INSTANCE_NAME")
-
-// Connect to Cloud Automation API
-def apiClient = new ApiClient()
-apiClient.setBasePath(pcaUrl)
-def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
-
-// Inform other platforms that other actions are canceled through Synchronization API
 def channel = "Service_Instance_" + instanceId
 
-// Check docker container status
-def ByteArrayOutputStream sout = new ByteArrayOutputStream();
-def ByteArrayOutputStream serr = new ByteArrayOutputStream();
-def proc = ["docker", "inspect", "--format", "{{ .State.Running }}", "${instanceName}"].execute().waitForProcessOutput(sout, serr)
-def isContainerRunning = new String(sout.toByteArray()).trim().toBoolean()
+// Connect to Cloud Automation API
+def serviceInstanceRestApi = new ServiceInstanceRestApi(new ApiClient().setBasePath(pcaUrl))
 
-if ((!isContainerRunning) && (!synchronizationapi.get(channel, "DELETE_LAUNCHED")) && (!synchronizationapi.get(channel, "STOP_LAUNCHED"))){
-    currentStatus = 'ERROR'
-    println("[ERROR] An internal error occured in docker container: " + instanceName)
-    // Update docker container is not running
-    def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
-    serviceInstanceData.setInstanceStatus(currentStatus)
-    serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
-    // Tell the CRON loop to stop
-    variables.put("IS_FINISHED",true)
-    // Exit with error
-    System.exit(1)
-} else {
-    def lastTime=variables.get('LAST_TIME_MARK')
-    // Fetch new logs since last fetch time mark.
-    def fetchLogsCmd = ["docker", "logs", "--since", lastTime, instanceName]
-    if(!lastTime){
-        // Fetch all logs from docker container
-        fetchLogsCmd = ["docker", "logs", instanceName]
-    }
-    fetchLogsCmd.execute().consumeProcessOutput(System.out, System.err)
-}
-
-// Check service instance status
+// If service instance is FINISHED or PAUSED then stop this loop and job and delete the sync channel
 def currentStatus = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId).getInstanceStatus()
-if(!currentStatus.equals("RUNNING")){
-    // Allow the Delete workflow to be fulfilled
-    synchronizationapi.put(channel, "DELETE_INSTANCE", true)
-    // Tell the CRON loop to stop
+if (currentStatus.equals("FINISHED") || currentStatus.equals("PAUSED") || synchronizationapi.get(channel, "RESUMED")){
     variables.put("IS_FINISHED",true)
+    if (currentStatus.equals("FINISHED")){
+        synchronizationapi.deleteChannel(channel)
+    }
+} else {
+    // Check if container has been stopped abnormally
+    def isContainerRunning = ["docker", "inspect", "--format", "{{ .State.Running }}", "${instanceName}"].execute().getText().trim().toBoolean()
+    if ((!isContainerRunning) && (!synchronizationapi.get(channel, "FINISH_LAUNCHED")) && (!synchronizationapi.get(channel, "PAUSE_LAUNCHED"))){
+        currentStatus = 'ERROR'
+        println("[ERROR] An internal error occured in docker container: " + instanceName)
+        // Update docker container is not running
+        def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
+        serviceInstanceData.setInstanceStatus(currentStatus)
+        serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+        // Tell the CRON loop to stop
+        variables.put("IS_FINISHED",true)
+        // Exit with error
+        System.exit(1)
+    } else {
+        // Fetch all logs or only new logs since last fetch time mark
+        def lastTime=variables.get('LAST_TIME_MARKER')
+        def fetchLogsCmd = lastTime ? ["docker", "logs", "--since", lastTime, instanceName] : ["docker", "logs", instanceName]
+        fetchLogsCmd.execute().waitForProcessOutput(System.out, System.err)
+    }
 }
 ]]>
           </code>
@@ -230,13 +218,12 @@ if(!currentStatus.equals("RUNNING")){
           <script>
             <code language="groovy">
               <![CDATA[
+// Check if loop task has ordered to finish the loop
 def isFinished = variables.get('IS_FINISHED') as boolean
-if(!isFinished){
-    variables.put("LAST_TIME_MARK",new Date().format("yyyy-MM-dd'T'HH:mm:ssXXX"))
-	loop = '*/1 * * * *'
-} else{
-    loop = false
-}
+loop = isFinished ? false : '*/1 * * * *'
+
+// Set a time marker to fetch logs since this marker.
+variables.put("LAST_TIME_MARKER",new Date().format("yyyy-MM-dd'T'HH:mm:ssXXX"))
 ]]>
             </code>
           </script>

--- a/Elasticsearch/resources/catalog/Finish_Elasticsearch.xml
+++ b/Elasticsearch/resources/catalog/Finish_Elasticsearch.xml
@@ -13,7 +13,7 @@
   <genericInformation>
     <info name="bucketName" value="cloud-automation"/>
     <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/elasticsearch.png"/>
-    <info name="pca.states" value="(RUNNING,FINISHED)(STOPPED,FINISHED)(ERROR,FINISHED)"/>
+    <info name="pca.states" value="(RUNNING,FINISHED)(PAUSED,FINISHED)(ERROR,FINISHED)"/>
     <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
     <info name="pca.service.id" value="Elasticsearch"/>
     <info name="group" value="public-objects"/>
@@ -43,14 +43,16 @@
 * THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS BEING FINISHED             *
 *********************************************************************************/
 
+println("BEGIN " + variables.get("PA_TASK_NAME"))
+
 // Acquire service instance id and instance name from synchro channel
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def channel = "Service_Instance_" + instanceId
 def instanceName = synchronizationapi.get(channel, "INSTANCE_NAME")
 variables.put("INSTANCE_NAME", instanceName)
 
 // Inform other platforms that service is being finished through Synchronization API
-synchronizationapi.put(channel, "DELETE_LAUNCHED", true)
+synchronizationapi.put(channel, "FINISH_LAUNCHED", true)
 ]]>
           </code>
         </script>
@@ -59,8 +61,6 @@ synchronizationapi.put(channel, "DELETE_LAUNCHED", true)
         <script>
           <code language="bash">
             <![CDATA[
-echo --- BEGIN  "$variables_PA_TASK_NAME"  ---
-
 echo Removing docker container: "$variables_INSTANCE_NAME"
 INSTANCE_NAME=$(docker rm -f $variables_INSTANCE_NAME 2>&1)
 echo $INSTANCE_NAME > $variables_INSTANCE_NAME"_status"
@@ -82,27 +82,24 @@ import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
 
 def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
 def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def instanceName = variables.get("INSTANCE_NAME")
-    
+
 def ALREADY_REMOVED_MESSAGE = "Error: No such container: " + instanceName
 
 // Connect to Cloud Automation API
-def apiClient = new ApiClient()
-apiClient.setBasePath(pcaUrl)
-def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
+def serviceInstanceRestApi = new ServiceInstanceRestApi(new ApiClient().setBasePath(pcaUrl))
 
 // Update service instance data : (status, endpoint)
-def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
 def status = new File(instanceName+"_status").text.trim()
 def currentStatus = (!status.equals(ALREADY_REMOVED_MESSAGE) && !status.equals(instanceName)) ? "ERROR" : "FINISHED"
+def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
 serviceInstanceData.setInstanceStatus(currentStatus)
-serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
 
-// Delete synchro channel
+// Inform other jobs that the service is finished and deleted.
 def channel = "Service_Instance_" + instanceId
-synchronizationapi.waitUntil(channel, "DELETE_INSTANCE", "{k,x -> x == true}")
-synchronizationapi.deleteChannel(channel)
+synchronizationapi.put(channel, "FINISH_DONE", true)
 
 // Print warning or error messages and force job to exit with error if there are any.
 if (status.equals(ALREADY_REMOVED_MESSAGE)){

--- a/Elasticsearch/resources/catalog/Pause_Elasticsearch.xml
+++ b/Elasticsearch/resources/catalog/Pause_Elasticsearch.xml
@@ -3,29 +3,29 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="urn:proactive:jobdescriptor:3.10"
      xsi:schemaLocation="urn:proactive:jobdescriptor:3.10 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.10/schedulerjob.xsd"
-    name="Stop_Docker" projectName="Cloud Automation - Lifecycle"
+    name="Pause_Elasticsearch" projectName="Cloud Automation - Lifecycle"
     priority="normal"
     onTaskError="continueJobExecution"
      maxNumberOfExecution="2">
   <description>
-    <![CDATA[ Stop Docker container. ]]>
+    <![CDATA[ Pause Elasticsearch instance. ]]>
   </description>
   <genericInformation>
     <info name="bucketName" value="cloud-automation"/>
+    <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/elasticsearch.png"/>
+    <info name="pca.states" value="(RUNNING,PAUSED)"/>
     <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+    <info name="pca.service.id" value="Elasticsearch"/>
     <info name="group" value="public-objects"/>
-    <info name="pca.service.id" value="Docker"/>
-    <info name="pca.states" value="(RUNNING,STOPPED)"/>
-    <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/docker.png"/>
   </genericInformation>
   <taskFlow>
-    <task name="Stop_Docker">
+    <task name="Pause_Elasticsearch">
       <description>
-        <![CDATA[ Stop Docker container ]]>
+        <![CDATA[ Pause Elasticsearch instance ]]>
       </description>
       <genericInformation>
-        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/docker.png"/>
-        <info name="documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/elasticsearch.png"/>
+        <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
       </genericInformation>
       <inputFiles>
         <files  includes="cloud-automation-service-client-8.2.0-SNAPSHOT.jar" accessMode="transferFromGlobalSpace"/>
@@ -40,17 +40,17 @@
           <code language="groovy">
             <![CDATA[
 /*********************************************************************************
-* THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS STOPPED                   *
+* THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS PAUSED                   *
 *********************************************************************************/
 
-// Acquire service instance id and instance name from synchro channel
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
-def channel = "Service_Instance_" + instanceId
-def instanceName = synchronizationapi.get(channel, "INSTANCE_NAME")
-variables.put("INSTANCE_NAME", instanceName)
+println("BEGIN " + variables.get("PA_TASK_NAME"))
 
-// Inform other platforms that service is being stopped through Synchronization API
-synchronizationapi.put(channel, "STOP_LAUNCHED", true)
+// Acquire service instance id and instance name from synchro channel
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
+def channel = "Service_Instance_" + instanceId
+
+// Inform other platforms that service is being paused through Synchronization API
+synchronizationapi.put(channel, "PAUSE_LAUNCHED", true)
 ]]>
           </code>
         </script>
@@ -59,8 +59,6 @@ synchronizationapi.put(channel, "STOP_LAUNCHED", true)
         <script>
           <code language="bash">
             <![CDATA[
-echo --- BEGIN "$variables_PA_TASK_NAME" ---
-
 echo Stopping docker container: "$variables_INSTANCE_NAME"
 INSTANCE_NAME=$(docker stop $variables_INSTANCE_NAME 2>&1)
 echo $INSTANCE_NAME > $variables_INSTANCE_NAME"_status"
@@ -73,7 +71,7 @@ echo $INSTANCE_NAME > $variables_INSTANCE_NAME"_status"
           <code language="groovy">
             <![CDATA[
 /*********************************************************************************
-* THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS STOPPED                   *
+* THIS POSTSCRIPT INFORMS PLATFORM THAT PCA SERVICE IS PAUSED                   *
 *********************************************************************************/
 
 import org.ow2.proactive.pca.service.client.ApiClient
@@ -82,22 +80,18 @@ import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
 
 def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
 def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
-
-// Acquire service instance id and instance name from synchro channel
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def instanceName = variables.get("INSTANCE_NAME")
 
 // Connect to Cloud Automation API
-def apiClient = new ApiClient()
-apiClient.setBasePath(pcaUrl)
-def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
+def serviceInstanceRestApi = new ServiceInstanceRestApi(new ApiClient().setBasePath(pcaUrl))
 
 // Update service instance data : (status, endpoint)
-def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
 def status = new File(instanceName+"_status").text.trim()
-def currentStatus = (!status.equals(instanceName)) ? "ERROR" : "STOPPED"
+def currentStatus = (!status.equals(instanceName)) ? "ERROR" : "PAUSED"
+def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
 serviceInstanceData.setInstanceStatus(currentStatus)
-serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
 
 // Print warning or error messages and force job to exit with error if there are any.
 if (!status.equals(instanceName)){

--- a/Elasticsearch/resources/catalog/Resume_Elasticsearch.xml
+++ b/Elasticsearch/resources/catalog/Resume_Elasticsearch.xml
@@ -13,7 +13,7 @@
   <genericInformation>
     <info name="bucketName" value="cloud-automation"/>
     <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/elasticsearch.png"/>
-    <info name="pca.states" value="(STOPPED,RUNNING)(RUNNING,RUNNING)"/>
+    <info name="pca.states" value="(PAUSED,RUNNING)(RUNNING,RUNNING)"/>
     <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
     <info name="pca.service.id" value="Elasticsearch"/>
     <info name="group" value="public-objects"/>
@@ -43,13 +43,16 @@
 * THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS BEING RESUMED              *
 *********************************************************************************/
 
+println("BEGIN " + variables.get("PA_TASK_NAME"))
+
 // Acquire service instance id and instance name from synchro channel
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def channel = "Service_Instance_" + instanceId
 
 // Inform other platforms that service is running through Synchronization API
 synchronizationapi.put(channel, "RUNNING", true)
-synchronizationapi.put(channel, "STOP_LAUNCHED", false)
+synchronizationapi.put(channel, "RESUMED", true)
+synchronizationapi.put(channel, "PAUSE_LAUNCHED", false)
 ]]>
           </code>
         </script>
@@ -58,8 +61,6 @@ synchronizationapi.put(channel, "STOP_LAUNCHED", false)
         <script>
           <code language="bash">
             <![CDATA[
-echo BEGIN  "$variables_PA_TASK_NAME"
-
 INSTANCE_NAME=$variables_INSTANCE_NAME
 
 if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
@@ -85,7 +86,7 @@ fi
           <code language="groovy">
             <![CDATA[
 /*********************************************************************************
-* THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS RESUMED                   *
+* THIS POSTSCRIPT INFORMS PLATFORM THAT PCA SERVICE IS RESUMED                   *
 *********************************************************************************/
 
 import org.ow2.proactive.pca.service.client.ApiClient
@@ -93,7 +94,7 @@ import org.ow2.proactive.pca.service.client.api.ServiceInstanceRestApi
 import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
 
 // Acquire service instance id
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def instanceName = variables.get("INSTANCE_NAME")
 
 def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
@@ -153,52 +154,38 @@ import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
 
 def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
 def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def instanceName = variables.get("INSTANCE_NAME")
-
-// Connect to Cloud Automation API
-def apiClient = new ApiClient()
-apiClient.setBasePath(pcaUrl)
-def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
-
-// Inform other platforms that other actions are canceled through Synchronization API
 def channel = "Service_Instance_" + instanceId
 
-// Check docker container status
-def ByteArrayOutputStream sout = new ByteArrayOutputStream();
-def ByteArrayOutputStream serr = new ByteArrayOutputStream();
-def proc = ["docker", "inspect", "--format", "{{ .State.Running }}", "${instanceName}"].execute().waitForProcessOutput(sout, serr)
-def isContainerRunning = new String(sout.toByteArray()).trim().toBoolean()
+// Connect to Cloud Automation API
+def serviceInstanceRestApi = new ServiceInstanceRestApi(new ApiClient().setBasePath(pcaUrl))
 
-if ((!isContainerRunning) && (!synchronizationapi.get(channel, "DELETE_LAUNCHED")) && (!synchronizationapi.get(channel, "STOP_LAUNCHED"))){
-    currentStatus = 'ERROR'
-    println("[ERROR] An internal error occured in docker container: " + instanceName)
-    // Update docker container is not running
-    def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
-    serviceInstanceData.setInstanceStatus(currentStatus)
-    serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
-    // Tell the CRON loop to stop
-    variables.put("IS_FINISHED",true)
-    // Exit with error
-    System.exit(1)
-} else {
-    def lastTime=variables.get('LAST_TIME_MARK')
-    // Fetch new logs since last fetch time mark.
-    def fetchLogsCmd = ["docker", "logs", "--since", lastTime, instanceName]
-    if(!lastTime){
-        // Fetch all logs from docker container
-        fetchLogsCmd = ["docker", "logs", instanceName]
-    }
-    fetchLogsCmd.execute().consumeProcessOutput(System.out, System.err)
-}
-
-// Check service instance status
+// If service instance is FINISHED or PAUSED then stop this loop and job and delete the sync channel
 def currentStatus = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId).getInstanceStatus()
-if(!currentStatus.equals("RUNNING")){
-    // Allow the Delete workflow to be fulfilled
-    synchronizationapi.put(channel, "DELETE_INSTANCE", true)
-    // Tell the CRON loop to stop
+if (currentStatus.equals("FINISHED") || currentStatus.equals("PAUSED")){
     variables.put("IS_FINISHED",true)
+    synchronizationapi.deleteChannel(channel)
+} else {
+    // Check if container has been stopped abnormally
+    def isContainerRunning = ["docker", "inspect", "--format", "{{ .State.Running }}", "${instanceName}"].execute().getText().trim().toBoolean()
+    if ((!isContainerRunning) && (!synchronizationapi.get(channel, "FINISH_LAUNCHED")) && (!synchronizationapi.get(channel, "PAUSE_LAUNCHED"))){
+        currentStatus = 'ERROR'
+        println("[ERROR] An internal error occured in docker container: " + instanceName)
+        // Update docker container is not running
+        def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
+        serviceInstanceData.setInstanceStatus(currentStatus)
+        serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+        // Tell the CRON loop to stop
+        variables.put("IS_FINISHED",true)
+        // Exit with error
+        System.exit(1)
+    } else {
+        // Fetch all logs or only new logs since last fetch time mark
+        def lastTime=variables.get('LAST_TIME_MARKER')
+        def fetchLogsCmd = lastTime ? ["docker", "logs", "--since", lastTime, instanceName] : ["docker", "logs", instanceName]
+        fetchLogsCmd.execute().waitForProcessOutput(System.out, System.err)
+    }
 }
 ]]>
           </code>
@@ -209,13 +196,12 @@ if(!currentStatus.equals("RUNNING")){
           <script>
             <code language="groovy">
               <![CDATA[
+// Check if loop task has ordered to finish the loop
 def isFinished = variables.get('IS_FINISHED') as boolean
-if(!isFinished){
-    variables.put("LAST_TIME_MARK",new Date().format("yyyy-MM-dd'T'HH:mm:ssXXX"))
-	loop = '*/1 * * * *'
-} else{
-    loop = false
-}
+loop = isFinished ? false : '*/1 * * * *'
+
+// Set a time marker to fetch logs since this marker.
+variables.put("LAST_TIME_MARKER",new Date().format("yyyy-MM-dd'T'HH:mm:ssXXX"))
 ]]>
             </code>
           </script>

--- a/MongoDB/METADATA.json
+++ b/MongoDB/METADATA.json
@@ -30,13 +30,13 @@
 				"file" : "resources/catalog/Resume_MongoDB.xml"
 			},
 			{
-				"name" : "Stop_MongoDB",
+				"name" : "Pause_MongoDB",
 				"metadata" : {
 					"kind": "Workflow/pca",
 					"commitMessage": "First commit",
 					"contentType": "application/xml"
 				},
-				"file" : "resources/catalog/Stop_MongoDB.xml"
+				"file" : "resources/catalog/Pause_MongoDB.xml"
 			},
 			{
 				"name" : "Finish_MongoDB",

--- a/MongoDB/resources/catalog/Finish_MongoDB.xml
+++ b/MongoDB/resources/catalog/Finish_MongoDB.xml
@@ -13,7 +13,7 @@
   <genericInformation>
     <info name="bucketName" value="cloud-automation"/>
     <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/mongodb.png"/>
-    <info name="pca.states" value="(RUNNING,FINISHED)(STOPPED,FINISHED)(ERROR,FINISHED)"/>
+    <info name="pca.states" value="(RUNNING,FINISHED)(PAUSED,FINISHED)(ERROR,FINISHED)"/>
     <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
     <info name="pca.service.id" value="MongoDB"/>
     <info name="group" value="public-objects"/>
@@ -43,14 +43,16 @@
 * THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS BEING FINISHED             *
 *********************************************************************************/
 
+println("BEGIN " + variables.get("PA_TASK_NAME"))
+
 // Acquire service instance id and instance name from synchro channel
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def channel = "Service_Instance_" + instanceId
 def instanceName = synchronizationapi.get(channel, "INSTANCE_NAME")
 variables.put("INSTANCE_NAME", instanceName)
 
 // Inform other platforms that service is being finished through Synchronization API
-synchronizationapi.put(channel, "DELETE_LAUNCHED", true)
+synchronizationapi.put(channel, "FINISH_LAUNCHED", true)
 ]]>
           </code>
         </script>
@@ -59,8 +61,6 @@ synchronizationapi.put(channel, "DELETE_LAUNCHED", true)
         <script>
           <code language="bash">
             <![CDATA[
-echo --- BEGIN  "$variables_PA_TASK_NAME"  ---
-
 echo Removing docker container: "$variables_INSTANCE_NAME"
 INSTANCE_NAME=$(docker rm -f $variables_INSTANCE_NAME 2>&1)
 echo $INSTANCE_NAME > $variables_INSTANCE_NAME"_status"
@@ -82,27 +82,24 @@ import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
 
 def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
 def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def instanceName = variables.get("INSTANCE_NAME")
-    
+
 def ALREADY_REMOVED_MESSAGE = "Error: No such container: " + instanceName
 
 // Connect to Cloud Automation API
-def apiClient = new ApiClient()
-apiClient.setBasePath(pcaUrl)
-def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
+def serviceInstanceRestApi = new ServiceInstanceRestApi(new ApiClient().setBasePath(pcaUrl))
 
 // Update service instance data : (status, endpoint)
-def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
 def status = new File(instanceName+"_status").text.trim()
 def currentStatus = (!status.equals(ALREADY_REMOVED_MESSAGE) && !status.equals(instanceName)) ? "ERROR" : "FINISHED"
+def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
 serviceInstanceData.setInstanceStatus(currentStatus)
-serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
 
-// Delete synchro channel
+// Inform other jobs that the service is finished and deleted.
 def channel = "Service_Instance_" + instanceId
-synchronizationapi.waitUntil(channel, "DELETE_INSTANCE", "{k,x -> x == true}")
-synchronizationapi.deleteChannel(channel)
+synchronizationapi.put(channel, "FINISH_DONE", true)
 
 // Print warning or error messages and force job to exit with error if there are any.
 if (status.equals(ALREADY_REMOVED_MESSAGE)){

--- a/MongoDB/resources/catalog/MongoDB.xml
+++ b/MongoDB/resources/catalog/MongoDB.xml
@@ -129,7 +129,7 @@ import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
 def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
 def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
 // Acquire service instance id and instance name
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def instanceName = variables.get("INSTANCE_NAME")
 
 def hostname = new URL(paSchedulerRestUrl).getHost()
@@ -215,52 +215,40 @@ import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
 
 def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
 def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def instanceName = variables.get("INSTANCE_NAME")
-
-// Connect to Cloud Automation API
-def apiClient = new ApiClient()
-apiClient.setBasePath(pcaUrl)
-def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
-
-// Inform other platforms that other actions are canceled through Synchronization API
 def channel = "Service_Instance_" + instanceId
 
-// Check docker container status
-def ByteArrayOutputStream sout = new ByteArrayOutputStream();
-def ByteArrayOutputStream serr = new ByteArrayOutputStream();
-def proc = ["docker", "inspect", "--format", "{{ .State.Running }}", "${instanceName}"].execute().waitForProcessOutput(sout, serr)
-def isContainerRunning = new String(sout.toByteArray()).trim().toBoolean()
+// Connect to Cloud Automation API
+def serviceInstanceRestApi = new ServiceInstanceRestApi(new ApiClient().setBasePath(pcaUrl))
 
-if ((!isContainerRunning) && (!synchronizationapi.get(channel, "DELETE_LAUNCHED")) && (!synchronizationapi.get(channel, "STOP_LAUNCHED"))){
-    currentStatus = 'ERROR'
-    println("[ERROR] An internal error occured in docker container: " + instanceName)
-    // Update docker container is not running
-    def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
-    serviceInstanceData.setInstanceStatus(currentStatus)
-    serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
-    // Tell the CRON loop to stop
-    variables.put("IS_FINISHED",true)
-    // Exit with error
-    System.exit(1)
-} else {
-    def lastTime=variables.get('LAST_TIME_MARK')
-    // Fetch new logs since last fetch time mark.
-    def fetchLogsCmd = ["docker", "logs", "--since", lastTime, instanceName]
-    if(!lastTime){
-        // Fetch all logs from docker container
-        fetchLogsCmd = ["docker", "logs", instanceName]
-    }
-    fetchLogsCmd.execute().consumeProcessOutput(System.out, System.err)
-}
-
-// Check service instance status
+// If service instance is FINISHED or PAUSED then stop this loop and job and delete the sync channel
 def currentStatus = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId).getInstanceStatus()
-if(!currentStatus.equals("RUNNING")){
-    // Allow the Delete workflow to be fulfilled
-    synchronizationapi.put(channel, "DELETE_INSTANCE", true)
-    // Tell the CRON loop to stop
+if (currentStatus.equals("FINISHED") || currentStatus.equals("PAUSED") || synchronizationapi.get(channel, "RESUMED")){
     variables.put("IS_FINISHED",true)
+    if (currentStatus.equals("FINISHED")){
+        synchronizationapi.deleteChannel(channel)
+    }
+} else {
+    // Check if container has been stopped abnormally
+    def isContainerRunning = ["docker", "inspect", "--format", "{{ .State.Running }}", "${instanceName}"].execute().getText().trim().toBoolean()
+    if ((!isContainerRunning) && (!synchronizationapi.get(channel, "FINISH_LAUNCHED")) && (!synchronizationapi.get(channel, "PAUSE_LAUNCHED"))){
+        currentStatus = 'ERROR'
+        println("[ERROR] An internal error occured in docker container: " + instanceName)
+        // Update docker container is not running
+        def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
+        serviceInstanceData.setInstanceStatus(currentStatus)
+        serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+        // Tell the CRON loop to stop
+        variables.put("IS_FINISHED",true)
+        // Exit with error
+        System.exit(1)
+    } else {
+        // Fetch all logs or only new logs since last fetch time mark
+        def lastTime=variables.get('LAST_TIME_MARKER')
+        def fetchLogsCmd = lastTime ? ["docker", "logs", "--since", lastTime, instanceName] : ["docker", "logs", instanceName]
+        fetchLogsCmd.execute().waitForProcessOutput(System.out, System.err)
+    }
 }
 ]]>
           </code>
@@ -271,13 +259,12 @@ if(!currentStatus.equals("RUNNING")){
           <script>
             <code language="groovy">
               <![CDATA[
+// Check if loop task has ordered to finish the loop
 def isFinished = variables.get('IS_FINISHED') as boolean
-if(!isFinished){
-    variables.put("LAST_TIME_MARK",new Date().format("yyyy-MM-dd'T'HH:mm:ssXXX"))
-	loop = '*/1 * * * *'
-} else{
-    loop = false
-}
+loop = isFinished ? false : '*/1 * * * *'
+
+// Set a time marker to fetch logs since this marker.
+variables.put("LAST_TIME_MARKER",new Date().format("yyyy-MM-dd'T'HH:mm:ssXXX"))
 ]]>
             </code>
           </script>

--- a/MongoDB/resources/catalog/Pause_MongoDB.xml
+++ b/MongoDB/resources/catalog/Pause_MongoDB.xml
@@ -3,28 +3,28 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="urn:proactive:jobdescriptor:3.10"
      xsi:schemaLocation="urn:proactive:jobdescriptor:3.10 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.10/schedulerjob.xsd"
-    name="Stop_Cassandra" projectName="Cloud Automation - Lifecycle"
+    name="Pause_MongoDB" projectName="Cloud Automation - Lifecycle"
     priority="normal"
     onTaskError="continueJobExecution"
      maxNumberOfExecution="2">
   <description>
-    <![CDATA[ Stop Cassandra instance. ]]>
+    <![CDATA[ Pause MongoDB instance. ]]>
   </description>
   <genericInformation>
     <info name="bucketName" value="cloud-automation"/>
-    <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png"/>
-    <info name="pca.states" value="(RUNNING,STOPPED)"/>
+    <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/mongodb.png"/>
+    <info name="pca.states" value="(RUNNING,PAUSED)"/>
     <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
-    <info name="pca.service.id" value="Cassandra"/>
+    <info name="pca.service.id" value="MongoDB"/>
     <info name="group" value="public-objects"/>
   </genericInformation>
   <taskFlow>
-    <task name="Stop_Cassandra">
+    <task name="Pause_MongoDB" >
       <description>
-        <![CDATA[ Stop Cassandra instance ]]>
+        <![CDATA[ Pause MongoDB instance ]]>
       </description>
       <genericInformation>
-        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png"/>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/mongodb.png"/>
         <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
       </genericInformation>
       <inputFiles>
@@ -40,15 +40,17 @@
           <code language="groovy">
             <![CDATA[
 /*********************************************************************************
-* THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS STOPPED                   *
+* THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS PAUSED                   *
 *********************************************************************************/
 
+println("BEGIN " + variables.get("PA_TASK_NAME"))
+
 // Acquire service instance id and instance name from synchro channel
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def channel = "Service_Instance_" + instanceId
 
-// Inform other platforms that service is being stopped through Synchronization API
-synchronizationapi.put(channel, "STOP_LAUNCHED", true)
+// Inform other platforms that service is being paused through Synchronization API
+synchronizationapi.put(channel, "PAUSE_LAUNCHED", true)
 ]]>
           </code>
         </script>
@@ -57,8 +59,6 @@ synchronizationapi.put(channel, "STOP_LAUNCHED", true)
         <script>
           <code language="bash">
             <![CDATA[
-echo --- BEGIN "$variables_PA_TASK_NAME" ---
-
 echo Stopping docker container: "$variables_INSTANCE_NAME"
 INSTANCE_NAME=$(docker stop $variables_INSTANCE_NAME 2>&1)
 echo $INSTANCE_NAME > $variables_INSTANCE_NAME"_status"
@@ -71,7 +71,7 @@ echo $INSTANCE_NAME > $variables_INSTANCE_NAME"_status"
           <code language="groovy">
             <![CDATA[
 /*********************************************************************************
-* THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS STOPPED                   *
+* THIS POSTSCRIPT INFORMS PLATFORM THAT PCA SERVICE IS PAUSED                   *
 *********************************************************************************/
 
 import org.ow2.proactive.pca.service.client.ApiClient
@@ -80,22 +80,18 @@ import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
 
 def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
 def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
-
-// Acquire service instance id and instance name from synchro channel
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def instanceName = variables.get("INSTANCE_NAME")
 
 // Connect to Cloud Automation API
-def apiClient = new ApiClient()
-apiClient.setBasePath(pcaUrl)
-def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
+def serviceInstanceRestApi = new ServiceInstanceRestApi(new ApiClient().setBasePath(pcaUrl))
 
 // Update service instance data : (status, endpoint)
-def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
 def status = new File(instanceName+"_status").text.trim()
-def currentStatus = (!status.equals(instanceName)) ? "ERROR" : "STOPPED"
+def currentStatus = (!status.equals(instanceName)) ? "ERROR" : "PAUSED"
+def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
 serviceInstanceData.setInstanceStatus(currentStatus)
-serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
 
 // Print warning or error messages and force job to exit with error if there are any.
 if (!status.equals(instanceName)){

--- a/MongoDB/resources/catalog/Resume_MongoDB.xml
+++ b/MongoDB/resources/catalog/Resume_MongoDB.xml
@@ -13,7 +13,7 @@
   <genericInformation>
     <info name="bucketName" value="cloud-automation"/>
     <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/mongodb.png"/>
-    <info name="pca.states" value="(STOPPED,RUNNING)(RUNNING,RUNNING)"/>
+    <info name="pca.states" value="(PAUSED,RUNNING)(RUNNING,RUNNING)"/>
     <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
     <info name="pca.service.id" value="MongoDB"/>
     <info name="group" value="public-objects"/>
@@ -43,13 +43,16 @@
 * THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS BEING RESUMED              *
 *********************************************************************************/
 
+println("BEGIN " + variables.get("PA_TASK_NAME"))
+
 // Acquire service instance id and instance name from synchro channel
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def channel = "Service_Instance_" + instanceId
 
 // Inform other platforms that service is running through Synchronization API
 synchronizationapi.put(channel, "RUNNING", true)
-synchronizationapi.put(channel, "STOP_LAUNCHED", false)
+synchronizationapi.put(channel, "RESUMED", true)
+synchronizationapi.put(channel, "PAUSE_LAUNCHED", false)
 ]]>
           </code>
         </script>
@@ -58,8 +61,6 @@ synchronizationapi.put(channel, "STOP_LAUNCHED", false)
         <script>
           <code language="bash">
             <![CDATA[
-echo BEGIN  "$variables_PA_TASK_NAME"
-
 INSTANCE_NAME=$variables_INSTANCE_NAME
 
 if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
@@ -85,7 +86,7 @@ fi
           <code language="groovy">
             <![CDATA[
 /*********************************************************************************
-* THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS RESUMED                   *
+* THIS POSTSCRIPT INFORMS PLATFORM THAT PCA SERVICE IS RESUMED                   *
 *********************************************************************************/
 
 import org.ow2.proactive.pca.service.client.ApiClient
@@ -93,7 +94,7 @@ import org.ow2.proactive.pca.service.client.api.ServiceInstanceRestApi
 import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
 
 // Acquire service instance id
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def instanceName = variables.get("INSTANCE_NAME")
 
 def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
@@ -153,52 +154,38 @@ import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
 
 def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
 def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def instanceName = variables.get("INSTANCE_NAME")
-
-// Connect to Cloud Automation API
-def apiClient = new ApiClient()
-apiClient.setBasePath(pcaUrl)
-def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
-
-// Inform other platforms that other actions are canceled through Synchronization API
 def channel = "Service_Instance_" + instanceId
 
-// Check docker container status
-def ByteArrayOutputStream sout = new ByteArrayOutputStream();
-def ByteArrayOutputStream serr = new ByteArrayOutputStream();
-def proc = ["docker", "inspect", "--format", "{{ .State.Running }}", "${instanceName}"].execute().waitForProcessOutput(sout, serr)
-def isContainerRunning = new String(sout.toByteArray()).trim().toBoolean()
+// Connect to Cloud Automation API
+def serviceInstanceRestApi = new ServiceInstanceRestApi(new ApiClient().setBasePath(pcaUrl))
 
-if ((!isContainerRunning) && (!synchronizationapi.get(channel, "DELETE_LAUNCHED")) && (!synchronizationapi.get(channel, "STOP_LAUNCHED"))){
-    currentStatus = 'ERROR'
-    println("[ERROR] An internal error occured in docker container: " + instanceName)
-    // Update docker container is not running
-    def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
-    serviceInstanceData.setInstanceStatus(currentStatus)
-    serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
-    // Tell the CRON loop to stop
-    variables.put("IS_FINISHED",true)
-    // Exit with error
-    System.exit(1)
-} else {
-    def lastTime=variables.get('LAST_TIME_MARK')
-    // Fetch new logs since last fetch time mark.
-    def fetchLogsCmd = ["docker", "logs", "--since", lastTime, instanceName]
-    if(!lastTime){
-        // Fetch all logs from docker container
-        fetchLogsCmd = ["docker", "logs", instanceName]
-    }
-    fetchLogsCmd.execute().consumeProcessOutput(System.out, System.err)
-}
-
-// Check service instance status
+// If service instance is FINISHED or PAUSED then stop this loop and job and delete the sync channel
 def currentStatus = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId).getInstanceStatus()
-if(!currentStatus.equals("RUNNING")){
-    // Allow the Delete workflow to be fulfilled
-    synchronizationapi.put(channel, "DELETE_INSTANCE", true)
-    // Tell the CRON loop to stop
+if (currentStatus.equals("FINISHED") || currentStatus.equals("PAUSED")){
     variables.put("IS_FINISHED",true)
+    synchronizationapi.deleteChannel(channel)
+} else {
+    // Check if container has been stopped abnormally
+    def isContainerRunning = ["docker", "inspect", "--format", "{{ .State.Running }}", "${instanceName}"].execute().getText().trim().toBoolean()
+    if ((!isContainerRunning) && (!synchronizationapi.get(channel, "FINISH_LAUNCHED")) && (!synchronizationapi.get(channel, "PAUSE_LAUNCHED"))){
+        currentStatus = 'ERROR'
+        println("[ERROR] An internal error occured in docker container: " + instanceName)
+        // Update docker container is not running
+        def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
+        serviceInstanceData.setInstanceStatus(currentStatus)
+        serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+        // Tell the CRON loop to stop
+        variables.put("IS_FINISHED",true)
+        // Exit with error
+        System.exit(1)
+    } else {
+        // Fetch all logs or only new logs since last fetch time mark
+        def lastTime=variables.get('LAST_TIME_MARKER')
+        def fetchLogsCmd = lastTime ? ["docker", "logs", "--since", lastTime, instanceName] : ["docker", "logs", instanceName]
+        fetchLogsCmd.execute().waitForProcessOutput(System.out, System.err)
+    }
 }
 ]]>
           </code>
@@ -209,13 +196,12 @@ if(!currentStatus.equals("RUNNING")){
           <script>
             <code language="groovy">
               <![CDATA[
+// Check if loop task has ordered to finish the loop
 def isFinished = variables.get('IS_FINISHED') as boolean
-if(!isFinished){
-    variables.put("LAST_TIME_MARK",new Date().format("yyyy-MM-dd'T'HH:mm:ssXXX"))
-	loop = '*/1 * * * *'
-} else{
-    loop = false
-}
+loop = isFinished ? false : '*/1 * * * *'
+
+// Set a time marker to fetch logs since this marker.
+variables.put("LAST_TIME_MARKER",new Date().format("yyyy-MM-dd'T'HH:mm:ssXXX"))
 ]]>
             </code>
           </script>

--- a/MySQL/METADATA.json
+++ b/MySQL/METADATA.json
@@ -39,13 +39,13 @@
 				"file" : "resources/catalog/Resume_MySQL.xml"
 			},
 			{
-				"name" : "Stop_MySQL",
+				"name" : "Pause_MySQL",
 				"metadata" : {
 					"kind": "Workflow/pca",
 					"commitMessage": "First commit",
 					"contentType": "application/xml"
 				},
-				"file" : "resources/catalog/Stop_MySQL.xml"
+				"file" : "resources/catalog/Pause_MySQL.xml"
 			}
 		]
 	}

--- a/MySQL/resources/catalog/Finish_MySQL.xml
+++ b/MySQL/resources/catalog/Finish_MySQL.xml
@@ -13,7 +13,7 @@
   <genericInformation>
     <info name="bucketName" value="cloud-automation"/>
     <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/mysql.png"/>
-    <info name="pca.states" value="(RUNNING,FINISHED)(STOPPED,FINISHED)(ERROR,FINISHED)"/>
+    <info name="pca.states" value="(RUNNING,FINISHED)(PAUSED,FINISHED)(ERROR,FINISHED)"/>
     <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
     <info name="pca.service.id" value="MySQL"/>
     <info name="group" value="public-objects"/>
@@ -43,14 +43,16 @@
 * THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS BEING FINISHED             *
 *********************************************************************************/
 
+println("BEGIN " + variables.get("PA_TASK_NAME"))
+
 // Acquire service instance id and instance name from synchro channel
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def channel = "Service_Instance_" + instanceId
 def instanceName = synchronizationapi.get(channel, "INSTANCE_NAME")
 variables.put("INSTANCE_NAME", instanceName)
 
 // Inform other platforms that service is being finished through Synchronization API
-synchronizationapi.put(channel, "DELETE_LAUNCHED", true)
+synchronizationapi.put(channel, "FINISH_LAUNCHED", true)
 ]]>
           </code>
         </script>
@@ -59,8 +61,6 @@ synchronizationapi.put(channel, "DELETE_LAUNCHED", true)
         <script>
           <code language="bash">
             <![CDATA[
-echo --- BEGIN  "$variables_PA_TASK_NAME"  ---
-
 echo Removing docker container: "$variables_INSTANCE_NAME"
 INSTANCE_NAME=$(docker rm -f $variables_INSTANCE_NAME 2>&1)
 echo $INSTANCE_NAME > $variables_INSTANCE_NAME"_status"
@@ -82,27 +82,24 @@ import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
 
 def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
 def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def instanceName = variables.get("INSTANCE_NAME")
-    
+
 def ALREADY_REMOVED_MESSAGE = "Error: No such container: " + instanceName
 
 // Connect to Cloud Automation API
-def apiClient = new ApiClient()
-apiClient.setBasePath(pcaUrl)
-def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
+def serviceInstanceRestApi = new ServiceInstanceRestApi(new ApiClient().setBasePath(pcaUrl))
 
 // Update service instance data : (status, endpoint)
-def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
 def status = new File(instanceName+"_status").text.trim()
 def currentStatus = (!status.equals(ALREADY_REMOVED_MESSAGE) && !status.equals(instanceName)) ? "ERROR" : "FINISHED"
+def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
 serviceInstanceData.setInstanceStatus(currentStatus)
-serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
 
-// Delete synchro channel
+// Inform other jobs that the service is finished and deleted.
 def channel = "Service_Instance_" + instanceId
-synchronizationapi.waitUntil(channel, "DELETE_INSTANCE", "{k,x -> x == true}")
-synchronizationapi.deleteChannel(channel)
+synchronizationapi.put(channel, "FINISH_DONE", true)
 
 // Print warning or error messages and force job to exit with error if there are any.
 if (status.equals(ALREADY_REMOVED_MESSAGE)){

--- a/MySQL/resources/catalog/MySQL.xml
+++ b/MySQL/resources/catalog/MySQL.xml
@@ -30,86 +30,7 @@ $PASSWORD (Optional): Password for the root user. ]]>
     <info name="group" value="public-objects"/>
   </genericInformation>
   <taskFlow>
-    <task name="Loop_Over_Instance_Status">
-      <genericInformation>
-        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/mysql.png"/>
-        <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
-      </genericInformation>
-      <depends>
-        <task ref="Start_MySQL"/>
-      </depends>
-      <inputFiles>
-        <files  includes="cloud-automation-service-client-8.2.0-SNAPSHOT.jar" accessMode="transferFromGlobalSpace"/>
-      </inputFiles>
-      <forkEnvironment >
-        <additionalClasspath>
-          <pathElement path="cloud-automation-service-client-8.2.0-SNAPSHOT.jar"/>
-        </additionalClasspath>
-      </forkEnvironment>
-      <scriptExecutable>
-        <script>
-          <code language="groovy">
-            <![CDATA[
-import org.ow2.proactive.pca.service.client.ApiClient
-import org.ow2.proactive.pca.service.client.api.ServiceInstanceRestApi
-import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
-
-println("BEGIN " + variables.get("PA_TASK_NAME"))
-
-def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
-def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
-def instanceName = variables.get("INSTANCE_NAME")
-
-println("INSTANCE_NAME="+instanceName)
-
-// Connect to Cloud Automation API
-def apiClient = new ApiClient()
-apiClient.setBasePath(pcaUrl)
-def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
-
-// Inform other platforms that other actions are canceled through Synchronization API
-def channel = "Service_Instance_" + instanceId
-synchronizationapi.put(channel, "DELETE_LAUNCHED", false)
-synchronizationapi.put(channel, "DELETE_INSTANCE", false)
-
-// Loop over service instance status
-def currentStatus = "RUNNING"
-def exitWithError = false
-while(currentStatus=="RUNNING") {
-    sleep(10000);
-    // Check docker container status
-    def ByteArrayOutputStream sout = new ByteArrayOutputStream();
-    def ByteArrayOutputStream serr = new ByteArrayOutputStream();
-    def proc = ["docker", "inspect", "--format", "{{ .State.Running }}", "${instanceName}"].execute().waitForProcessOutput(sout, serr)
-    def isContainerRunning = new String(sout.toByteArray()).trim().toBoolean()
-
-    if ((!isContainerRunning) && (!synchronizationapi.get(channel, "DELETE_LAUNCHED")) && (!synchronizationapi.get(channel, "STOP_LAUNCHED"))){
-        currentStatus = 'ERROR'
-        exitWithError = true
-        println("[ERROR] An internal error occured in docker container: " + instanceName)
-        // Update docker container is not running
-        def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
-        serviceInstanceData.setInstanceStatus(currentStatus)
-        serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
-        break
-    }
-    // Check service instance status
-    currentStatus = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId).getInstanceStatus()
-}
-
-// Allow the Delete workflow to be fulfilled
-synchronizationapi.put(channel, "DELETE_INSTANCE", true)
-if (exitWithError){
-    System.exit(1)
-}
-println("END " + variables.get("PA_TASK_NAME"))
-]]>
-          </code>
-        </script>
-      </scriptExecutable>
-    </task>
-    <task name="Start_MySQL">
+    <task name="Start_MySQL" >
       <description>
         <![CDATA[ Pull MySQL image and start a container ]]>
       </description>
@@ -177,9 +98,9 @@ else
         INSTANCE_STATUS=$(docker run --name "$INSTANCE_NAME" -p $PORT -e MYSQL_ROOT_PASSWORD="$ROOT_PASSWORD" -e MYSQL_USER="$USER" -e MYSQL_PASSWORD=$PASSWORD -d "$DOCKER_IMAGE")
     elif [ "$DATABASE" != null ] && [ "$USER" == null ]; then
         INSTANCE_STATUS=$(docker run --name "$INSTANCE_NAME" -p $PORT -e MYSQL_ROOT_PASSWORD="$ROOT_PASSWORD" -e MYSQL_DATABASE="$DATABASE" -d "$DOCKER_IMAGE")
-    else 
+    else
         INSTANCE_STATUS=$(docker run --name "$INSTANCE_NAME" -p $PORT -e MYSQL_ROOT_PASSWORD="$ROOT_PASSWORD" -e MYSQL_USER="$USER" -e MYSQL_PASSWORD=$PASSWORD -e MYSQL_DATABASE="$DATABASE" -d "$DOCKER_IMAGE")
-    fi 
+    fi
     ################################################################################
     if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
         RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)
@@ -216,7 +137,7 @@ import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
 def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
 def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
 // Acquire service instance id and instance name
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def instanceName = variables.get("INSTANCE_NAME")
 
 def hostname = new URL(paSchedulerRestUrl).getHost()
@@ -271,6 +192,92 @@ println("END " + variables.get("PA_TASK_NAME"))
           </code>
         </script>
       </post>
+    </task>
+    <task name="Loop_Over_Instance_Status" >
+      <description>
+        <![CDATA[ Loop over service instance status and fetch docker container logs.
+It will run every minute. ]]>
+      </description>
+      <genericInformation>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/mysql.png"/>
+        <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+      </genericInformation>
+      <depends>
+        <task ref="Start_MySQL"/>
+      </depends>
+      <inputFiles>
+        <files  includes="cloud-automation-service-client-8.2.0-SNAPSHOT.jar" accessMode="transferFromGlobalSpace"/>
+      </inputFiles>
+      <forkEnvironment >
+        <additionalClasspath>
+          <pathElement path="cloud-automation-service-client-8.2.0-SNAPSHOT.jar"/>
+        </additionalClasspath>
+      </forkEnvironment>
+      <scriptExecutable>
+        <script>
+          <code language="groovy">
+            <![CDATA[
+import org.ow2.proactive.pca.service.client.ApiClient
+import org.ow2.proactive.pca.service.client.api.ServiceInstanceRestApi
+import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
+
+def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
+def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
+def instanceName = variables.get("INSTANCE_NAME")
+def channel = "Service_Instance_" + instanceId
+
+// Connect to Cloud Automation API
+def serviceInstanceRestApi = new ServiceInstanceRestApi(new ApiClient().setBasePath(pcaUrl))
+
+// If service instance is FINISHED or PAUSED then stop this loop and job and delete the sync channel
+def currentStatus = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId).getInstanceStatus()
+if (currentStatus.equals("FINISHED") || currentStatus.equals("PAUSED") || synchronizationapi.get(channel, "RESUMED")){
+    variables.put("IS_FINISHED",true)
+    if (currentStatus.equals("FINISHED")){
+        synchronizationapi.deleteChannel(channel)
+    }
+} else {
+    // Check if container has been stopped abnormally
+    def isContainerRunning = ["docker", "inspect", "--format", "{{ .State.Running }}", "${instanceName}"].execute().getText().trim().toBoolean()
+    if ((!isContainerRunning) && (!synchronizationapi.get(channel, "FINISH_LAUNCHED")) && (!synchronizationapi.get(channel, "PAUSE_LAUNCHED"))){
+        currentStatus = 'ERROR'
+        println("[ERROR] An internal error occured in docker container: " + instanceName)
+        // Update docker container is not running
+        def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
+        serviceInstanceData.setInstanceStatus(currentStatus)
+        serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+        // Tell the CRON loop to stop
+        variables.put("IS_FINISHED",true)
+        // Exit with error
+        System.exit(1)
+    } else {
+        // Fetch all logs or only new logs since last fetch time mark
+        def lastTime=variables.get('LAST_TIME_MARKER')
+        def fetchLogsCmd = lastTime ? ["docker", "logs", "--since", lastTime, instanceName] : ["docker", "logs", instanceName]
+        fetchLogsCmd.execute().waitForProcessOutput(System.out, System.err)
+    }
+}
+]]>
+          </code>
+        </script>
+      </scriptExecutable>
+      <controlFlow >
+        <loop target="Loop_Over_Instance_Status">
+          <script>
+            <code language="groovy">
+              <![CDATA[
+// Check if loop task has ordered to finish the loop
+def isFinished = variables.get('IS_FINISHED') as boolean
+loop = isFinished ? false : '*/1 * * * *'
+
+// Set a time marker to fetch logs since this marker.
+variables.put("LAST_TIME_MARKER",new Date().format("yyyy-MM-dd'T'HH:mm:ssXXX"))
+]]>
+            </code>
+          </script>
+        </loop>
+      </controlFlow>
     </task>
   </taskFlow>
 </job>

--- a/MySQL/resources/catalog/Pause_MySQL.xml
+++ b/MySQL/resources/catalog/Pause_MySQL.xml
@@ -3,28 +3,28 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="urn:proactive:jobdescriptor:3.10"
      xsi:schemaLocation="urn:proactive:jobdescriptor:3.10 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.10/schedulerjob.xsd"
-    name="Stop_MongoDB" projectName="Cloud Automation - Lifecycle"
+    name="Pause_MySQL" projectName="Cloud Automation - Lifecycle"
     priority="normal"
     onTaskError="continueJobExecution"
      maxNumberOfExecution="2">
   <description>
-    <![CDATA[ Stop MongoDB instance. ]]>
+    <![CDATA[ Pause MySQL instance. ]]>
   </description>
   <genericInformation>
     <info name="bucketName" value="cloud-automation"/>
-    <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/mongodb.png"/>
-    <info name="pca.states" value="(RUNNING,STOPPED)"/>
+    <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/mysql.png"/>
+    <info name="pca.states" value="(RUNNING,PAUSED)"/>
     <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
-    <info name="pca.service.id" value="MongoDB"/>
+    <info name="pca.service.id" value="MySQL"/>
     <info name="group" value="public-objects"/>
   </genericInformation>
   <taskFlow>
-    <task name="Stop_MongoDB">
+    <task name="Pause_MySQL">
       <description>
-        <![CDATA[ Stop MongoDB instance ]]>
+        <![CDATA[ Pause MySQL instance ]]>
       </description>
       <genericInformation>
-        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/mongodb.png"/>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/mysql.png"/>
         <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
       </genericInformation>
       <inputFiles>
@@ -40,15 +40,17 @@
           <code language="groovy">
             <![CDATA[
 /*********************************************************************************
-* THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS STOPPED                   *
+* THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS PAUSED                   *
 *********************************************************************************/
 
+println("BEGIN " + variables.get("PA_TASK_NAME"))
+
 // Acquire service instance id and instance name from synchro channel
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def channel = "Service_Instance_" + instanceId
 
-// Inform other platforms that service is being stopped through Synchronization API
-synchronizationapi.put(channel, "STOP_LAUNCHED", true)
+// Inform other platforms that service is being paused through Synchronization API
+synchronizationapi.put(channel, "PAUSE_LAUNCHED", true)
 ]]>
           </code>
         </script>
@@ -57,8 +59,6 @@ synchronizationapi.put(channel, "STOP_LAUNCHED", true)
         <script>
           <code language="bash">
             <![CDATA[
-echo --- BEGIN "$variables_PA_TASK_NAME" ---
-
 echo Stopping docker container: "$variables_INSTANCE_NAME"
 INSTANCE_NAME=$(docker stop $variables_INSTANCE_NAME 2>&1)
 echo $INSTANCE_NAME > $variables_INSTANCE_NAME"_status"
@@ -71,7 +71,7 @@ echo $INSTANCE_NAME > $variables_INSTANCE_NAME"_status"
           <code language="groovy">
             <![CDATA[
 /*********************************************************************************
-* THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS STOPPED                   *
+* THIS POSTSCRIPT INFORMS PLATFORM THAT PCA SERVICE IS PAUSED                   *
 *********************************************************************************/
 
 import org.ow2.proactive.pca.service.client.ApiClient
@@ -80,22 +80,18 @@ import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
 
 def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
 def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
-
-// Acquire service instance id and instance name from synchro channel
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def instanceName = variables.get("INSTANCE_NAME")
 
 // Connect to Cloud Automation API
-def apiClient = new ApiClient()
-apiClient.setBasePath(pcaUrl)
-def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
+def serviceInstanceRestApi = new ServiceInstanceRestApi(new ApiClient().setBasePath(pcaUrl))
 
 // Update service instance data : (status, endpoint)
-def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
 def status = new File(instanceName+"_status").text.trim()
-def currentStatus = (!status.equals(instanceName)) ? "ERROR" : "STOPPED"
+def currentStatus = (!status.equals(instanceName)) ? "ERROR" : "PAUSED"
+def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
 serviceInstanceData.setInstanceStatus(currentStatus)
-serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
 
 // Print warning or error messages and force job to exit with error if there are any.
 if (!status.equals(instanceName)){

--- a/MySQL/resources/catalog/Resume_MySQL.xml
+++ b/MySQL/resources/catalog/Resume_MySQL.xml
@@ -13,7 +13,7 @@
   <genericInformation>
     <info name="bucketName" value="cloud-automation"/>
     <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/mysql.png"/>
-    <info name="pca.states" value="(STOPPED,RUNNING)(RUNNING,RUNNING)"/>
+    <info name="pca.states" value="(PAUSED,RUNNING)(RUNNING,RUNNING)"/>
     <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
     <info name="pca.service.id" value="MySQL"/>
     <info name="group" value="public-objects"/>
@@ -43,13 +43,16 @@
 * THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS BEING RESUMED              *
 *********************************************************************************/
 
+println("BEGIN " + variables.get("PA_TASK_NAME"))
+
 // Acquire service instance id and instance name from synchro channel
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def channel = "Service_Instance_" + instanceId
 
 // Inform other platforms that service is running through Synchronization API
 synchronizationapi.put(channel, "RUNNING", true)
-synchronizationapi.put(channel, "STOP_LAUNCHED", false)
+synchronizationapi.put(channel, "RESUMED", true)
+synchronizationapi.put(channel, "PAUSE_LAUNCHED", false)
 ]]>
           </code>
         </script>
@@ -58,8 +61,6 @@ synchronizationapi.put(channel, "STOP_LAUNCHED", false)
         <script>
           <code language="bash">
             <![CDATA[
-echo BEGIN  "$variables_PA_TASK_NAME"
-
 INSTANCE_NAME=$variables_INSTANCE_NAME
 
 if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
@@ -73,7 +74,7 @@ if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
         INSTANCE_STATUS=$(docker start $INSTANCE_NAME 2>&1)
         echo $INSTANCE_STATUS > $INSTANCE_NAME"_status"
 	fi
-else 
+else
     echo Error: No such container: "$INSTANCE_NAME" > $INSTANCE_NAME"_status"
 fi
 ]]>
@@ -85,7 +86,7 @@ fi
           <code language="groovy">
             <![CDATA[
 /*********************************************************************************
-* THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS RESUMED                   *
+* THIS POSTSCRIPT INFORMS PLATFORM THAT PCA SERVICE IS RESUMED                   *
 *********************************************************************************/
 
 import org.ow2.proactive.pca.service.client.ApiClient
@@ -93,9 +94,9 @@ import org.ow2.proactive.pca.service.client.api.ServiceInstanceRestApi
 import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
 
 // Acquire service instance id
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def instanceName = variables.get("INSTANCE_NAME")
-    
+
 def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
 def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
 
@@ -123,7 +124,11 @@ println("END " + variables.get("PA_TASK_NAME"))
         </script>
       </post>
     </task>
-    <task name="Loop_Over_Instance_Status">
+    <task name="Loop_Over_Instance_Status" >
+      <description>
+        <![CDATA[ Loop over service instance status and fetch docker container logs.
+It will run every minute. ]]>
+      </description>
       <genericInformation>
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/mysql.png"/>
         <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
@@ -147,55 +152,61 @@ import org.ow2.proactive.pca.service.client.ApiClient
 import org.ow2.proactive.pca.service.client.api.ServiceInstanceRestApi
 import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
 
-println("BEGIN " + variables.get("PA_TASK_NAME"))
-
 def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
 def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def instanceName = variables.get("INSTANCE_NAME")
+def channel = "Service_Instance_" + instanceId
 
 // Connect to Cloud Automation API
-def apiClient = new ApiClient()
-apiClient.setBasePath(pcaUrl)
-def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
+def serviceInstanceRestApi = new ServiceInstanceRestApi(new ApiClient().setBasePath(pcaUrl))
 
-// Inform other platforms that other actions are canceled through Synchronization API
-def channel = "Service_Instance_" + instanceId
-synchronizationapi.put(channel, "DELETE_LAUNCHED", false)
-synchronizationapi.put(channel, "DELETE_INSTANCE", false)
-
-// Loop over service instance status
-def currentStatus = "RUNNING"
-
-while(currentStatus=="RUNNING") {
-    sleep(10000);
-    // Check docker container status
-    def ByteArrayOutputStream sout = new ByteArrayOutputStream();
-    def ByteArrayOutputStream serr = new ByteArrayOutputStream();
-    def proc = ["docker", "inspect", "--format", "{{ .State.Running }}", "${instanceName}"].execute().waitForProcessOutput(sout, serr)
-    def isContainerRunning = new String(sout.toByteArray()).trim().toBoolean()
-
-    if ((!isContainerRunning) && (!synchronizationapi.get(channel, "DELETE_LAUNCHED")) && (!synchronizationapi.get(channel, "STOP_LAUNCHED"))){
+// If service instance is FINISHED or PAUSED then stop this loop and job and delete the sync channel
+def currentStatus = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId).getInstanceStatus()
+if (currentStatus.equals("FINISHED") || currentStatus.equals("PAUSED")){
+    variables.put("IS_FINISHED",true)
+    synchronizationapi.deleteChannel(channel)
+} else {
+    // Check if container has been stopped abnormally
+    def isContainerRunning = ["docker", "inspect", "--format", "{{ .State.Running }}", "${instanceName}"].execute().getText().trim().toBoolean()
+    if ((!isContainerRunning) && (!synchronizationapi.get(channel, "FINISH_LAUNCHED")) && (!synchronizationapi.get(channel, "PAUSE_LAUNCHED"))){
         currentStatus = 'ERROR'
         println("[ERROR] An internal error occured in docker container: " + instanceName)
         // Update docker container is not running
         def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
         serviceInstanceData.setInstanceStatus(currentStatus)
-        serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
-        break
+        serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+        // Tell the CRON loop to stop
+        variables.put("IS_FINISHED",true)
+        // Exit with error
+        System.exit(1)
+    } else {
+        // Fetch all logs or only new logs since last fetch time mark
+        def lastTime=variables.get('LAST_TIME_MARKER')
+        def fetchLogsCmd = lastTime ? ["docker", "logs", "--since", lastTime, instanceName] : ["docker", "logs", instanceName]
+        fetchLogsCmd.execute().waitForProcessOutput(System.out, System.err)
     }
-    // Check service instance status
-    currentStatus = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId).getInstanceStatus()
 }
-
-// Allow the Delete workflow to be fulfilled
-synchronizationapi.put(channel, "DELETE_INSTANCE", true)
-
-println("END " + variables.get("PA_TASK_NAME"))
 ]]>
           </code>
         </script>
       </scriptExecutable>
+      <controlFlow >
+        <loop target="Loop_Over_Instance_Status">
+          <script>
+            <code language="groovy">
+              <![CDATA[
+// Check if loop task has ordered to finish the loop
+def isFinished = variables.get('IS_FINISHED') as boolean
+loop = isFinished ? false : '*/1 * * * *'
+
+// Set a time marker to fetch logs since this marker.
+variables.put("LAST_TIME_MARKER",new Date().format("yyyy-MM-dd'T'HH:mm:ssXXX"))
+]]>
+            </code>
+          </script>
+        </loop>
+      </controlFlow>
     </task>
   </taskFlow>
 </job>

--- a/PostgreSQL/METADATA.json
+++ b/PostgreSQL/METADATA.json
@@ -30,13 +30,13 @@
 				"file" : "resources/catalog/Finish_PostgreSQL.xml"
 			},
       {
-        "name" : "Stop_PostgreSQL",
+        "name" : "Pause_PostgreSQL",
         "metadata" : {
           "kind": "Workflow/pca",
           "commitMessage": "First commit",
           "contentType": "application/xml"
         },
-        "file" : "resources/catalog/Stop_PostgreSQL.xml"
+        "file" : "resources/catalog/Pause_PostgreSQL.xml"
       }
 		]
 	}

--- a/PostgreSQL/resources/catalog/Finish_PostgreSQL.xml
+++ b/PostgreSQL/resources/catalog/Finish_PostgreSQL.xml
@@ -13,7 +13,7 @@
   <genericInformation>
     <info name="bucketName" value="cloud-automation"/>
     <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/postgresql.png"/>
-    <info name="pca.states" value="(RUNNING,FINISHED)(STOPPED,FINISHED)(ERROR,FINISHED)"/>
+    <info name="pca.states" value="(RUNNING,FINISHED)(PAUSED,FINISHED)(ERROR,FINISHED)"/>
     <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
     <info name="pca.service.id" value="PostgreSQL"/>
     <info name="group" value="public-objects"/>
@@ -43,14 +43,16 @@
 * THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS BEING FINISHED             *
 *********************************************************************************/
 
+println("BEGIN " + variables.get("PA_TASK_NAME"))
+
 // Acquire service instance id and instance name from synchro channel
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def channel = "Service_Instance_" + instanceId
 def instanceName = synchronizationapi.get(channel, "INSTANCE_NAME")
 variables.put("INSTANCE_NAME", instanceName)
 
 // Inform other platforms that service is being finished through Synchronization API
-synchronizationapi.put(channel, "DELETE_LAUNCHED", true)
+synchronizationapi.put(channel, "FINISH_LAUNCHED", true)
 ]]>
           </code>
         </script>
@@ -59,8 +61,6 @@ synchronizationapi.put(channel, "DELETE_LAUNCHED", true)
         <script>
           <code language="bash">
             <![CDATA[
-echo --- BEGIN  "$variables_PA_TASK_NAME"  ---
-
 echo Removing docker container: "$variables_INSTANCE_NAME"
 INSTANCE_NAME=$(docker rm -f $variables_INSTANCE_NAME 2>&1)
 echo $INSTANCE_NAME > $variables_INSTANCE_NAME"_status"
@@ -82,27 +82,24 @@ import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
 
 def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
 def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def instanceName = variables.get("INSTANCE_NAME")
-    
+
 def ALREADY_REMOVED_MESSAGE = "Error: No such container: " + instanceName
 
 // Connect to Cloud Automation API
-def apiClient = new ApiClient()
-apiClient.setBasePath(pcaUrl)
-def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
+def serviceInstanceRestApi = new ServiceInstanceRestApi(new ApiClient().setBasePath(pcaUrl))
 
 // Update service instance data : (status, endpoint)
-def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
 def status = new File(instanceName+"_status").text.trim()
 def currentStatus = (!status.equals(ALREADY_REMOVED_MESSAGE) && !status.equals(instanceName)) ? "ERROR" : "FINISHED"
+def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
 serviceInstanceData.setInstanceStatus(currentStatus)
-serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
 
-// Delete synchro channel
+// Inform other jobs that the service is finished and deleted.
 def channel = "Service_Instance_" + instanceId
-synchronizationapi.waitUntil(channel, "DELETE_INSTANCE", "{k,x -> x == true}")
-synchronizationapi.deleteChannel(channel)
+synchronizationapi.put(channel, "FINISH_DONE", true)
 
 // Print warning or error messages and force job to exit with error if there are any.
 if (status.equals(ALREADY_REMOVED_MESSAGE)){

--- a/PostgreSQL/resources/catalog/Pause_PostgreSQL.xml
+++ b/PostgreSQL/resources/catalog/Pause_PostgreSQL.xml
@@ -3,29 +3,29 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="urn:proactive:jobdescriptor:3.10"
      xsi:schemaLocation="urn:proactive:jobdescriptor:3.10 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.10/schedulerjob.xsd"
-    name="Stop_MySQL" projectName="Cloud Automation - Lifecycle"
+    name="Pause_PostgreSQL" projectName="Cloud Automation - Lifecycle"
     priority="normal"
     onTaskError="continueJobExecution"
      maxNumberOfExecution="2">
   <description>
-    <![CDATA[ Stop MySQL instance. ]]>
+    <![CDATA[ Pause PostgreSQL instance. ]]>
   </description>
   <genericInformation>
     <info name="bucketName" value="cloud-automation"/>
-    <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/mysql.png"/>
-    <info name="pca.states" value="(RUNNING,STOPPED)"/>
+    <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/postgresql.png"/>
+    <info name="pca.states" value="(RUNNING,PAUSED)"/>
     <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
-    <info name="pca.service.id" value="MySQL"/>
+    <info name="pca.service.id" value="PostgreSQL"/>
     <info name="group" value="public-objects"/>
   </genericInformation>
   <taskFlow>
-    <task name="Stop_MySQL">
+    <task name="Pause_PostgreSQL">
       <description>
-        <![CDATA[ Stop MySQL instance ]]>
+        <![CDATA[ Pause PostgreSQL instance ]]>
       </description>
       <genericInformation>
-        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/mysql.png"/>
-        <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/postgresql.png"/>
+        <info name="documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
       </genericInformation>
       <inputFiles>
         <files  includes="cloud-automation-service-client-8.2.0-SNAPSHOT.jar" accessMode="transferFromGlobalSpace"/>
@@ -40,15 +40,17 @@
           <code language="groovy">
             <![CDATA[
 /*********************************************************************************
-* THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS STOPPED                   *
+* THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS PAUSED                   *
 *********************************************************************************/
 
+println("BEGIN " + variables.get("PA_TASK_NAME"))
+
 // Acquire service instance id and instance name from synchro channel
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def channel = "Service_Instance_" + instanceId
 
-// Inform other platforms that service is being stopped through Synchronization API
-synchronizationapi.put(channel, "STOP_LAUNCHED", true)
+// Inform other platforms that service is being paused through Synchronization API
+synchronizationapi.put(channel, "PAUSE_LAUNCHED", true)
 ]]>
           </code>
         </script>
@@ -57,8 +59,6 @@ synchronizationapi.put(channel, "STOP_LAUNCHED", true)
         <script>
           <code language="bash">
             <![CDATA[
-echo --- BEGIN "$variables_PA_TASK_NAME" ---
-
 echo Stopping docker container: "$variables_INSTANCE_NAME"
 INSTANCE_NAME=$(docker stop $variables_INSTANCE_NAME 2>&1)
 echo $INSTANCE_NAME > $variables_INSTANCE_NAME"_status"
@@ -71,7 +71,7 @@ echo $INSTANCE_NAME > $variables_INSTANCE_NAME"_status"
           <code language="groovy">
             <![CDATA[
 /*********************************************************************************
-* THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS STOPPED                   *
+* THIS POSTSCRIPT INFORMS PLATFORM THAT PCA SERVICE IS PAUSED                   *
 *********************************************************************************/
 
 import org.ow2.proactive.pca.service.client.ApiClient
@@ -80,22 +80,18 @@ import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
 
 def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
 def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
-
-// Acquire service instance id and instance name from synchro channel
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def instanceName = variables.get("INSTANCE_NAME")
 
 // Connect to Cloud Automation API
-def apiClient = new ApiClient()
-apiClient.setBasePath(pcaUrl)
-def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
+def serviceInstanceRestApi = new ServiceInstanceRestApi(new ApiClient().setBasePath(pcaUrl))
 
 // Update service instance data : (status, endpoint)
-def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
 def status = new File(instanceName+"_status").text.trim()
-def currentStatus = (!status.equals(instanceName)) ? "ERROR" : "STOPPED"
+def currentStatus = (!status.equals(instanceName)) ? "ERROR" : "PAUSED"
+def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
 serviceInstanceData.setInstanceStatus(currentStatus)
-serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
 
 // Print warning or error messages and force job to exit with error if there are any.
 if (!status.equals(instanceName)){

--- a/PostgreSQL/resources/catalog/PostgreSQL.xml
+++ b/PostgreSQL/resources/catalog/PostgreSQL.xml
@@ -30,7 +30,11 @@ $DATABASE (Optional) : Name of a database to be created on start. ]]>
     <info name="group" value="public-objects"/>
   </genericInformation>
   <taskFlow>
-    <task name="Loop_Over_Instance_Status">
+    <task name="Loop_Over_Instance_Status" >
+      <description>
+        <![CDATA[ Loop over service instance status and fetch docker container logs.
+It will run every minute. ]]>
+      </description>
       <genericInformation>
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/postgresql.png"/>
         <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
@@ -54,65 +58,67 @@ import org.ow2.proactive.pca.service.client.ApiClient
 import org.ow2.proactive.pca.service.client.api.ServiceInstanceRestApi
 import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
 
-println("BEGIN " + variables.get("PA_TASK_NAME"))
-
 def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
 def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def instanceName = variables.get("INSTANCE_NAME")
-
-println("INSTANCE_NAME="+instanceName)
+def channel = "Service_Instance_" + instanceId
 
 // Connect to Cloud Automation API
-def apiClient = new ApiClient()
-apiClient.setBasePath(pcaUrl)
-def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
+def serviceInstanceRestApi = new ServiceInstanceRestApi(new ApiClient().setBasePath(pcaUrl))
 
-// Inform other platforms that other actions are canceled through Synchronization API
-def channel = "Service_Instance_" + instanceId
-synchronizationapi.put(channel, "DELETE_LAUNCHED", false)
-synchronizationapi.put(channel, "DELETE_INSTANCE", false)
-
-// Loop over service instance status
-def currentStatus = "RUNNING"
-def exitWithError = false
-while(currentStatus=="RUNNING") {
-    sleep(10000);
-    // Check docker container status
-    def ByteArrayOutputStream sout = new ByteArrayOutputStream();
-    def ByteArrayOutputStream serr = new ByteArrayOutputStream();
-    def proc = ["docker", "inspect", "--format", "{{ .State.Running }}", "${instanceName}"].execute().waitForProcessOutput(sout, serr)
-    def isContainerRunning = new String(sout.toByteArray()).trim().toBoolean()
-
-    if ((!isContainerRunning) && (!synchronizationapi.get(channel, "DELETE_LAUNCHED")) && (!synchronizationapi.get(channel, "STOP_LAUNCHED"))){
+// If service instance is FINISHED or PAUSED then stop this loop and job and delete the sync channel
+def currentStatus = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId).getInstanceStatus()
+if (currentStatus.equals("FINISHED") || currentStatus.equals("PAUSED") || synchronizationapi.get(channel, "RESUMED")){
+    variables.put("IS_FINISHED",true)
+    if (currentStatus.equals("FINISHED")){
+        synchronizationapi.deleteChannel(channel)
+    }
+} else {
+    // Check if container has been stopped abnormally
+    def isContainerRunning = ["docker", "inspect", "--format", "{{ .State.Running }}", "${instanceName}"].execute().getText().trim().toBoolean()
+    if ((!isContainerRunning) && (!synchronizationapi.get(channel, "FINISH_LAUNCHED")) && (!synchronizationapi.get(channel, "PAUSE_LAUNCHED"))){
         currentStatus = 'ERROR'
-        exitWithError = true
         println("[ERROR] An internal error occured in docker container: " + instanceName)
         // Update docker container is not running
         def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
         serviceInstanceData.setInstanceStatus(currentStatus)
-        serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
-        break
+        serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+        // Tell the CRON loop to stop
+        variables.put("IS_FINISHED",true)
+        // Exit with error
+        System.exit(1)
+    } else {
+        // Fetch all logs or only new logs since last fetch time mark
+        def lastTime=variables.get('LAST_TIME_MARKER')
+        def fetchLogsCmd = lastTime ? ["docker", "logs", "--since", lastTime, instanceName] : ["docker", "logs", instanceName]
+        fetchLogsCmd.execute().waitForProcessOutput(System.out, System.err)
     }
-    // Check service instance status
-    currentStatus = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId).getInstanceStatus()
 }
-
-// Allow the Delete workflow to be fulfilled
-synchronizationapi.put(channel, "DELETE_INSTANCE", true)
-if (exitWithError){
-    System.exit(1)
-}
-println("END " + variables.get("PA_TASK_NAME"))
 ]]>
           </code>
         </script>
       </scriptExecutable>
+      <controlFlow >
+        <loop target="Loop_Over_Instance_Status">
+          <script>
+            <code language="groovy">
+              <![CDATA[
+// Check if loop task has ordered to finish the loop
+def isFinished = variables.get('IS_FINISHED') as boolean
+loop = isFinished ? false : '*/1 * * * *'
+
+// Set a time marker to fetch logs since this marker.
+variables.put("LAST_TIME_MARKER",new Date().format("yyyy-MM-dd'T'HH:mm:ssXXX"))
+]]>
+            </code>
+          </script>
+        </loop>
+      </controlFlow>
     </task>
     <task name="Start_PostgreSQL"
-    
-    
-    onTaskError="cancelJob" >
+
+          onTaskError="cancelJob" >
       <description>
         <![CDATA[ Pull PostgreSQL image and start a container ]]>
       </description>
@@ -200,7 +206,7 @@ else
         docker run --name "$INSTANCE_NAME" -p "$PORT" -e POSTGRES_USER="$USER" -e POSTGRES_PASSWORD="$PASSWORD" -d "$DOCKER_IMAGE" -c 'listen_addresses=0.0.0.0'
     elif [ "$DATABASE" != null ] && [ "$USER" == null ]; then
         docker run --name "$INSTANCE_NAME" -p "$PORT" -e POSTGRES_DATABASE="$DATABASE" -d "$DOCKER_IMAGE" -c 'listen_addresses=0.0.0.0'
-    else 
+    else
         docker run --name "$INSTANCE_NAME" -p "$PORT" -e POSTGRES_USER="$USER" -e POSTGRES_PASSWORD="$PASSWORD" -e POSTGRES_DB="$DATABASE" -d "$DOCKER_IMAGE" -c 'listen_addresses=0.0.0.0'
     fi
     if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
@@ -238,7 +244,7 @@ import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
 def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
 def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
 // Acquire service instance id and instance name
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def instanceName = variables.get("INSTANCE_NAME")
 
 def hostname = new URL(paSchedulerRestUrl).getHost()

--- a/PostgreSQL/resources/catalog/Resume_PostgreSQL.xml
+++ b/PostgreSQL/resources/catalog/Resume_PostgreSQL.xml
@@ -13,18 +13,116 @@
   <genericInformation>
     <info name="bucketName" value="cloud-automation"/>
     <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/postgresql.png"/>
-    <info name="pca.states" value="(STOPPED,RUNNING)(RUNNING,RUNNING)"/>
+    <info name="pca.states" value="(PAUSED,RUNNING)(RUNNING,RUNNING)"/>
     <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
     <info name="pca.service.id" value="PostgreSQL"/>
     <info name="group" value="public-objects"/>
   </genericInformation>
   <taskFlow>
-    <task name="Resume_PostgreSQL"
-    
-    
-    onTaskError="cancelJob" >
+    <task name="Loop_Over_Instance_Status" >
       <description>
-        <![CDATA[ Resume PostgreSQL instance ]]>
+        <![CDATA[ Loop over service instance status and fetch docker container logs.
+It will run every minute. ]]>
+      </description>
+      <genericInformation>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/postgresql.png"/>
+        <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+      </genericInformation>
+      <depends>
+        <task ref="Resume_PostgreSQL"/>
+      </depends>
+      <inputFiles>
+        <files  includes="cloud-automation-service-client-8.2.0-SNAPSHOT.jar" accessMode="transferFromGlobalSpace"/>
+      </inputFiles>
+      <forkEnvironment >
+        <additionalClasspath>
+          <pathElement path="cloud-automation-service-client-8.2.0-SNAPSHOT.jar"/>
+        </additionalClasspath>
+      </forkEnvironment>
+      <scriptExecutable>
+        <script>
+          <code language="groovy">
+            <![CDATA[
+import org.ow2.proactive.pca.service.client.ApiClient
+import org.ow2.proactive.pca.service.client.api.ServiceInstanceRestApi
+import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
+
+def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
+def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
+def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceName = variables.get("INSTANCE_NAME")
+
+// Connect to Cloud Automation API
+def apiClient = new ApiClient()
+apiClient.setBasePath(pcaUrl)
+def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
+
+// Inform other platforms that other actions are canceled through Synchronization API
+def channel = "Service_Instance_" + instanceId
+
+// Check docker container status
+def ByteArrayOutputStream sout = new ByteArrayOutputStream();
+def ByteArrayOutputStream serr = new ByteArrayOutputStream();
+def proc = ["docker", "inspect", "--format", "{{ .State.Running }}", "${instanceName}"].execute().waitForProcessOutput(sout, serr)
+def isContainerRunning = new String(sout.toByteArray()).trim().toBoolean()
+
+if ((!isContainerRunning) && (!synchronizationapi.get(channel, "DELETE_LAUNCHED")) && (!synchronizationapi.get(channel, "STOP_LAUNCHED"))){
+    currentStatus = 'ERROR'
+    println("[ERROR] An internal error occured in docker container: " + instanceName)
+    // Update docker container is not running
+    def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
+    serviceInstanceData.setInstanceStatus(currentStatus)
+    serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+    // Tell the CRON loop to stop
+    variables.put("IS_FINISHED",true)
+    // Exit with error
+    System.exit(1)
+} else {
+    def lastTime=variables.get('LAST_TIME_MARK')
+    // Fetch new logs since last fetch time mark.
+    def fetchLogsCmd = ["docker", "logs", "--since", lastTime, instanceName]
+    if(!lastTime){
+        // Fetch all logs from docker container
+        fetchLogsCmd = ["docker", "logs", instanceName]
+    }
+    fetchLogsCmd.execute().consumeProcessOutput(System.out, System.err)
+}
+
+// Check service instance status
+def currentStatus = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId).getInstanceStatus()
+if(!currentStatus.equals("RUNNING")){
+    // Allow the Delete workflow to be fulfilled
+    synchronizationapi.put(channel, "DELETE_INSTANCE", true)
+    // Tell the CRON loop to stop
+    variables.put("IS_FINISHED",true)
+}
+]]>
+          </code>
+        </script>
+      </scriptExecutable>
+      <controlFlow >
+        <loop target="Loop_Over_Instance_Status">
+          <script>
+            <code language="groovy">
+              <![CDATA[
+def isFinished = variables.get('IS_FINISHED') as boolean
+if(!isFinished){
+    variables.put("LAST_TIME_MARK",new Date().format("yyyy-MM-dd'T'HH:mm:ssXXX"))
+	loop = '*/1 * * * *'
+} else{
+    loop = false
+}
+]]>
+            </code>
+          </script>
+        </loop>
+      </controlFlow>
+    </task>
+    <task name="Resume_PostgreSQL"
+
+          onTaskError="cancelJob" >
+      <description>
+        <![CDATA[ Pull PostgreSQL image and start a container ]]>
       </description>
       <genericInformation>
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/postgresql.png"/>
@@ -46,15 +144,16 @@
 * THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS BEING RESUMED              *
 *********************************************************************************/
 
-// Acquire service instance id from synchro channel
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+println("BEGIN " + variables.get("PA_TASK_NAME"))
+
+// Acquire service instance id and instance name from synchro channel
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def channel = "Service_Instance_" + instanceId
-def instanceName = synchronizationapi.get(channel, "INSTANCE_NAME")
-variables.put("INSTANCE_NAME", instanceName)
 
 // Inform other platforms that service is running through Synchronization API
 synchronizationapi.put(channel, "RUNNING", true)
-synchronizationapi.put(channel, "STOP_LAUNCHED", false)
+synchronizationapi.put(channel, "RESUMED", true)
+synchronizationapi.put(channel, "PAUSE_LAUNCHED", false)
 ]]>
           </code>
         </script>
@@ -63,8 +162,6 @@ synchronizationapi.put(channel, "STOP_LAUNCHED", false)
         <script>
           <code language="bash">
             <![CDATA[
-echo BEGIN  "$variables_PA_TASK_NAME"
-
 INSTANCE_NAME=$variables_INSTANCE_NAME
 
 if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
@@ -78,7 +175,7 @@ if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
         INSTANCE_STATUS=$(docker start $INSTANCE_NAME 2>&1)
         echo $INSTANCE_STATUS > $INSTANCE_NAME"_status"
 	fi
-else 
+else
     echo Error: No such container: "$INSTANCE_NAME" > $INSTANCE_NAME"_status"
 fi
 ]]>
@@ -90,7 +187,7 @@ fi
           <code language="groovy">
             <![CDATA[
 /*********************************************************************************
-* THIS PRESCRIPT INFORMS PLATFORM THAT PCA SERVICE IS RESUMED                   *
+* THIS POSTSCRIPT INFORMS PLATFORM THAT PCA SERVICE IS RESUMED                   *
 *********************************************************************************/
 
 import org.ow2.proactive.pca.service.client.ApiClient
@@ -98,9 +195,9 @@ import org.ow2.proactive.pca.service.client.api.ServiceInstanceRestApi
 import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
 
 // Acquire service instance id
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def instanceName = variables.get("INSTANCE_NAME")
-    
+
 def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
 def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
 
@@ -127,80 +224,6 @@ println("END " + variables.get("PA_TASK_NAME"))
           </code>
         </script>
       </post>
-    </task>
-    <task name="Loop_Over_Instance_Status">
-      <genericInformation>
-        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/postgresql.png"/>
-        <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
-      </genericInformation>
-      <depends>
-        <task ref="Resume_PostgreSQL"/>
-      </depends>
-      <inputFiles>
-        <files  includes="cloud-automation-service-client-8.2.0-SNAPSHOT.jar" accessMode="transferFromGlobalSpace"/>
-      </inputFiles>
-      <forkEnvironment >
-        <additionalClasspath>
-          <pathElement path="cloud-automation-service-client-8.2.0-SNAPSHOT.jar"/>
-        </additionalClasspath>
-      </forkEnvironment>
-      <scriptExecutable>
-        <script>
-          <code language="groovy">
-            <![CDATA[
-import org.ow2.proactive.pca.service.client.ApiClient
-import org.ow2.proactive.pca.service.client.api.ServiceInstanceRestApi
-import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
-
-println("BEGIN " + variables.get("PA_TASK_NAME"))
-
-def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
-def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
-def instanceName = variables.get("INSTANCE_NAME")
-
-// Connect to Cloud Automation API
-def apiClient = new ApiClient()
-apiClient.setBasePath(pcaUrl)
-def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
-
-// Inform other platforms that other actions are canceled through Synchronization API
-def channel = "Service_Instance_" + instanceId
-synchronizationapi.put(channel, "DELETE_LAUNCHED", false)
-synchronizationapi.put(channel, "DELETE_INSTANCE", false)
-
-// Loop over service instance status
-def currentStatus = "RUNNING"
-
-while(currentStatus=="RUNNING") {
-    sleep(10000);
-    // Check docker container status
-    def ByteArrayOutputStream sout = new ByteArrayOutputStream();
-    def ByteArrayOutputStream serr = new ByteArrayOutputStream();
-    def proc = ["docker", "inspect", "--format", "{{ .State.Running }}", "${instanceName}"].execute().waitForProcessOutput(sout, serr)
-    def isContainerRunning = new String(sout.toByteArray()).trim().toBoolean()
-
-    if ((!isContainerRunning) && (!synchronizationapi.get(channel, "DELETE_LAUNCHED")) && (!synchronizationapi.get(channel, "STOP_LAUNCHED"))){
-        currentStatus = 'ERROR'
-        println("[ERROR] An internal error occured in docker container: " + instanceName)
-        // Update docker container is not running
-        def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
-        serviceInstanceData.setInstanceStatus(currentStatus)
-        serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
-        break
-    }
-    // Check service instance status
-    currentStatus = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId).getInstanceStatus()
-}
-
-// Allow the Delete workflow to be fulfilled
-synchronizationapi.put(channel, "DELETE_INSTANCE", true)
-
-println("END " + variables.get("PA_TASK_NAME"))
-]]>
-          </code>
-        </script>
-      </scriptExecutable>
     </task>
   </taskFlow>
 </job>


### PR DESCRIPTION
In this PR, we propose a fix for the collision bug between PCA services that creates a deadlock if all nodes are busy running PCA services. This fix unleashes the load on the available nodes by running PCA updates as cron tasks every 1 minute

We also add a feature that fetches displays docker container logs that the PCA rely on