### PR TITLE
Apply fixed random docker port per PCA to prevent change upon restart

### DIFF
--- a/Cassandra/resources/catalog/Cassandra.xml
+++ b/Cassandra/resources/catalog/Cassandra.xml
@@ -55,6 +55,17 @@ PORT=9042
 ENV_VARS=$variables_ENV_VARS
 ################################################################################
 
+# Manually find a free random port to preserve it in case if docker (re)start (Pause/Resume)
+GET_RANDOM_PORT(){
+    read LOWERPORT UPPERPORT < /proc/sys/net/ipv4/ip_local_port_range
+    while :
+    do
+        RND_PORT="`shuf -i $LOWERPORT-$UPPERPORT -n 1`"
+        ss -lpn | grep -q ":$PORT " || break
+    done
+    echo $RND_PORT
+}
+
 echo "Pulling "$variables_PA_JOB_NAME" image"
 docker pull $DOCKER_IMAGE
 
@@ -80,10 +91,11 @@ else
     ################################################################################
     ### THIS PART IS IMAGE SPECIFIC. IF YOU NEED TO MODIFY SOMETHING, DO IT HERE ###
     echo "Running $INSTANCE_NAME container"
+    F_PORT=$(GET_RANDOM_PORT)
     if [ -z "$ENV_VARS" ]; then
-        INSTANCE_STATUS=$( eval "docker run --name "$INSTANCE_NAME" -p "$PORT" -d "$DOCKER_IMAGE"" 2>&1)
+        INSTANCE_STATUS=$( eval "docker run --name $INSTANCE_NAME -p $F_PORT:$PORT -d $DOCKER_IMAGE" 2>&1)
     else
-        INSTANCE_STATUS=$( eval "docker run --name "$INSTANCE_NAME" -p "$PORT" "$ENV_VARS" -d "$DOCKER_IMAGE"" 2>&1)
+        INSTANCE_STATUS=$( eval "docker run --name $INSTANCE_NAME -p $F_PORT:$PORT "$ENV_VARS" -d $DOCKER_IMAGE" 2>&1)
     fi
     ################################################################################
     if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then

--- a/Cassandra/resources/catalog/Cassandra.xml
+++ b/Cassandra/resources/catalog/Cassandra.xml
@@ -61,7 +61,7 @@ GET_RANDOM_PORT(){
     while :
     do
         RND_PORT="`shuf -i $LOWERPORT-$UPPERPORT -n 1`"
-        ss -lpn | grep -q ":$PORT " || break
+        ss -lpn | grep -q ":$RND_PORT " || break
     done
     echo $RND_PORT
 }

--- a/Docker/resources/catalog/Docker.xml
+++ b/Docker/resources/catalog/Docker.xml
@@ -90,7 +90,7 @@ GET_RANDOM_PORT(){
     while :
     do
         RND_PORT="`shuf -i $LOWERPORT-$UPPERPORT -n 1`"
-        ss -lpn | grep -q ":$PORT " || break
+        ss -lpn | grep -q ":$RND_PORT " || break
     done
     echo $RND_PORT
 }

