### PR TITLE
 Use fixed random port for PCA services

### DIFF
--- a/Elasticsearch/resources/catalog/Elasticsearch.xml
+++ b/Elasticsearch/resources/catalog/Elasticsearch.xml
@@ -56,6 +56,16 @@ PORT=9200
 echo "Pulling "$variables_PA_JOB_NAME" image"
 docker pull $DOCKER_IMAGE
 
+GET_RANDOM_PORT(){
+    read LOWERPORT UPPERPORT < /proc/sys/net/ipv4/ip_local_port_range
+    while :
+    do
+        RND_PORT="`shuf -i $LOWERPORT-$UPPERPORT -n 1`"
+        ss -lpn | grep -q ":$PORT " || break
+    done
+    echo $RND_PORT
+}
+
 INSTANCE_NAME=$variables_INSTANCE_NAME
 
 if [ -z "$INSTANCE_NAME" ]; then
@@ -76,7 +86,8 @@ else
     ################################################################################
     ### THIS PART IS IMAGE SPECIFIC. IF YOU NEED TO MODIFY SOMETHING, DO IT HERE ###
     echo "Running $INSTANCE_NAME container"
-    docker run -d --name $INSTANCE_NAME -p $PORT -e "discovery.type=single-node" $DOCKER_IMAGE
+    F_PORT=$(GET_RANDOM_PORT)
+    docker run -d --name $INSTANCE_NAME -p $F_PORT:$PORT -e "discovery.type=single-node" $DOCKER_IMAGE
     ################################################################################
 fi
 