--- a/Docker/resources/catalog/Docker.xml
+++ b/Docker/resources/catalog/Docker.xml
@@ -84,6 +84,19 @@ variables.put("INSTANCE_NAME",variables.get("DOCKER_CONTAINER"))
             <![CDATA[
 echo BEGIN "$variables_PA_TASK_NAME"
 
+# Manually find a free random port to preserve it in case if docker (re)start (Pause/Resume)
+GET_RANDOM_PORT(){
+    read LOWERPORT UPPERPORT < /proc/sys/net/ipv4/ip_local_port_range
+    while :
+    do
+        RND_PORT="`shuf -i $LOWERPORT-$UPPERPORT -n 1`"
+        ss -lpn | grep -q ":$PORT " || break
+    done
+    echo $RND_PORT
+}
+
+F_PORT=$(GET_RANDOM_PORT)
+
 ################################################################################
 ### THIS PART IS IMAGE SPECIFIC. IF YOU NEED TO MODIFY SOMETHING, DO IT HERE ###
 DOCKER_IMAGE="$variables_DOCKER_IMAGE"
@@ -132,15 +145,15 @@ else
     ################################################################################
     ### THIS PART IS IMAGE SPECIFIC. IF YOU NEED TO MODIFY SOMETHING, DO IT HERE ###
     echo "Running docker container: $INSTANCE_NAME"
-    echo "docker run --name $INSTANCE_NAME -p "$PORT" "$DOCKER_OPTIONS" -d "$DOCKER_IMAGE" "$DOCKER_COMMAND""
+    echo "docker run --name $INSTANCE_NAME -p $F_PORT:$PORT "$DOCKER_OPTIONS" -d $DOCKER_IMAGE "$DOCKER_COMMAND""
     if [ -z "$DOCKER_OPTIONS" -a -z "$DOCKER_COMMAND" ]; then
-        INSTANCE_STATUS=$( eval "docker run --name "$INSTANCE_NAME" -p "$PORT" -d "$DOCKER_IMAGE"" 2>&1)
+        INSTANCE_STATUS=$( eval "docker run --name $INSTANCE_NAME -p $F_PORT:$PORT -d $DOCKER_IMAGE" 2>&1)
     elif [ ! -z "$DOCKER_OPTIONS" -a -z "$DOCKER_COMMAND" ]; then
-        INSTANCE_STATUS=$(eval "docker run --name "$INSTANCE_NAME" -p "$PORT" "$DOCKER_OPTIONS" -d "$DOCKER_IMAGE"" 2>&1)
+        INSTANCE_STATUS=$(eval "docker run --name $INSTANCE_NAME -p $F_PORT:$PORT "$DOCKER_OPTIONS" -d $DOCKER_IMAGE" 2>&1)
     elif [ -z "$DOCKER_OPTIONS" -a ! -z "$DOCKER_COMMAND" ]; then
-        INSTANCE_STATUS=$(eval "docker run --name "$INSTANCE_NAME" -p "$PORT" -d "$DOCKER_IMAGE" "$DOCKER_COMMAND""  2>&1)
+        INSTANCE_STATUS=$(eval "docker run --name $INSTANCE_NAME -p $F_PORT:$PORT -d $DOCKER_IMAGE "$DOCKER_COMMAND""  2>&1)
     else
-        INSTANCE_STATUS=$(eval "docker run --name "$INSTANCE_NAME" -p "$PORT" "$DOCKER_OPTIONS" -d "$DOCKER_IMAGE" "$DOCKER_COMMAND"" 2>&1)
+        INSTANCE_STATUS=$(eval "docker run --name $INSTANCE_NAME -p $F_PORT:$PORT "$DOCKER_OPTIONS" -d $DOCKER_IMAGE "$DOCKER_COMMAND"" 2>&1)
     fi
     if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
         RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)

--- a/Docker/resources/catalog/Pause_Docker.xml
+++ b/Docker/resources/catalog/Pause_Docker.xml
@@ -48,6 +48,8 @@ println("BEGIN " + variables.get("PA_TASK_NAME"))
 // Acquire service instance id and instance name from synchro channel
 def instanceId = variables.get("PCA_INSTANCE_ID") as long
 def channel = "Service_Instance_" + instanceId
+def instanceName = synchronizationapi.get(channel, "INSTANCE_NAME")
+variables.put("INSTANCE_NAME", instanceName)
 
 // Inform other platforms that service is being paused through Synchronization API
 synchronizationapi.put(channel, "PAUSE_LAUNCHED", true)
@@ -59,8 +61,6 @@ synchronizationapi.put(channel, "PAUSE_LAUNCHED", true)
         <script>
           <code language="bash">
             <![CDATA[
-echo --- BEGIN "$variables_PA_TASK_NAME" ---
-
 echo Stopping docker container: "$variables_INSTANCE_NAME"
 INSTANCE_NAME=$(docker stop $variables_INSTANCE_NAME 2>&1)
 echo $INSTANCE_NAME > $variables_INSTANCE_NAME"_status"

--- a/Elasticsearch/resources/catalog/Elasticsearch.xml
+++ b/Elasticsearch/resources/catalog/Elasticsearch.xml
@@ -61,7 +61,7 @@ GET_RANDOM_PORT(){
     while :
     do
         RND_PORT="`shuf -i $LOWERPORT-$UPPERPORT -n 1`"
-        ss -lpn | grep -q ":$PORT " || break
+        ss -lpn | grep -q ":$RND_PORT " || break
     done
     echo $RND_PORT
 }

--- a/MongoDB/resources/catalog/MongoDB.xml
+++ b/MongoDB/resources/catalog/MongoDB.xml
@@ -15,9 +15,9 @@
   <description>
     <![CDATA[ Deploy a MongoDB Database server.
 The service can be started using the following variables:
-$MONGODB_INSTANCE_NAME (Required): service instance name
-$MONGODB_USER (Optional): Username for the root user.
-$MONGODB_PASSWORD (Optional): Password for the root user. ]]>
+$INSTANCE_NAME (Required): service instance name
+$USER (Optional): Username for the root user.
+$PASSWORD (Optional): Password for the root user. ]]>
   </description>
   <genericInformation>
     <info name="bucketName" value="cloud-automation"/>

--- a/MongoDB/resources/catalog/MongoDB.xml
+++ b/MongoDB/resources/catalog/MongoDB.xml
@@ -68,7 +68,7 @@ GET_RANDOM_PORT(){
     while :
     do
         RND_PORT="`shuf -i $LOWERPORT-$UPPERPORT -n 1`"
-        ss -lpn | grep -q ":$PORT " || break
+        ss -lpn | grep -q ":$RND_PORT " || break
     done
     echo $RND_PORT
 }

--- a/MySQL/resources/catalog/MySQL.xml
+++ b/MySQL/resources/catalog/MySQL.xml
@@ -52,6 +52,19 @@ $PASSWORD (Optional): Password for the root user. ]]>
             <![CDATA[
 echo BEGIN "$variables_PA_TASK_NAME"
 
+# Manually find a free random port to preserve it in case if docker (re)start (Pause/Resume)
+GET_RANDOM_PORT(){
+    read LOWERPORT UPPERPORT < /proc/sys/net/ipv4/ip_local_port_range
+    while :
+    do
+        RND_PORT="`shuf -i $LOWERPORT-$UPPERPORT -n 1`"
+        ss -lpn | grep -q ":$PORT " || break
+    done
+    echo $RND_PORT
+}
+
+F_PORT=$(GET_RANDOM_PORT)
+
 ################################################################################
 ### THIS PART IS IMAGE SPECIFIC. IF YOU NEED TO MODIFY SOMETHING, DO IT HERE ###
 DOCKER_IMAGE=activeeon/mysql
@@ -93,13 +106,13 @@ else
     ### THIS PART IS IMAGE SPECIFIC. IF YOU NEED TO MODIFY SOMETHING, DO IT HERE ###
     echo "Running $INSTANCE_NAME container"
     if [ "$DATABASE" == null ] && [ "$USER" == null ]; then
-        INSTANCE_STATUS=$(docker run --name "$INSTANCE_NAME" -p $PORT -e MYSQL_ROOT_PASSWORD="$ROOT_PASSWORD" -d "$DOCKER_IMAGE")
+        INSTANCE_STATUS=$(docker run --name "$INSTANCE_NAME" -p $F_PORT:$PORT -e MYSQL_ROOT_PASSWORD="$ROOT_PASSWORD" -d "$DOCKER_IMAGE")
     elif [ "$DATABASE" == null ] && [ "$USER" != null ]; then
-        INSTANCE_STATUS=$(docker run --name "$INSTANCE_NAME" -p $PORT -e MYSQL_ROOT_PASSWORD="$ROOT_PASSWORD" -e MYSQL_USER="$USER" -e MYSQL_PASSWORD=$PASSWORD -d "$DOCKER_IMAGE")
+        INSTANCE_STATUS=$(docker run --name "$INSTANCE_NAME" -p $F_PORT:$PORT -e MYSQL_ROOT_PASSWORD="$ROOT_PASSWORD" -e MYSQL_USER="$USER" -e MYSQL_PASSWORD=$PASSWORD -d "$DOCKER_IMAGE")
     elif [ "$DATABASE" != null ] && [ "$USER" == null ]; then
-        INSTANCE_STATUS=$(docker run --name "$INSTANCE_NAME" -p $PORT -e MYSQL_ROOT_PASSWORD="$ROOT_PASSWORD" -e MYSQL_DATABASE="$DATABASE" -d "$DOCKER_IMAGE")
+        INSTANCE_STATUS=$(docker run --name "$INSTANCE_NAME" -p $F_PORT:$PORT -e MYSQL_ROOT_PASSWORD="$ROOT_PASSWORD" -e MYSQL_DATABASE="$DATABASE" -d "$DOCKER_IMAGE")
     else
-        INSTANCE_STATUS=$(docker run --name "$INSTANCE_NAME" -p $PORT -e MYSQL_ROOT_PASSWORD="$ROOT_PASSWORD" -e MYSQL_USER="$USER" -e MYSQL_PASSWORD=$PASSWORD -e MYSQL_DATABASE="$DATABASE" -d "$DOCKER_IMAGE")
+        INSTANCE_STATUS=$(docker run --name "$INSTANCE_NAME" -p $F_PORT:$PORT -e MYSQL_ROOT_PASSWORD="$ROOT_PASSWORD" -e MYSQL_USER="$USER" -e MYSQL_PASSWORD=$PASSWORD -e MYSQL_DATABASE="$DATABASE" -d "$DOCKER_IMAGE")
     fi
     ################################################################################
     if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then

--- a/MySQL/resources/catalog/MySQL.xml
+++ b/MySQL/resources/catalog/MySQL.xml
@@ -58,7 +58,7 @@ GET_RANDOM_PORT(){
     while :
     do
         RND_PORT="`shuf -i $LOWERPORT-$UPPERPORT -n 1`"
-        ss -lpn | grep -q ":$PORT " || break
+        ss -lpn | grep -q ":$RND_PORT " || break
     done
     echo $RND_PORT
 }

--- a/PostgreSQL/resources/catalog/PostgreSQL.xml
+++ b/PostgreSQL/resources/catalog/PostgreSQL.xml
@@ -181,7 +181,7 @@ GET_RANDOM_PORT(){
     while :
     do
         RND_PORT="`shuf -i $LOWERPORT-$UPPERPORT -n 1`"
-        ss -lpn | grep -q ":$PORT " || break
+        ss -lpn | grep -q ":$RND_PORT " || break
     done
     echo $RND_PORT
 }


### PR DESCRIPTION
In this PR, we for docker to use a fixed random port number when forwarding ports to prevent assigning a new random port for PCA services upon restart (Pause -> Resume)
This is done programmatically by picking a free port randomly within the linux port random port range
Disclaimer: this works only on linux (the same is assumed for PCA anyway)