--- a/MongoDB/resources/catalog/MongoDB.xml
+++ b/MongoDB/resources/catalog/MongoDB.xml
@@ -63,6 +63,16 @@ if [ \( ! -z "$USER" -a -z "$PASSWORD" \) -o \( -z "$USER" -a ! -z "$PASSWORD" \
 fi
 ################################################################################
 
+GET_RANDOM_PORT(){
+    read LOWERPORT UPPERPORT < /proc/sys/net/ipv4/ip_local_port_range
+    while :
+    do
+        RND_PORT="`shuf -i $LOWERPORT-$UPPERPORT -n 1`"
+        ss -lpn | grep -q ":$PORT " || break
+    done
+    echo $RND_PORT
+}
+
 echo "Pulling "$variables_PA_JOB_NAME" image"
 docker pull $DOCKER_IMAGE
 
@@ -88,10 +98,11 @@ else
     ################################################################################
     ### THIS PART IS IMAGE SPECIFIC. IF YOU NEED TO MODIFY SOMETHING, DO IT HERE ###
     echo "Running $INSTANCE_NAME container"
+    F_PORT=$(GET_RANDOM_PORT)
     if [ "$USER" == null ]; then
-        INSTANCE_STATUS=$(docker run --name $INSTANCE_NAME -p $PORT -d $DOCKER_IMAGE)
+        INSTANCE_STATUS=$(docker run --name $INSTANCE_NAME -p $F_PORT:$PORT -d $DOCKER_IMAGE)
     else
-        INSTANCE_STATUS=$(docker run --name $INSTANCE_NAME -p $PORT -e MONGO_INITDB_ROOT_USERNAME=$USER -e MONGO_INITDB_ROOT_PASSWORD=$PASSWORD -d $DOCKER_IMAGE)
+        INSTANCE_STATUS=$(docker run --name $INSTANCE_NAME -p $F_PORT:$PORT -e MONGO_INITDB_ROOT_USERNAME=$USER -e MONGO_INITDB_ROOT_PASSWORD=$PASSWORD -d $DOCKER_IMAGE)
     fi
     ################################################################################
     if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then

--- a/PostgreSQL/resources/catalog/Finish_PostgreSQL.xml
+++ b/PostgreSQL/resources/catalog/Finish_PostgreSQL.xml
@@ -8,7 +8,7 @@
     onTaskError="continueJobExecution"
      maxNumberOfExecution="2">
   <description>
-    <![CDATA[ Delete Docker instance. ]]>
+    <![CDATA[ Delete PostgreSQL instance. ]]>
   </description>
   <genericInformation>
     <info name="bucketName" value="cloud-automation"/>

--- a/PostgreSQL/resources/catalog/Pause_PostgreSQL.xml
+++ b/PostgreSQL/resources/catalog/Pause_PostgreSQL.xml
@@ -25,7 +25,7 @@
       </description>
       <genericInformation>
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/postgresql.png"/>
-        <info name="documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+        <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
       </genericInformation>
       <inputFiles>
         <files  includes="cloud-automation-service-client-8.2.0-SNAPSHOT.jar" accessMode="transferFromGlobalSpace"/>

--- a/PostgreSQL/resources/catalog/PostgreSQL.xml
+++ b/PostgreSQL/resources/catalog/PostgreSQL.xml
@@ -116,9 +116,7 @@ variables.put("LAST_TIME_MARKER",new Date().format("yyyy-MM-dd'T'HH:mm:ssXXX"))
         </loop>
       </controlFlow>
     </task>
-    <task name="Start_PostgreSQL"
-
-          onTaskError="cancelJob" >
+    <task name="Start_PostgreSQL" onTaskError="cancelJob" >
       <description>
         <![CDATA[ Pull PostgreSQL image and start a container ]]>
       </description>
@@ -178,6 +176,16 @@ fi
 echo "Pulling "$variables_PA_JOB_NAME" image"
 docker pull $DOCKER_IMAGE
 
+GET_RANDOM_PORT(){
+    read LOWERPORT UPPERPORT < /proc/sys/net/ipv4/ip_local_port_range
+    while :
+    do
+        RND_PORT="`shuf -i $LOWERPORT-$UPPERPORT -n 1`"
+        ss -lpn | grep -q ":$PORT " || break
+    done
+    echo $RND_PORT
+}
+
 INSTANCE_NAME=$variables_INSTANCE_NAME
 
 if [ -z "$INSTANCE_NAME" ]; then
@@ -200,14 +208,15 @@ else
     ################################################################################
     ### THIS PART IS IMAGE SPECIFIC. IF YOU NEED TO MODIFY SOMETHING, DO IT HERE ###
     echo "Running docker container: $INSTANCE_NAME"
+    F_PORT=$(GET_RANDOM_PORT)
     if [ "$DATABASE" == null ] && [ "$USER" == null ]; then
-        docker run --name "$INSTANCE_NAME" -p "$PORT" -e POSTGRES_PASSWORD="$PASSWORD" -d "$DOCKER_IMAGE" -c 'listen_addresses=0.0.0.0'
+        docker run --name "$INSTANCE_NAME" -p $F_PORT:"$PORT" -e POSTGRES_PASSWORD="$PASSWORD" -d "$DOCKER_IMAGE" -c 'listen_addresses=0.0.0.0'
     elif [ "$DATABASE" == null ] && [ "$USER" != null ]; then
-        docker run --name "$INSTANCE_NAME" -p "$PORT" -e POSTGRES_USER="$USER" -e POSTGRES_PASSWORD="$PASSWORD" -d "$DOCKER_IMAGE" -c 'listen_addresses=0.0.0.0'
+        docker run --name "$INSTANCE_NAME" -p $F_PORT:"$PORT" -e POSTGRES_USER="$USER" -e POSTGRES_PASSWORD="$PASSWORD" -d "$DOCKER_IMAGE" -c 'listen_addresses=0.0.0.0'
     elif [ "$DATABASE" != null ] && [ "$USER" == null ]; then
-        docker run --name "$INSTANCE_NAME" -p "$PORT" -e POSTGRES_DATABASE="$DATABASE" -d "$DOCKER_IMAGE" -c 'listen_addresses=0.0.0.0'
+        docker run --name "$INSTANCE_NAME" -p $F_PORT:"$PORT" -e POSTGRES_DATABASE="$DATABASE" -d "$DOCKER_IMAGE" -c 'listen_addresses=0.0.0.0'
     else
-        docker run --name "$INSTANCE_NAME" -p "$PORT" -e POSTGRES_USER="$USER" -e POSTGRES_PASSWORD="$PASSWORD" -e POSTGRES_DB="$DATABASE" -d "$DOCKER_IMAGE" -c 'listen_addresses=0.0.0.0'
+        docker run --name "$INSTANCE_NAME" -p $F_PORT:"$PORT" -e POSTGRES_USER="$USER" -e POSTGRES_PASSWORD="$PASSWORD" -e POSTGRES_DB="$DATABASE" -d "$DOCKER_IMAGE" -c 'listen_addresses=0.0.0.0'
     fi
     if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
         RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)

--- a/PostgreSQL/resources/catalog/Resume_PostgreSQL.xml
+++ b/PostgreSQL/resources/catalog/Resume_PostgreSQL.xml
@@ -49,52 +49,38 @@ import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
 
 def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
 def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
-def instanceId = variables.get("PCA_INSTANCE_ID") as int
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def instanceName = variables.get("INSTANCE_NAME")
-
-// Connect to Cloud Automation API
-def apiClient = new ApiClient()
-apiClient.setBasePath(pcaUrl)
-def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
-
-// Inform other platforms that other actions are canceled through Synchronization API
 def channel = "Service_Instance_" + instanceId
 
-// Check docker container status
-def ByteArrayOutputStream sout = new ByteArrayOutputStream();
-def ByteArrayOutputStream serr = new ByteArrayOutputStream();
-def proc = ["docker", "inspect", "--format", "{{ .State.Running }}", "${instanceName}"].execute().waitForProcessOutput(sout, serr)
-def isContainerRunning = new String(sout.toByteArray()).trim().toBoolean()
+// Connect to Cloud Automation API
+def serviceInstanceRestApi = new ServiceInstanceRestApi(new ApiClient().setBasePath(pcaUrl))
 
-if ((!isContainerRunning) && (!synchronizationapi.get(channel, "DELETE_LAUNCHED")) && (!synchronizationapi.get(channel, "STOP_LAUNCHED"))){
-    currentStatus = 'ERROR'
-    println("[ERROR] An internal error occured in docker container: " + instanceName)
-    // Update docker container is not running
-    def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
-    serviceInstanceData.setInstanceStatus(currentStatus)
-    serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
-    // Tell the CRON loop to stop
-    variables.put("IS_FINISHED",true)
-    // Exit with error
-    System.exit(1)
-} else {
-    def lastTime=variables.get('LAST_TIME_MARK')
-    // Fetch new logs since last fetch time mark.
-    def fetchLogsCmd = ["docker", "logs", "--since", lastTime, instanceName]
-    if(!lastTime){
-        // Fetch all logs from docker container
-        fetchLogsCmd = ["docker", "logs", instanceName]
-    }
-    fetchLogsCmd.execute().consumeProcessOutput(System.out, System.err)
-}
-
-// Check service instance status
+// If service instance is FINISHED or PAUSED then stop this loop and job and delete the sync channel
 def currentStatus = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId).getInstanceStatus()
-if(!currentStatus.equals("RUNNING")){
-    // Allow the Delete workflow to be fulfilled
-    synchronizationapi.put(channel, "DELETE_INSTANCE", true)
-    // Tell the CRON loop to stop
+if (currentStatus.equals("FINISHED") || currentStatus.equals("PAUSED")){
     variables.put("IS_FINISHED",true)
+    synchronizationapi.deleteChannel(channel)
+} else {
+    // Check if container has been stopped abnormally
+    def isContainerRunning = ["docker", "inspect", "--format", "{{ .State.Running }}", "${instanceName}"].execute().getText().trim().toBoolean()
+    if ((!isContainerRunning) && (!synchronizationapi.get(channel, "FINISH_LAUNCHED")) && (!synchronizationapi.get(channel, "PAUSE_LAUNCHED"))){
+        currentStatus = 'ERROR'
+        println("[ERROR] An internal error occured in docker container: " + instanceName)
+        // Update docker container is not running
+        def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
+        serviceInstanceData.setInstanceStatus(currentStatus)
+        serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+        // Tell the CRON loop to stop
+        variables.put("IS_FINISHED",true)
+        // Exit with error
+        System.exit(1)
+    } else {
+        // Fetch all logs or only new logs since last fetch time mark
+        def lastTime=variables.get('LAST_TIME_MARKER')
+        def fetchLogsCmd = lastTime ? ["docker", "logs", "--since", lastTime, instanceName] : ["docker", "logs", instanceName]
+        fetchLogsCmd.execute().waitForProcessOutput(System.out, System.err)
+    }
 }
 ]]>
           </code>


### PR DESCRIPTION
In this PR, we force docker to use a manuallyt-randomly generated free port in order to preserve this port in case of a service restart (Resume after Pause)