### PR TITLE
add oracle PCA service and improve data-connectors workflows

### DIFF
--- a/DataConnectors/resources/catalog/Cassandra.xml
+++ b/DataConnectors/resources/catalog/Cassandra.xml
@@ -106,14 +106,6 @@ if QUERY is None:
     print("CASSANDRA_QUERY not defined by the user.")
     sys.exit(1)
     
-IS_LABELED_DATA = 'False'
-try:
-    LABEL = variables.get("LABEL")
-    if LABEL:
-        IS_LABELED_DATA='True'
-except NameError:
-    pass
-
 ########
 
 def pandas_factory(colnames, rows):
@@ -139,19 +131,8 @@ dataframe = rows._current_rows
 
 columns_name = dataframe.columns
 columns_number = len(columns_name)
-
-if IS_LABELED_DATA == 'True':
-    label_index= dataframe.columns.get_loc(LABEL)
-    data_indices=[x for i,x in enumerate(range(columns_number)) if i!=label_index]
-    data  = dataframe.values[:,data_indices]
-    label = dataframe.values[:,label_index]
-    data_df = pd.DataFrame(data=data,columns=columns_name[data_indices])
-    label_df = pd.DataFrame(data=label,columns=[columns_name[label_index]])
-    LABEL_TRAIN_DF_JSON = label_df.to_json(orient='split')
-    LABEL_TEST_DF_JSON = label_df.to_json(orient='split')  
-else:
-    data = dataframe.values
-    data_df = pd.DataFrame(data=data,columns=columns_name)
+data = dataframe.values
+data_df = pd.DataFrame(data=data,columns=columns_name)
 
 
 COLUMNS_NAME_JSON = pd.Series(columns_name).to_json()
@@ -161,16 +142,10 @@ DATAFRAME_JSON = dataframe.to_json(orient='split')
 
 
 try:
-    if IS_LABELED_DATA == 'True':
-        variables.put("LABEL_TRAIN_DF_JSON", LABEL_TRAIN_DF_JSON)
-        variables.put("LABEL_TEST_DF_JSON", LABEL_TEST_DF_JSON)
-        dataframe=data_df.join(label_df)
-    
     variables.put("DATAFRAME_JSON", DATAFRAME_JSON)
     variables.put("COLUMNS_NAME_JSON", COLUMNS_NAME_JSON)
     variables.put("DATA_TRAIN_DF_JSON", DATA_TRAIN_DF_JSON)
     variables.put("DATA_TEST_DF_JSON", DATA_TEST_DF_JSON)
-    variables.put("IS_LABELED_DATA", IS_LABELED_DATA)
     
     # Write results to the task result in CSV format
     result = dataframe.to_csv(index=False).encode('utf-8')
@@ -294,14 +269,6 @@ if PRIMARY_KEY is None:
     print("PRIMARY_KEY not defined by the user.")
     sys.exit(1)
 
-IS_LABELED_DATA = 'False'
-try:
-    LABEL = variables.get("LABEL")
-    if LABEL:
-        IS_LABELED_DATA='True'
-except NameError:
- pass
-
 ########
 if AUTHENTICATION:
     auth_provider = PlainTextAuthProvider(
@@ -351,18 +318,18 @@ print("END Export_Data")
         #workflow-designer {
             left:0 !important;
             top:0 !important;
-            width:1139px;
-            height:566px;
+            width:2864px;
+            height:3248px;
             }
-        </style></head><body><div id="workflow-visualization-view"><div id="workflow-visualization" style="position:relative;top:-269.9875030517578px;left:-477px"><div class="task ui-draggable _jsPlumb_endpoint_anchor_" id="jsPlumb_1_1277" style="top: 403px; left: 482px;"><a class="task-name"><img src="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png" width="20px">&nbsp;<span class="name">Import_from_Cassandra</span></a></div><div class="task _jsPlumb_endpoint_anchor_ ui-draggable" id="jsPlumb_1_1280" style="top: 275px; left: 482px;"><a class="task-name"><img src="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png" width="20px">&nbsp;<span class="name">Export_to_Cassandra</span></a></div><svg style="position:absolute;left:537px;top:314.5px" width="26.5" height="89" pointer-events="none" position="absolute" version="1.1"
+        </style></head><body><div id="workflow-visualization-view"><div id="workflow-visualization" style="position:relative;top:-481px;left:-864px"><div class="task ui-draggable _jsPlumb_endpoint_anchor_" id="jsPlumb_1_238" style="top: 614px; left: 869px;"><a class="task-name"><img src="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png" width="20px">&nbsp;<span class="name">Import_from_Cassandra</span></a></div><div class="task _jsPlumb_endpoint_anchor_ ui-draggable" id="jsPlumb_1_241" style="top: 486px; left: 869px;"><a class="task-name"><img src="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png" width="20px">&nbsp;<span class="name">Export_to_Cassandra</span></a></div><svg style="position:absolute;left:924.5px;top:525.5px" width="26.5" height="89" pointer-events="none" position="absolute" version="1.1"
       xmlns="http://www.w3.org/1999/xhtml" class="_jsPlumb_connector "><path d="M 5.5 88 C 15.5 38 -10 50 0 0 " transform="translate(10.5,0.5)" pointer-events="visibleStroke" version="1.1"
       xmlns="http://www.w3.org/1999/xhtml" fill="none" stroke="#666" style=""></path><path pointer-events="all" version="1.1"
       xmlns="http://www.w3.org/1999/xhtml" d="M7.868953124999999,66.78168750000002 L12.848095417762192,46.18537370290451 L6.478576933147113,52.85089950918167 L-1.0826925730561543,47.575749894757394 L7.868953124999999,66.78168750000002" class="" stroke="#666" fill="#666" transform="translate(10.5,0.5)"></path><path pointer-events="all" version="1.1"
-      xmlns="http://www.w3.org/1999/xhtml" d="M7.868953124999999,66.78168750000002 L12.848095417762192,46.18537370290451 L6.478576933147113,52.85089950918167 L-1.0826925730561543,47.575749894757394 L7.868953124999999,66.78168750000002" class="" stroke="#666" fill="#666" transform="translate(10.5,0.5)"></path></svg><div class="_jsPlumb_endpoint source-endpoint dependency-source-endpoint connected _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable" style="position: absolute; height: 20px; width: 20px; left: 543px; top: 433px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" d="M7.868953124999999,66.78168750000002 L12.848095417762192,46.18537370290451 L6.478576933147113,52.85089950918167 L-1.0826925730561543,47.575749894757394 L7.868953124999999,66.78168750000002" class="" stroke="#666" fill="#666" transform="translate(10.5,0.5)"></path></svg><div class="_jsPlumb_endpoint source-endpoint dependency-source-endpoint connected _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable" style="position: absolute; height: 20px; width: 20px; left: 930.5px; top: 644px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
       xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
-      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint target-endpoint dependency-target-endpoint _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 543px; top: 393px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint target-endpoint dependency-target-endpoint _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 930.5px; top: 604px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
       xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
-      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint source-endpoint dependency-source-endpoint connected _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 537.5px; top: 305px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint source-endpoint dependency-source-endpoint connected _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 925px; top: 516px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
       xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
       xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div></div></div></body></html>
  ]]>

--- a/DataConnectors/resources/catalog/Greenplum.xml
+++ b/DataConnectors/resources/catalog/Greenplum.xml
@@ -31,7 +31,6 @@ The imported data is exported in a JSON format using the variable $DATAFRAME_JSO
       </description>
       <variables>
         <variable name="GPDB_QUERY" value="" inherited="false" />
-        <variable name="RDBMS_DRIVER" value="psycopg2" inherited="false" />
         <variable name="OUTPUT_FILE" value="" inherited="false" />
         <variable name="OUTPUT_TYPE" value="CSV" inherited="false" model="PA:List(CSV,HTML)"/>
       </variables>
@@ -98,7 +97,6 @@ This task uses also the task variable RMDB_DRIVER as a driver to connect to the 
       </description>
       <variables>
         <variable name="GPDB_TABLE" value="" inherited="false" />
-        <variable name="RDBMS_DRIVER" value="psycopg2" inherited="false" />
         <variable name="INSERT_MODE" value="append" inherited="false" model="PA:LIST(fail, replace, append)"/>
         <variable name="INPUT_FILE" value="" inherited="false" />
       </variables>

--- a/DataConnectors/resources/catalog/MySQL.xml
+++ b/DataConnectors/resources/catalog/MySQL.xml
@@ -31,7 +31,6 @@ The imported data is exported in a JSON format using the variable $DATAFRAME_JSO
       </description>
       <variables>
         <variable name="MYSQL_QUERY" value="" inherited="false" />
-        <variable name="RDBMS_DRIVER" value="mysqlconnector" inherited="false" />
         <variable name="OUTPUT_FILE" value="" inherited="false" />
         <variable name="OUTPUT_TYPE" value="CSV" inherited="false" model="PA:List(CSV,HTML)"/>
       </variables>
@@ -98,7 +97,6 @@ This task uses also the task variable RMDB_DRIVER as a driver to connect to the 
       </description>
       <variables>
         <variable name="MYSQL_TABLE" value="" inherited="false" />
-        <variable name="RDBMS_DRIVER" value="mysqlconnector" inherited="false" />
         <variable name="INSERT_MODE" value="append" inherited="false" model="PA:LIST(fail, replace, append)"/>
         <variable name="INPUT_FILE" value="" inherited="false" />
       </variables>

--- a/DataConnectors/resources/catalog/Oracle.xml
+++ b/DataConnectors/resources/catalog/Oracle.xml
@@ -31,7 +31,6 @@ The imported data is exported in a JSON format using the variable $DATAFRAME_JSO
       </description>
       <variables>
         <variable name="ORACLE_QUERY" value="" inherited="false" />
-        <variable name="RDBMS_DRIVER" value="cx_oracle" inherited="false" />
         <variable name="OUTPUT_FILE" value="" inherited="false" />
         <variable name="OUTPUT_TYPE" value="CSV" inherited="false" model="PA:List(CSV,HTML)"/>
       </variables>
@@ -98,7 +97,6 @@ This task uses also the task variable RMDB_DRIVER as a driver to connect to the 
       </description>
       <variables>
         <variable name="ORACLE_TABLE" value="" inherited="false" />
-        <variable name="RDBMS_DRIVER" value="cx_oracle" inherited="false" />
         <variable name="INSERT_MODE" value="append" inherited="false" model="PA:LIST(fail, replace, append)"/>
         <variable name="INPUT_FILE" value="" inherited="false" />
       </variables>

--- a/DataConnectors/resources/catalog/PostgreSQL.xml
+++ b/DataConnectors/resources/catalog/PostgreSQL.xml
@@ -31,7 +31,6 @@ The imported data is exported in a JSON format using the variable $DATAFRAME_JSO
       </description>
       <variables>
         <variable name="POSTGRES_QUERY" value="" inherited="false" />
-        <variable name="RDBMS_DRIVER" value="psycopg2" inherited="false" />
         <variable name="OUTPUT_FILE" value="" inherited="false" />
         <variable name="OUTPUT_TYPE" value="CSV" inherited="false" model="PA:List(CSV,HTML)"/>
       </variables>
@@ -98,7 +97,6 @@ This task uses also the task variable RMDB_DRIVER as a driver to connect to the 
       </description>
       <variables>
         <variable name="POSTGRES_TABLE" value="" inherited="false" />
-        <variable name="RDBMS_DRIVER" value="psycopg2" inherited="false" />
         <variable name="INSERT_MODE" value="append" inherited="false" model="PA:LIST(fail, replace, append)"/>
         <variable name="INPUT_FILE" value="" inherited="false" />
       </variables>

--- a/DataConnectors/resources/catalog/SQL_Pooled_Connection_Query.xml
+++ b/DataConnectors/resources/catalog/SQL_Pooled_Connection_Query.xml
@@ -116,6 +116,10 @@ if (!password) {
 
 //Construct the jdbc URL
 jdbcUrl = "jdbc:" + RDBMS_PROTOCOL + "://" + host + ":" + port + "/"+ database
+//Oracle is a particular case
+if(RDBMS_PROTOCOL.equals("oracle")){
+    jdbcUrl = "jdbc:oracle:thin:@//" + host + ":" + port + "/"+ database
+}
 interceptor = new SystemOutputInterceptor({ id, str -> print(str); false})
 interceptor.start()
 if(password){

--- a/DataConnectors/resources/catalog/SQL_Pooled_Connection_Update.xml
+++ b/DataConnectors/resources/catalog/SQL_Pooled_Connection_Update.xml
@@ -116,6 +116,10 @@ if (!password) {
 
 //Construct the jdbc URL
 jdbcUrl = "jdbc:" + RDBMS_PROTOCOL + "://" + host + ":" + port + "/"+ database
+//Oracle is a particular case
+if(RDBMS_PROTOCOL.equals("oracle")){
+    jdbcUrl = "jdbc:oracle:thin:@//" + host + ":" + port + "/"+ database
+}
 interceptor = new SystemOutputInterceptor({ id, str -> print(str); false})
 interceptor.start()
 if(password){

--- a/DataConnectors/resources/catalog/SQL_Server.xml
+++ b/DataConnectors/resources/catalog/SQL_Server.xml
@@ -31,7 +31,6 @@ The imported data is exported in a JSON format using the variable $DATAFRAME_JSO
       </description>
       <variables>
         <variable name="SQL_SERVER_QUERY" value="" inherited="false" />
-        <variable name="RDBMS_DRIVER" value="pyodbc" inherited="false" />
         <variable name="OUTPUT_FILE" value="" inherited="false" />
         <variable name="OUTPUT_TYPE" value="CSV" inherited="false" model="PA:List(CSV,HTML)"/>
       </variables>
@@ -98,7 +97,6 @@ This task uses also the task variable RMDB_DRIVER as a driver to connect to the 
       </description>
       <variables>
         <variable name="SQL_SERVER_TABLE" value="" inherited="false" />
-        <variable name="RDBMS_DRIVER" value="pyodbc" inherited="false" />
         <variable name="INSERT_MODE" value="append" inherited="false" model="PA:LIST(fail, replace, append)"/>
         <variable name="INPUT_FILE" value="" inherited="false" />
       </variables>

--- a/DataConnectors/resources/test/scenarios.json
+++ b/DataConnectors/resources/test/scenarios.json
@@ -1,0 +1,10 @@
+[
+  {
+    "workflow":"SQL_Pooled_Connection_Update",
+    "variables": {}
+  },
+  {
+    "workflow":"SQL_Pooled_Connection_Query",
+    "variables": {}
+  }
+]

--- a/DatabaseServices/METADATA.json
+++ b/DatabaseServices/METADATA.json
@@ -162,6 +162,33 @@
           "contentType": "application/xml"
         },
         "file": "resources/catalog/Cassandra_Database_Interaction.xml"
+      },
+      {
+        "name": "Oracle_Service_Start",
+        "metadata": {
+          "kind": "Workflow/standard",
+          "commitMessage": "First commit",
+          "contentType": "application/xml"
+        },
+        "file": "resources/catalog/Oracle_Service_Start.xml"
+      },
+      {
+        "name": "Cassandra_Service_Actions",
+        "metadata": {
+          "kind": "Workflow/standard",
+          "commitMessage": "First commit",
+          "contentType": "application/xml"
+        },
+        "file": "resources/catalog/Oracle_Service_Actions.xml"
+      },
+      {
+        "name": "Cassandra_Database_Interaction",
+        "metadata": {
+          "kind": "Workflow/standard",
+          "commitMessage": "First commit",
+          "contentType": "application/xml"
+        },
+        "file": "resources/catalog/Oracle_Database_Interaction.xml"
       }
     ]
   }

--- a/DatabaseServices/resources/catalog/Cassandra_Database_Interaction.xml
+++ b/DatabaseServices/resources/catalog/Cassandra_Database_Interaction.xml
@@ -39,336 +39,6 @@ sleep(3000)
         </script>
       </scriptExecutable>
     </task>
-    <task name="Import_from_Cassandra" >
-      <description>
-        <![CDATA[ This task allows importing data from Cassandra.
-The task requires the following third-party credentials: CASSANDRA_USERNAME and CASSANDRA_PASSWORD. Please refer to the User documentation to learn how to add third-party credentials.
-It requires the following variables:
-$CASSANDRA_KEYSPACE: Keyspace to use.
-$CASSANDRA_QUERY: Query to fetch data.
-$CASSANDRA_OUPUT: Relative path in the data space used to save the results in a CSV file. ]]>
-      </description>
-      <variables>
-        <variable name="LABEL" value="" inherited="false" />
-        <variable name="CASSANDRA_QUERY" value="SELECT * FROM diabetes" inherited="false" />
-        <variable name="CASSANDRA_OUTPUT" value="" inherited="false" />
-      </variables>
-      <genericInformation>
-        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png"/>
-        <info name="task.documentation" value="http://doc.activeeon.com/latest/user/ProActiveUserGuide.html#_nosql"/>
-      </genericInformation>
-      <depends>
-        <task ref="Export_to_Cassandra"/>
-      </depends>
-      <forkEnvironment javaHome="/usr" >
-        <envScript>
-          <script>
-            <code language="python">
-              <![CDATA[
-#Be aware, that the prefix command is internally split by spaces. So paths with spaces won't work.
-# Prepare Docker parameters
-containerName = 'activeeon/dlm3'
-dockerRunCommand =  'docker run '
-dockerParameters = '--rm '
-# Prepare ProActive home volume
-paHomeHost = variables.get("PA_SCHEDULER_HOME")
-paHomeContainer = variables.get("PA_SCHEDULER_HOME")
-proActiveHomeVolume = '-v '+paHomeHost +':'+paHomeContainer+' '
-# Prepare working directory (For Dataspaces and serialized task file)
-workspaceHost = localspace
-workspaceContainer = localspace
-workspaceVolume = '-v '+localspace +':'+localspace+' '
-# Prepare container working directory
-containerWorkingDirectory = '-w '+workspaceContainer+' '
-# Save pre execution command into magic variable 'preJavaHomeCmd', which is picked up by the node
-preJavaHomeCmd = dockerRunCommand + dockerParameters + proActiveHomeVolume + workspaceVolume + containerWorkingDirectory + containerName
-]]>
-            </code>
-          </script>
-        </envScript>
-      </forkEnvironment>
-      <scriptExecutable>
-        <script>
-          <code language="cpython">
-            <![CDATA[
-import pandas as pd
-import numpy as np
-from cassandra.cluster import Cluster
-from cassandra.auth import PlainTextAuthProvider
-from cassandra.query import dict_factory
-
-print("BEGIN Import_Data from CASSANDRA ...")
-AUTHENTICATION = False
-HOST = variables.get("CASSANDRA_HOST")
-PORT = variables.get("CASSANDRA_PORT")
-KEYSPACE = variables.get("CASSANDRA_KEYSPACE")
-CASSANDRA_USERNAME = credentials.get("CASSANDRA_USERNAME")
-CASSANDRA_PASSWORD = credentials.get("CASSANDRA_PASSWORD")
-QUERY = variables.get("CASSANDRA_QUERY")
-CASSANDRA_OUTPUT = variables.get("CASSANDRA_OUTPUT")
-
-if HOST is None:
-    print("CASSANDRA_HOST not defined by the user.")
-    sys.exit(1)
-if PORT is None:
-    print("CASSANDRA_PORT not defined by the user. Using the default value: 9042")
-    PORT = 9042
-if KEYSPACE is None:
-    print("CASSANDRA_KEYSPACE not defined by the user.")
-    sys.exit(1)
-if (CASSANDRA_USERNAME is None and CASSANDRA_PASSWORD is not None) or (CASSANDRA_USERNAME is not None and CASSANDRA_PASSWORD is None):
-    print("[ERROR] CASSANDRA_USERNAME and CASSANDRA_PASSWORD are used in junction. They should be either both entered or both blank.")
-    sys.exit(1)
-if CASSANDRA_USERNAME is not None and CASSANDRA_PASSWORD is not None:
-    AUTHENTICATION = True
-    print("*******Authentication is enabled*******")
-else:
-    print("*******Authentication is not enabled*******")
-if QUERY is None:
-    print("CASSANDRA_QUERY not defined by the user.")
-    sys.exit(1)
-
-IS_LABELED_DATA = 'False'
-try:
-    LABEL = variables.get("LABEL")
-    if LABEL:
-        IS_LABELED_DATA='True'
-except NameError:
-    pass
-
-########
-
-def pandas_factory(colnames, rows):
-    return pd.DataFrame(rows, columns=colnames)
-auth_provider = PlainTextAuthProvider(
-                    username=CASSANDRA_USERNAME, password=CASSANDRA_PASSWORD)
-cluster = Cluster(contact_points=[HOST], port=PORT, auth_provider=auth_provider)
-session = cluster.connect(KEYSPACE)
-session.row_factory = pandas_factory
-#10000000 needed for large queries, otherwise driver will do pagination. Default is 50000.
-session.default_fetch_size = 10000000
-
-print("EXECUTING QUERY...")
-print('CASSANDRA_HOST='+HOST)
-print('CASSANDRA_PORT=', PORT)
-print('CASSANDRA_KEYSPACE='+KEYSPACE)
-print('CASSANDRA_QUERY='+QUERY)
-if CASSANDRA_OUTPUT:
-    print('CASSANDRA_OUTPUT='+CASSANDRA_OUTPUT)
-
-rows = session.execute(QUERY)
-dataframe = rows._current_rows
-
-columns_name = dataframe.columns
-columns_number = len(columns_name)
-
-if IS_LABELED_DATA == 'True':
-    label_index= dataframe.columns.get_loc(LABEL)
-    data_indices=[x for i,x in enumerate(range(columns_number)) if i!=label_index]
-    data  = dataframe.values[:,data_indices]
-    label = dataframe.values[:,label_index]
-    data_df = pd.DataFrame(data=data,columns=columns_name[data_indices])
-    label_df = pd.DataFrame(data=label,columns=[columns_name[label_index]])
-    LABEL_TRAIN_DF_JSON = label_df.to_json(orient='split')
-    LABEL_TEST_DF_JSON = label_df.to_json(orient='split')
-else:
-    data = dataframe.values
-    data_df = pd.DataFrame(data=data,columns=columns_name)
-
-
-COLUMNS_NAME_JSON = pd.Series(columns_name).to_json()
-DATA_TRAIN_DF_JSON = data_df.to_json(orient='split')
-DATA_TEST_DF_JSON = data_df.to_json(orient='split')
-DATAFRAME_JSON = dataframe.to_json(orient='split')
-
-
-try:
-    if IS_LABELED_DATA == 'True':
-        variables.put("LABEL_TRAIN_DF_JSON", LABEL_TRAIN_DF_JSON)
-        variables.put("LABEL_TEST_DF_JSON", LABEL_TEST_DF_JSON)
-        dataframe=data_df.join(label_df)
-
-    variables.put("DATAFRAME_JSON", DATAFRAME_JSON)
-    variables.put("COLUMNS_NAME_JSON", COLUMNS_NAME_JSON)
-    variables.put("DATA_TRAIN_DF_JSON", DATA_TRAIN_DF_JSON)
-    variables.put("DATA_TEST_DF_JSON", DATA_TEST_DF_JSON)
-    variables.put("IS_LABELED_DATA", IS_LABELED_DATA)
-
-    # Write results to the task result in CSV format
-    result = dataframe.to_csv(index=False).encode('utf-8')
-    resultMetadata.put("file.extension", ".csv")
-    resultMetadata.put("file.name", "result.csv")
-    resultMetadata.put("content.type", "text/csv")
-
-    # If an CASSANDRA_OUTPUT path in the dataspace is designated, then write to this file.
-    if CASSANDRA_OUTPUT:
-         dataframe.to_csv(path_or_buf=CASSANDRA_OUTPUT, index=False)
-except NameError:
-    pass
-
-#***********************************************
-print("END Import_Data")
-]]>
-          </code>
-        </script>
-      </scriptExecutable>
-      <outputFiles>
-        <files  includes="$CASSANDRA_OUTPUT" accessMode="transferToGlobalSpace"/>
-      </outputFiles>
-    </task>
-    <task name="Export_to_Cassandra" >
-      <description>
-        <![CDATA[ This task allows exporting data to Cassandra.
-The task requires the following third-party credentials: CASSANDRA_USERNAME and CASSANDRA_PASSWORD. Please refer to the User documentation to learn how to add third-party credentials.
-It requires the following variables:
-$CASSANDRA_TABLE (required) Data is stored in tables containing rows of columns, similar to SQL definitions.. It is created if it does not exist
-$CASSANDRA_KEY (required) A primary key identifies the location and order of stored data. The primary key is defined when the table is created and cannot be altered.
-$CASSANDRA_INPUT (required) is the relative path of the CSV file that contains data to be imported. This variable can:
- - An URL. Valid URL schemes include http, ftp, s3, and file.
- - A relative path in the data space of a csv file. ]]>
-      </description>
-      <variables>
-        <variable name="CASSANDRA_TABLE" value="diabetes" inherited="false" />
-        <variable name="CASSANDRA_PRIMARY_KEY" value="preg" inherited="false" />
-        <variable name="CASSANDRA_INPUT" value="pima-indians-diabetes.csv" inherited="false" />
-      </variables>
-      <genericInformation>
-        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png"/>
-        <info name="task.documentation" value="http://doc.activeeon.com/latest/user/ProActiveUserGuide.html#_nosql"/>
-      </genericInformation>
-      <depends>
-        <task ref="Prepare_Cassandra_Cluster"/>
-      </depends>
-      <inputFiles>
-        <files  includes="$CASSANDRA_INPUT" accessMode="transferFromGlobalSpace"/>
-      </inputFiles>
-      <forkEnvironment javaHome="/usr" >
-        <envScript>
-          <script>
-            <code language="python">
-              <![CDATA[
-#Be aware, that the prefix command is internally split by spaces. So paths with spaces won't work.
-# Prepare Docker parameters
-containerName = 'activeeon/dlm3'
-dockerRunCommand =  'docker run '
-dockerParameters = '--rm '
-# Prepare ProActive home volume
-paHomeHost = variables.get("PA_SCHEDULER_HOME")
-paHomeContainer = variables.get("PA_SCHEDULER_HOME")
-proActiveHomeVolume = '-v '+paHomeHost +':'+paHomeContainer+' '
-# Prepare working directory (For Dataspaces and serialized task file)
-workspaceHost = localspace
-workspaceContainer = localspace
-workspaceVolume = '-v '+localspace +':'+localspace+' '
-# Prepare container working directory
-containerWorkingDirectory = '-w '+workspaceContainer+' '
-# Save pre execution command into magic variable 'preJavaHomeCmd', which is picked up by the node
-preJavaHomeCmd = dockerRunCommand + dockerParameters + proActiveHomeVolume + workspaceVolume + containerWorkingDirectory + containerName
-]]>
-            </code>
-          </script>
-        </envScript>
-      </forkEnvironment>
-      <scriptExecutable>
-        <script>
-          <code language="cpython">
-            <![CDATA[
-import pandas as pd
-import numpy as np
-import re
-import sys
-from cassandra.cluster import Cluster
-from cassandra.auth import PlainTextAuthProvider
-from cassandra.query import dict_factory
-
-print("BEGIN Export_Data to CASSANDRA ...")
-AUTHENTICATION = False
-HOST = variables.get("CASSANDRA_HOST")
-PORT = variables.get("CASSANDRA_PORT")
-KEYSPACE = variables.get("CASSANDRA_KEYSPACE")
-CASSANDRA_USERNAME = credentials.get("CASSANDRA_USERNAME")
-CASSANDRA_PASSWORD = credentials.get("CASSANDRA_PASSWORD")
-TABLE = variables.get("CASSANDRA_TABLE")
-CASSANDRA_INPUT = variables.get("CASSANDRA_INPUT")
-PRIMARY_KEY = variables.get("CASSANDRA_PRIMARY_KEY")
-
-if HOST is None:
-    print("CASSANDRA_HOST not defined by the user.")
-    sys.exit(1)
-if PORT is None:
-    print("CASSANDRA_PORT not defined by the user. Using the default value: 9042")
-    PORT = 9042
-if KEYSPACE is None:
-    print("CASSANDRA_KEYSPACE not defined by the user.")
-    sys.exit(1)
-if (CASSANDRA_USERNAME is None and CASSANDRA_PASSWORD is not None) or (CASSANDRA_USERNAME is not None and CASSANDRA_PASSWORD is None):
-    print("[ERROR] CASSANDRA_USERNAME and CASSANDRA_PASSWORD are used in junction. They should be either both entered or both blank.")
-    sys.exit(1)
-if CASSANDRA_USERNAME is not None and CASSANDRA_PASSWORD is not None:
-    AUTHENTICATION = True
-    print("*******Authentication is enabled*******")
-else:
-    print("*******Authentication is not enabled*******")
-if TABLE is None:
-    print("CASSANDRA_TABLE not defined by the user.")
-    sys.exit(1)
-if CASSANDRA_INPUT is None:
-    print("CASSANDRA_INPUT not defined by the user.")
-    sys.exit(1)
-if PRIMARY_KEY is None:
-    print("PRIMARY_KEY not defined by the user.")
-    sys.exit(1)
-
-IS_LABELED_DATA = 'False'
-try:
-    LABEL = variables.get("LABEL")
-    if LABEL:
-        IS_LABELED_DATA='True'
-except NameError:
- pass
-
-########
-if AUTHENTICATION:
-    auth_provider = PlainTextAuthProvider(
-                    username=CASSANDRA_USERNAME, password=CASSANDRA_PASSWORD)
-    cluster = Cluster(contact_points=[HOST], port=PORT, auth_provider=auth_provider)
-else:
-    cluster = Cluster(contact_points=[HOST], port=PORT)
-
-session = cluster.connect(KEYSPACE)
-
-print("INSERTING DATA IN CASSANDRA...")
-print('CASSANDRA_HOST='+HOST)
-print('CASSANDRA_PORT=', PORT)
-print('CASSANDRA_KEYSPACE='+KEYSPACE)
-print('CASSANDRA_TABLE=' + TABLE)
-print('CASSANDRA_PRIMARY_KEY=' + PRIMARY_KEY)
-
-dataframe = pd.read_csv(CASSANDRA_INPUT, sep='\t|;|,',index_col=None, engine='python')
-column_names = list(dataframe.columns.values)
-column_types= re.sub("\d", "",','.join('{}'.format(*k) for k in zip(dataframe.dtypes))).split(',')
-TABLE_HEADER = ',\n'.join('{} {}'.format(*t) for t in zip(column_names, column_types))
-CREATE_TABLE = """CREATE TABLE IF NOT EXISTS {0}.{1}({2},
-  PRIMARY KEY ({3}));""".format(KEYSPACE, TABLE, TABLE_HEADER, PRIMARY_KEY)
-
-session.execute(CREATE_TABLE)
-INSERT_STATEMENT = """ INSERT INTO {0} ({1}) VALUES """.format(TABLE, ','.join(map(str, column_names)))
-BATCH_SIZE = dataframe.size
-BATCH_QUERY = 'BEGIN BATCH\n'
-for row in dataframe.itertuples(index = False):
-    BATCH_QUERY += """{0}({1})\n""".format(INSERT_STATEMENT ,','.join(map(str, row)))
-BATCH_QUERY += 'APPLY BATCH;'
-try:
-    session.execute(BATCH_QUERY)
-except Exception as e:
-    print(e)
-    sys.exit(1)
-print("END Export_Data")
-]]>
-          </code>
-        </script>
-      </scriptExecutable>
-    </task>
     <task name="Prepare_Cassandra_Cluster" >
       <description>
         <![CDATA[ This task aims to prepare the cassandra cluster by creating a keyspace and add authentication. ]]>
@@ -439,6 +109,14 @@ session.execute("""CREATE KEYSPACE IF NOT EXISTS %s WITH replication = { 'class'
           </code>
         </script>
       </scriptExecutable>
+      <metadata>
+        <positionTop>
+            368
+        </positionTop>
+        <positionLeft>
+            632.5
+        </positionLeft>
+      </metadata>
     </task>
     <task name="Start_Cassandra" 
     
@@ -488,6 +166,302 @@ session.execute("""CREATE KEYSPACE IF NOT EXISTS %s WITH replication = { 'class'
       </scriptExecutable>
       <controlFlow block="none"></controlFlow>
     </task>
+    <task name="Import_from_Cassandra" >
+      <description>
+        <![CDATA[ This task allows importing data from Cassandra.
+The task requires the following third-party credentials: CASSANDRA_USERNAME and CASSANDRA_PASSWORD. Please refer to the User documentation to learn how to add third-party credentials.
+It requires the following variables:
+$CASSANDRA_KEYSPACE: Keyspace to use.
+$CASSANDRA_QUERY: Query to fetch data.
+$CASSANDRA_OUPUT: Relative path in the data space used to save the results in a CSV file. ]]>
+      </description>
+      <variables>
+        <variable name="CASSANDRA_QUERY" value="SELECT * FROM diabetes" inherited="false" />
+        <variable name="CASSANDRA_OUTPUT" value="" inherited="false" />
+      </variables>
+      <genericInformation>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png"/>
+        <info name="task.documentation" value="http://doc.activeeon.com/latest/user/ProActiveUserGuide.html#_nosql"/>
+      </genericInformation>
+      <depends>
+        <task ref="Export_to_Cassandra"/>
+      </depends>
+      <forkEnvironment javaHome="/usr" >
+        <envScript>
+          <script>
+            <code language="python">
+              <![CDATA[
+#Be aware, that the prefix command is internally split by spaces. So paths with spaces won't work.
+# Prepare Docker parameters 
+containerName = 'activeeon/dlm3'
+dockerRunCommand =  'docker run ' 
+dockerParameters = '--rm ' 
+# Prepare ProActive home volume 
+paHomeHost = variables.get("PA_SCHEDULER_HOME") 
+paHomeContainer = variables.get("PA_SCHEDULER_HOME") 
+proActiveHomeVolume = '-v '+paHomeHost +':'+paHomeContainer+' ' 
+# Prepare working directory (For Dataspaces and serialized task file) 
+workspaceHost = localspace 
+workspaceContainer = localspace 
+workspaceVolume = '-v '+localspace +':'+localspace+' ' 
+# Prepare container working directory 
+containerWorkingDirectory = '-w '+workspaceContainer+' ' 
+# Save pre execution command into magic variable 'preJavaHomeCmd', which is picked up by the node 
+preJavaHomeCmd = dockerRunCommand + dockerParameters + proActiveHomeVolume + workspaceVolume + containerWorkingDirectory + containerName
+]]>
+            </code>
+          </script>
+        </envScript>
+      </forkEnvironment>
+      <scriptExecutable>
+        <script>
+          <code language="cpython">
+            <![CDATA[
+import pandas as pd
+import numpy as np
+from cassandra.cluster import Cluster
+from cassandra.auth import PlainTextAuthProvider
+from cassandra.query import dict_factory
+
+print("BEGIN Import_Data from CASSANDRA ...")
+AUTHENTICATION = False
+HOST = variables.get("CASSANDRA_HOST")
+PORT = variables.get("CASSANDRA_PORT")
+KEYSPACE = variables.get("CASSANDRA_KEYSPACE")
+CASSANDRA_USERNAME = credentials.get("CASSANDRA_USERNAME")
+CASSANDRA_PASSWORD = credentials.get("CASSANDRA_PASSWORD")
+QUERY = variables.get("CASSANDRA_QUERY")
+CASSANDRA_OUTPUT = variables.get("CASSANDRA_OUTPUT")
+
+if HOST is None:
+    print("CASSANDRA_HOST not defined by the user.")
+    sys.exit(1)
+if PORT is None:
+    print("CASSANDRA_PORT not defined by the user. Using the default value: 9042")
+    PORT = 9042
+if KEYSPACE is None: 
+    print("CASSANDRA_KEYSPACE not defined by the user.")
+    sys.exit(1)
+if (CASSANDRA_USERNAME is None and CASSANDRA_PASSWORD is not None) or (CASSANDRA_USERNAME is not None and CASSANDRA_PASSWORD is None):
+    print("[ERROR] CASSANDRA_USERNAME and CASSANDRA_PASSWORD are used in junction. They should be either both entered or both blank.")
+    sys.exit(1)
+if CASSANDRA_USERNAME is not None and CASSANDRA_PASSWORD is not None:
+    AUTHENTICATION = True
+    print("*******Authentication is enabled*******")
+else:
+    print("*******Authentication is not enabled*******")
+if QUERY is None:
+    print("CASSANDRA_QUERY not defined by the user.")
+    sys.exit(1)
+    
+########
+
+def pandas_factory(colnames, rows):
+    return pd.DataFrame(rows, columns=colnames)
+auth_provider = PlainTextAuthProvider(
+                    username=CASSANDRA_USERNAME, password=CASSANDRA_PASSWORD)
+cluster = Cluster(contact_points=[HOST], port=PORT, auth_provider=auth_provider)
+session = cluster.connect(KEYSPACE)
+session.row_factory = pandas_factory
+#10000000 needed for large queries, otherwise driver will do pagination. Default is 50000.
+session.default_fetch_size = 10000000
+
+print("EXECUTING QUERY...")
+print('CASSANDRA_HOST='+HOST)
+print('CASSANDRA_PORT=', PORT)
+print('CASSANDRA_KEYSPACE='+KEYSPACE)
+print('CASSANDRA_QUERY='+QUERY)
+if CASSANDRA_OUTPUT:
+    print('CASSANDRA_OUTPUT='+CASSANDRA_OUTPUT)
+
+rows = session.execute(QUERY)
+dataframe = rows._current_rows
+
+columns_name = dataframe.columns
+columns_number = len(columns_name)
+data = dataframe.values
+data_df = pd.DataFrame(data=data,columns=columns_name)
+
+
+COLUMNS_NAME_JSON = pd.Series(columns_name).to_json()
+DATA_TRAIN_DF_JSON = data_df.to_json(orient='split')
+DATA_TEST_DF_JSON = data_df.to_json(orient='split')
+DATAFRAME_JSON = dataframe.to_json(orient='split')
+
+
+try:
+    variables.put("DATAFRAME_JSON", DATAFRAME_JSON)
+    variables.put("COLUMNS_NAME_JSON", COLUMNS_NAME_JSON)
+    variables.put("DATA_TRAIN_DF_JSON", DATA_TRAIN_DF_JSON)
+    variables.put("DATA_TEST_DF_JSON", DATA_TEST_DF_JSON)
+    
+    # Write results to the task result in CSV format
+    result = dataframe.to_csv(index=False).encode('utf-8')
+    resultMetadata.put("file.extension", ".csv")
+    resultMetadata.put("file.name", "result.csv")
+    resultMetadata.put("content.type", "text/csv")
+    
+    # If an CASSANDRA_OUTPUT path in the dataspace is designated, then write to this file.
+    if CASSANDRA_OUTPUT:
+         dataframe.to_csv(path_or_buf=CASSANDRA_OUTPUT, index=False)
+except NameError:
+    pass
+
+#***********************************************
+print("END Import_Data")
+]]>
+          </code>
+        </script>
+      </scriptExecutable>
+      <outputFiles>
+        <files  includes="$CASSANDRA_OUTPUT" accessMode="transferToGlobalSpace"/>
+      </outputFiles>
+    </task>
+    <task name="Export_to_Cassandra" >
+      <description>
+        <![CDATA[ This task allows exporting data to Cassandra.
+The task requires the following third-party credentials: CASSANDRA_USERNAME and CASSANDRA_PASSWORD. Please refer to the User documentation to learn how to add third-party credentials.
+It requires the following variables:
+$CASSANDRA_TABLE (required) Data is stored in tables containing rows of columns, similar to SQL definitions.. It is created if it does not exist
+$CASSANDRA_KEY (required) A primary key identifies the location and order of stored data. The primary key is defined when the table is created and cannot be altered.
+$CASSANDRA_INPUT (required) is the relative path of the CSV file that contains data to be imported. This variable can:
+ - An URL. Valid URL schemes include http, ftp, s3, and file. 
+ - A relative path in the data space of a csv file. ]]>
+      </description>
+      <variables>
+        <variable name="CASSANDRA_TABLE" value="diabetes" inherited="false" />
+        <variable name="CASSANDRA_PRIMARY_KEY" value="preg" inherited="false" />
+        <variable name="CASSANDRA_INPUT" value="pima-indians-diabetes.csv" inherited="false" />
+      </variables>
+      <genericInformation>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png"/>
+        <info name="task.documentation" value="http://doc.activeeon.com/latest/user/ProActiveUserGuide.html#_nosql"/>
+      </genericInformation>
+      <depends>
+        <task ref="Prepare_Cassandra_Cluster"/>
+      </depends>
+      <inputFiles>
+        <files  includes="$CASSANDRA_INPUT" accessMode="transferFromGlobalSpace"/>
+      </inputFiles>
+      <forkEnvironment javaHome="/usr" >
+        <envScript>
+          <script>
+            <code language="python">
+              <![CDATA[
+#Be aware, that the prefix command is internally split by spaces. So paths with spaces won't work.
+# Prepare Docker parameters 
+containerName = 'activeeon/dlm3'
+dockerRunCommand =  'docker run ' 
+dockerParameters = '--rm ' 
+# Prepare ProActive home volume 
+paHomeHost = variables.get("PA_SCHEDULER_HOME") 
+paHomeContainer = variables.get("PA_SCHEDULER_HOME") 
+proActiveHomeVolume = '-v '+paHomeHost +':'+paHomeContainer+' ' 
+# Prepare working directory (For Dataspaces and serialized task file) 
+workspaceHost = localspace 
+workspaceContainer = localspace 
+workspaceVolume = '-v '+localspace +':'+localspace+' ' 
+# Prepare container working directory 
+containerWorkingDirectory = '-w '+workspaceContainer+' ' 
+# Save pre execution command into magic variable 'preJavaHomeCmd', which is picked up by the node 
+preJavaHomeCmd = dockerRunCommand + dockerParameters + proActiveHomeVolume + workspaceVolume + containerWorkingDirectory + containerName
+]]>
+            </code>
+          </script>
+        </envScript>
+      </forkEnvironment>
+      <scriptExecutable>
+        <script>
+          <code language="cpython">
+            <![CDATA[
+import pandas as pd
+import numpy as np
+import re
+import sys
+from cassandra.cluster import Cluster
+from cassandra.auth import PlainTextAuthProvider
+from cassandra.query import dict_factory
+
+print("BEGIN Export_Data to CASSANDRA ...")
+AUTHENTICATION = False
+HOST = variables.get("CASSANDRA_HOST")
+PORT = variables.get("CASSANDRA_PORT")
+KEYSPACE = variables.get("CASSANDRA_KEYSPACE")
+CASSANDRA_USERNAME = credentials.get("CASSANDRA_USERNAME")
+CASSANDRA_PASSWORD = credentials.get("CASSANDRA_PASSWORD")
+TABLE = variables.get("CASSANDRA_TABLE")
+CASSANDRA_INPUT = variables.get("CASSANDRA_INPUT")
+PRIMARY_KEY = variables.get("CASSANDRA_PRIMARY_KEY")
+
+if HOST is None:
+    print("CASSANDRA_HOST not defined by the user.")
+    sys.exit(1)
+if PORT is None:
+    print("CASSANDRA_PORT not defined by the user. Using the default value: 9042")
+    PORT = 9042
+if KEYSPACE is None: 
+    print("CASSANDRA_KEYSPACE not defined by the user.")
+    sys.exit(1)
+if (CASSANDRA_USERNAME is None and CASSANDRA_PASSWORD is not None) or (CASSANDRA_USERNAME is not None and CASSANDRA_PASSWORD is None):
+    print("[ERROR] CASSANDRA_USERNAME and CASSANDRA_PASSWORD are used in junction. They should be either both entered or both blank.")
+    sys.exit(1)
+if CASSANDRA_USERNAME is not None and CASSANDRA_PASSWORD is not None:
+    AUTHENTICATION = True
+    print("*******Authentication is enabled*******")
+else:
+    print("*******Authentication is not enabled*******")
+if TABLE is None:
+    print("CASSANDRA_TABLE not defined by the user.")
+    sys.exit(1)
+if CASSANDRA_INPUT is None:
+    print("CASSANDRA_INPUT not defined by the user.")
+    sys.exit(1)
+if PRIMARY_KEY is None:
+    print("PRIMARY_KEY not defined by the user.")
+    sys.exit(1)
+
+########
+if AUTHENTICATION:
+    auth_provider = PlainTextAuthProvider(
+                    username=CASSANDRA_USERNAME, password=CASSANDRA_PASSWORD)
+    cluster = Cluster(contact_points=[HOST], port=PORT, auth_provider=auth_provider)
+else:
+    cluster = Cluster(contact_points=[HOST], port=PORT)
+
+session = cluster.connect(KEYSPACE)
+
+print("INSERTING DATA IN CASSANDRA...")
+print('CASSANDRA_HOST='+HOST)
+print('CASSANDRA_PORT=', PORT)
+print('CASSANDRA_KEYSPACE='+KEYSPACE)
+print('CASSANDRA_TABLE=' + TABLE)
+print('CASSANDRA_PRIMARY_KEY=' + PRIMARY_KEY)
+
+dataframe = pd.read_csv(CASSANDRA_INPUT, sep='\t|;|,',index_col=None, engine='python')
+column_names = list(dataframe.columns.values) 
+column_types= re.sub("\d", "",','.join('{}'.format(*k) for k in zip(dataframe.dtypes))).split(',')
+TABLE_HEADER = ',\n'.join('{} {}'.format(*t) for t in zip(column_names, column_types))
+CREATE_TABLE = """CREATE TABLE IF NOT EXISTS {0}.{1}({2},
+  PRIMARY KEY ({3}));""".format(KEYSPACE, TABLE, TABLE_HEADER, PRIMARY_KEY)
+
+session.execute(CREATE_TABLE)
+INSERT_STATEMENT = """ INSERT INTO {0} ({1}) VALUES """.format(TABLE, ','.join(map(str, column_names)))
+BATCH_SIZE = dataframe.size
+BATCH_QUERY = 'BEGIN BATCH\n'
+for row in dataframe.itertuples(index = False):
+    BATCH_QUERY += """{0}({1})\n""".format(INSERT_STATEMENT ,','.join(map(str, row)))
+BATCH_QUERY += 'APPLY BATCH;'
+try:
+    session.execute(BATCH_QUERY)
+except Exception as e:
+    print(e)
+    sys.exit(1)
+print("END Export_Data")
+]]>
+          </code>
+        </script>
+      </scriptExecutable>
+    </task>
   </taskFlow>
   <metadata>
     <visualization>
@@ -495,50 +469,50 @@ session.execute("""CREATE KEYSPACE IF NOT EXISTS %s WITH replication = { 'class'
         #workflow-designer {
             left:0 !important;
             top:0 !important;
-            width:2854px;
+            width:2864px;
             height:3248px;
             }
-        </style></head><body><div id="workflow-visualization-view"><div id="workflow-visualization" style="position:relative;top:-156px;left:-892px"><div class="task ui-draggable _jsPlumb_endpoint_anchor_" id="jsPlumb_1_1669" style="top: 271px; left: 912px;"><a class="task-name"><img src="/studio/images/Groovy.png" width="20px">&nbsp;<span class="name">Parse_Endpoint</span></a></div><div class="task ui-draggable _jsPlumb_endpoint_anchor_" id="jsPlumb_1_1672" style="top: 654px; left: 912px;"><a class="task-name"><img src="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png" width="20px">&nbsp;<span class="name">Import_from_Cassandra</span></a></div><div class="task ui-draggable _jsPlumb_endpoint_anchor_" id="jsPlumb_1_1675" style="top: 526px; left: 912px;"><a class="task-name"><img src="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png" width="20px">&nbsp;<span class="name">Export_to_Cassandra</span></a></div><div class="task ui-draggable _jsPlumb_endpoint_anchor_" id="jsPlumb_1_1678" style="top: 398px; left: 912px;"><a class="task-name"><img src="/studio/images/Python.png" width="20px">&nbsp;<span class="name">Prepare_Cassandra_Cluster</span></a></div><div class="task _jsPlumb_endpoint_anchor_ ui-draggable" id="jsPlumb_1_1681" style="top: 161px; left: 897px;"><a class="task-name"><img src="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png" width="20px">&nbsp;<span class="name">Start_Cassandra</span></a></div><div class="task ui-draggable _jsPlumb_endpoint_anchor_ active-task" id="jsPlumb_1_1684" style="top: 753px; left: 909px;"><a class="task-name"><img src="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png" width="20px">&nbsp;<span class="name">Cassandra_Service_Action</span></a></div><svg style="position:absolute;left:941.5px;top:200.5px" width="34" height="71" pointer-events="none" position="absolute" version="1.1"
-      xmlns="http://www.w3.org/1999/xhtml" class="_jsPlumb_connector "><path d="M 13 70 C 23 20 -10 50 0 0 " transform="translate(10.5,0.5)" pointer-events="visibleStroke" version="1.1"
+        </style></head><body><div id="workflow-visualization-view"><div id="workflow-visualization" style="position:relative;top:-107px;left:-627.5px"><div class="task ui-draggable _jsPlumb_endpoint_anchor_" id="jsPlumb_1_346" style="top: 240px; left: 632.5px;"><a class="task-name"><img src="/studio/images/Groovy.png" width="20px">&nbsp;<span class="name">Parse_Endpoint</span></a></div><div class="task ui-draggable _jsPlumb_endpoint_anchor_" id="jsPlumb_1_349" style="top: 368px; left: 632.5px;"><a class="task-name"><img src="/studio/images/Python.png" width="20px">&nbsp;<span class="name">Prepare_Cassandra_Cluster</span></a></div><div class="task _jsPlumb_endpoint_anchor_ ui-draggable" id="jsPlumb_1_352" style="top: 112px; left: 632.5px;"><a class="task-name"><img src="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png" width="20px">&nbsp;<span class="name">Start_Cassandra</span></a></div><div class="task ui-draggable _jsPlumb_endpoint_anchor_" id="jsPlumb_1_355" style="top: 752px; left: 632.5px;"><a class="task-name"><img src="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png" width="20px">&nbsp;<span class="name">Cassandra_Service_Action</span></a></div><div class="task ui-draggable _jsPlumb_endpoint_anchor_" id="jsPlumb_1_358" style="top: 624px; left: 632.5px;"><a class="task-name"><img src="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png" width="20px">&nbsp;<span class="name">Import_from_Cassandra</span></a></div><div class="task ui-draggable _jsPlumb_endpoint_anchor_" id="jsPlumb_1_361" style="top: 496px; left: 632.5px;"><a class="task-name"><img src="/automation-dashboard/styles/patterns/img/wf-icons/cassandra.png" width="20px">&nbsp;<span class="name">Export_to_Cassandra</span></a></div><svg style="position:absolute;left:675px;top:151.5px" width="23" height="89" pointer-events="none" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" class="_jsPlumb_connector "><path d="M 0 88 C -10 38 12 50 2 0 " transform="translate(10.5,0.5)" pointer-events="visibleStroke" version="1.1"
       xmlns="http://www.w3.org/1999/xhtml" fill="none" stroke="#666" style=""></path><path pointer-events="all" version="1.1"
-      xmlns="http://www.w3.org/1999/xhtml" d="M14.88775,52.36000000000001 L17.51038630944286,31.333307944700586 L11.933902216535985,38.675162285502815 L3.825548594945669,34.2871557281646 L14.88775,52.36000000000001" class="" stroke="#666" fill="#666" transform="translate(10.5,0.5)"></path><path pointer-events="all" version="1.1"
-      xmlns="http://www.w3.org/1999/xhtml" d="M14.88775,52.36000000000001 L17.51038630944286,31.333307944700586 L11.933902216535985,38.675162285502815 L3.825548594945669,34.2871557281646 L14.88775,52.36000000000001" class="" stroke="#666" fill="#666" transform="translate(10.5,0.5)"></path></svg><svg style="position:absolute;left:967.5px;top:565.5px" width="26.5" height="89" pointer-events="none" position="absolute" version="1.1"
-      xmlns="http://www.w3.org/1999/xhtml" class="_jsPlumb_connector"><path d="M 5.5 88 C 15.5 38 -10 50 0 0 " transform="translate(10.5,0.5)" pointer-events="visibleStroke" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" d="M-2.6529999999999996,66.78168750000002 L5.422684726887218,47.19129913754225 L-1.8927913941925154,52.80234263424697 L-8.556660138865833,46.431090531734775 L-2.6529999999999996,66.78168750000002" class="" stroke="#666" fill="#666" transform="translate(10.5,0.5)"></path><path pointer-events="all" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" d="M-2.6529999999999996,66.78168750000002 L5.422684726887218,47.19129913754225 L-1.8927913941925154,52.80234263424697 L-8.556660138865833,46.431090531734775 L-2.6529999999999996,66.78168750000002" class="" stroke="#666" fill="#666" transform="translate(10.5,0.5)"></path></svg><svg style="position:absolute;left:675px;top:279.5px" width="49" height="89" pointer-events="none" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" class="_jsPlumb_connector "><path d="M 28 88 C 38 38 -10 50 0 0 " transform="translate(10.5,0.5)" pointer-events="visibleStroke" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="none" stroke="#666" style=""></path><path pointer-events="all" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" d="M28.3293185,65.8307285 L27.243134379193783,44.66896571766761 L23.033139643665223,52.87115715208451 L14.283563031278282,49.96514457400239 L28.3293185,65.8307285" class="" stroke="#666" fill="#666" transform="translate(10.5,0.5)"></path><path pointer-events="all" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" d="M28.3293185,65.8307285 L27.243134379193783,44.66896571766761 L23.033139643665223,52.87115715208451 L14.283563031278282,49.96514457400239 L28.3293185,65.8307285" class="" stroke="#666" fill="#666" transform="translate(10.5,0.5)"></path></svg><svg style="position:absolute;left:693.5px;top:663.5px" width="27.5" height="89" pointer-events="none" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" class="_jsPlumb_connector "><path d="M 6.5 88 C 16.5 38 -10 50 0 0 " transform="translate(10.5,0.5)" pointer-events="visibleStroke" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="none" stroke="#666" style=""></path><path pointer-events="all" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" d="M8.787796875,66.78168750000002 L13.502214816791486,46.123171980483264 L7.218760132881903,52.86988949607962 L-0.4095831871289066,47.692208722601364 L8.787796875,66.78168750000002" class="" stroke="#666" fill="#666" transform="translate(10.5,0.5)"></path><path pointer-events="all" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" d="M8.787796875,66.78168750000002 L13.502214816791486,46.123171980483264 L7.218760132881903,52.86988949607962 L-0.4095831871289066,47.692208722601364 L8.787796875,66.78168750000002" class="" stroke="#666" fill="#666" transform="translate(10.5,0.5)"></path></svg><svg style="position:absolute;left:688px;top:535.5px" width="26.5" height="89" pointer-events="none" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" class="_jsPlumb_connector "><path d="M 5.5 88 C 15.5 38 -10 50 0 0 " transform="translate(10.5,0.5)" pointer-events="visibleStroke" version="1.1"
       xmlns="http://www.w3.org/1999/xhtml" fill="none" stroke="#666" style=""></path><path pointer-events="all" version="1.1"
       xmlns="http://www.w3.org/1999/xhtml" d="M7.868953124999999,66.78168750000002 L12.848095417762192,46.18537370290451 L6.478576933147113,52.85089950918167 L-1.0826925730561543,47.575749894757394 L7.868953124999999,66.78168750000002" class="" stroke="#666" fill="#666" transform="translate(10.5,0.5)"></path><path pointer-events="all" version="1.1"
-      xmlns="http://www.w3.org/1999/xhtml" d="M7.868953124999999,66.78168750000002 L12.848095417762192,46.18537370290451 L6.478576933147113,52.85089950918167 L-1.0826925730561543,47.575749894757394 L7.868953124999999,66.78168750000002" class="" stroke="#666" fill="#666" transform="translate(10.5,0.5)"></path></svg><svg style="position:absolute;left:967.5px;top:437.5px" width="36" height="89" pointer-events="none" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" d="M7.868953124999999,66.78168750000002 L12.848095417762192,46.18537370290451 L6.478576933147113,52.85089950918167 L-1.0826925730561543,47.575749894757394 L7.868953124999999,66.78168750000002" class="" stroke="#666" fill="#666" transform="translate(10.5,0.5)"></path></svg><svg style="position:absolute;left:688px;top:407.5px" width="36" height="89" pointer-events="none" position="absolute" version="1.1"
       xmlns="http://www.w3.org/1999/xhtml" class="_jsPlumb_connector "><path d="M 0 88 C -10 38 25 50 15 0 " transform="translate(10.5,0.5)" pointer-events="visibleStroke" version="1.1"
       xmlns="http://www.w3.org/1999/xhtml" fill="none" stroke="#666" style=""></path><path pointer-events="all" version="1.1"
       xmlns="http://www.w3.org/1999/xhtml" d="M-1.5508800000000005,66.303232 L9.739006151742196,48.37173817821538 L1.575805362924103,52.656846447727325 L-3.9073794005304716,45.245052815291274 L-1.5508800000000005,66.303232" class="" stroke="#666" fill="#666" transform="translate(10.5,0.5)"></path><path pointer-events="all" version="1.1"
-      xmlns="http://www.w3.org/1999/xhtml" d="M-1.5508800000000005,66.303232 L9.739006151742196,48.37173817821538 L1.575805362924103,52.656846447727325 L-3.9073794005304716,45.245052815291274 L-1.5508800000000005,66.303232" class="" stroke="#666" fill="#666" transform="translate(10.5,0.5)"></path></svg><svg style="position:absolute;left:954.5px;top:310.5px" width="49" height="88" pointer-events="none" position="absolute" version="1.1"
-      xmlns="http://www.w3.org/1999/xhtml" class="_jsPlumb_connector "><path d="M 28 87 C 38 37 -10 50 0 0 " transform="translate(10.5,0.5)" pointer-events="visibleStroke" version="1.1"
-      xmlns="http://www.w3.org/1999/xhtml" fill="none" stroke="#666" style=""></path><path pointer-events="all" version="1.1"
-      xmlns="http://www.w3.org/1999/xhtml" d="M28.3293185,64.92074025000001 L27.143087387822856,43.76434982657232 L22.97192212381845,51.986355685264165 L14.208702823087012,49.12174620275386 L28.3293185,64.92074025000001" class="" stroke="#666" fill="#666" transform="translate(10.5,0.5)"></path><path pointer-events="all" version="1.1"
-      xmlns="http://www.w3.org/1999/xhtml" d="M28.3293185,64.92074025000001 L27.143087387822856,43.76434982657232 L22.97192212381845,51.986355685264165 L14.208702823087012,49.12174620275386 L28.3293185,64.92074025000001" class="" stroke="#666" fill="#666" transform="translate(10.5,0.5)"></path></svg><svg style="position:absolute;left:973px;top:693.5px" width="24" height="60" pointer-events="none" position="absolute" version="1.1"
-      xmlns="http://www.w3.org/1999/xhtml" class="_jsPlumb_connector "><path d="M 3 59 C 13 9 -10 50 0 0 " transform="translate(10.5,0.5)" pointer-events="visibleStroke" version="1.1"
-      xmlns="http://www.w3.org/1999/xhtml" fill="none" stroke="#666" style=""></path><path pointer-events="all" version="1.1"
-      xmlns="http://www.w3.org/1999/xhtml" d="M5.3719019999999995,43.71384600000001 L11.370443503211945,23.391014016385036 L4.676922237205071,29.731106528447754 L-2.6122959683403124,24.085993779179965 L5.3719019999999995,43.71384600000001" class="" stroke="#666" fill="#666" transform="translate(10.5,0.5)"></path><path pointer-events="all" version="1.1"
-      xmlns="http://www.w3.org/1999/xhtml" d="M5.3719019999999995,43.71384600000001 L11.370443503211945,23.391014016385036 L4.676922237205071,29.731106528447754 L-2.6122959683403124,24.085993779179965 L5.3719019999999995,43.71384600000001" class="" stroke="#666" fill="#666" transform="translate(10.5,0.5)"></path></svg><div class="_jsPlumb_endpoint source-endpoint dependency-source-endpoint connected _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 955px; top: 301px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" d="M-1.5508800000000005,66.303232 L9.739006151742196,48.37173817821538 L1.575805362924103,52.656846447727325 L-3.9073794005304716,45.245052815291274 L-1.5508800000000005,66.303232" class="" stroke="#666" fill="#666" transform="translate(10.5,0.5)"></path></svg><div class="_jsPlumb_endpoint source-endpoint dependency-source-endpoint connected _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 675.5px; top: 270px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
       xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
-      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint target-endpoint dependency-target-endpoint _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 955px; top: 261px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint target-endpoint dependency-target-endpoint _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 675.5px; top: 230px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
       xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
-      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint source-endpoint dependency-source-endpoint connected _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 973.5px; top: 684px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint source-endpoint dependency-source-endpoint connected _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 703.5px; top: 398px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
       xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
-      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint target-endpoint dependency-target-endpoint _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 973.5px; top: 644px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint target-endpoint dependency-target-endpoint _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 703.5px; top: 358px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
       xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
-      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint source-endpoint dependency-source-endpoint connected _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 968px; top: 556px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint source-endpoint dependency-source-endpoint connected _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 677.5px; top: 142px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
       xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
-      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint target-endpoint dependency-target-endpoint _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 968px; top: 516px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint source-endpoint dependency-source-endpoint connected _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable" style="position: absolute; height: 20px; width: 20px; left: 700.5px; top: 782px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
       xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
-      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint source-endpoint dependency-source-endpoint connected _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 983px; top: 428px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint target-endpoint dependency-target-endpoint _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 700.5px; top: 742px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
       xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
-      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint target-endpoint dependency-target-endpoint _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 983px; top: 388px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint source-endpoint dependency-source-endpoint connected _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 694px; top: 654px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
       xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
-      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint source-endpoint dependency-source-endpoint connected _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 942px; top: 191px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint target-endpoint dependency-target-endpoint _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 694px; top: 614px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
       xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
-      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint source-endpoint dependency-source-endpoint connected _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable" style="position: absolute; height: 20px; width: 20px; left: 976.5px; top: 783px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint source-endpoint dependency-source-endpoint connected _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 688.5px; top: 526px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
       xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
-      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint target-endpoint dependency-target-endpoint _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 976.5px; top: 743px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint target-endpoint dependency-target-endpoint _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 688.5px; top: 486px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
       xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
       xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div></div></div></body></html>
  ]]>

--- a/DatabaseServices/resources/catalog/Cassandra_Service_Actions.xml
+++ b/DatabaseServices/resources/catalog/Cassandra_Service_Actions.xml
@@ -3,7 +3,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="urn:proactive:jobdescriptor:3.11" xsi:schemaLocation="urn:proactive:jobdescriptor:3.11 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.11/schedulerjob.xsd"  name="Cassandra_Service_Actions" projectName="Cassandra" priority="normal" onTaskError="continueJobExecution"  maxNumberOfExecution="2" >
   <description>
-    <![CDATA[ This workflow manages the life-cycle of Cassandra PCA service. It allows to trigger three possible actions: Pause_PostgreSQL, Resume_PostgreSQL and Finish_PostgreSQL. ]]>
+    <![CDATA[ This workflow manages the life-cycle of Cassandra PCA service. It allows to trigger three possible actions: Pause_Cassandra, Resume_Cassandra and Finish_Cassandra. ]]>
   </description>
   <genericInformation>
     <info name="bucketName" value="database-services"/>

--- a/DatabaseServices/resources/catalog/Oracle_Database_Interaction.xml
+++ b/DatabaseServices/resources/catalog/Oracle_Database_Interaction.xml
@@ -97,7 +97,7 @@ The imported data is exported in a JSON format using the variable $DATAFRAME_JSO
 # In the Java Home location field, use the value: "/usr" to force using the JRE provided in the docker image below (Recommended).
 # Be aware, that the prefix command is internally split by spaces. So paths with spaces won't work.
 # Prepare Docker parameters 
-containerName = 'activeeon/dbconnectors' 
+containerName = 'activeeon/dlm3'
 dockerRunCommand =  'docker run ' 
 dockerParameters = '--rm ' 
 # Prepare ProActive home volume 
@@ -166,7 +166,7 @@ This task uses also the task variable RMDB_DRIVER as a driver to connect to the 
 # In the Java Home location field, use the value: "/usr" to force using the JRE provided in the docker image below (Recommended).
 # Be aware, that the prefix command is internally split by spaces. So paths with spaces won't work.
 # Prepare Docker parameters 
-containerName = 'activeeon/dbconnectors' 
+containerName = 'activeeon/dlm3'
 dockerRunCommand =  'docker run ' 
 dockerParameters = '--rm ' 
 # Prepare ProActive home volume 

--- a/DatabaseServices/resources/catalog/Oracle_Database_Interaction.xml
+++ b/DatabaseServices/resources/catalog/Oracle_Database_Interaction.xml
@@ -1,0 +1,269 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:proactive:jobdescriptor:3.11" xsi:schemaLocation="urn:proactive:jobdescriptor:3.11 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.11/schedulerjob.xsd"  name="Oracle_Database_Interaction" projectName="Oracle Workflows" priority="normal" onTaskError="continueJobExecution"  maxNumberOfExecution="2" >
+  <variables>
+    <variable name="ENV_VARS" value="" />
+    <variable name="ORACLE_DATABASE" value="xe" />
+    <variable name="ORACLE_USER" value="system" />
+  </variables>
+  <description>
+    <![CDATA[ This workflow shows how to deploy and use a PCA Oracle service.
+It demonstrates how to start a Oracle database server using the PCA client API, export and import data from the database then stop the service. ]]>
+  </description>
+  <genericInformation>
+    <info name="bucketName" value="database-services"/>
+    <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/oracle.png"/>
+    <info name="Documentation" value="https://doc.activeeon.com/latest/user/ProActiveUserGuide.html#_sql"/>
+    <info name="group" value="public-objects"/>
+  </genericInformation>
+  <taskFlow>
+    <task name="Parse_Endpoint" >
+      <description>
+        <![CDATA[ This task aims to parse PCA endpoint in order to retrieve a HOST and a PORT number to use them as an input in the data connector tasks. ]]>
+      </description>
+      <depends>
+        <task ref="Start_Oracle"/>
+      </depends>
+      <scriptExecutable>
+        <script>
+          <code language="groovy">
+            <![CDATA[
+def endpoint = new URL(results[0].toString())
+variables.put("ORACLE_HOST",endpoint.getHost())
+variables.put("ORACLE_PORT",endpoint.getPort())
+variables.put("ORACLE_ENV_VARS", variables.get("ENV_VARS"))
+// Wait for database sever to be up and fully running.
+sleep(3000)
+]]>
+          </code>
+        </script>
+      </scriptExecutable>
+    </task>
+    <task name="Start_Oracle" 
+    
+    onTaskError="cancelJob" >
+      <description>
+        <![CDATA[ Start the Oracle server as a service. ]]>
+      </description>
+      <variables>
+        <variable name="SERVICE_ID" value="Oracle" inherited="false" />
+        <variable name="INSTANCE_NAME" value="oracle-server" inherited="false" />
+        <variable name="ENV_VARS" value="" inherited="false" />
+      </variables>
+      <genericInformation>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/oracle.png"/>
+        <info name="task.documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+      </genericInformation>
+      <scriptExecutable>
+        <script>
+          <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Service_Start/raw" language="groovy">
+            <arguments>
+              <argument value="ENV_VARS"/>
+            </arguments>
+          </file>
+        </script>
+      </scriptExecutable>
+      <controlFlow block="none"></controlFlow>
+    </task>
+    <task name="import_from_oracle" >
+      <description>
+        <![CDATA[ Load data from an Oracle SQL database.
+It requires the following third-party credential: {key: oracle://<username>@<host>:<port>, value: ORACLE_PASSWORD}. Please refer to the User documentation to learn how to add third-party credentials.
+It uses the following variables:
+$ORACLE_QUERY (required) is the user's sql query.
+$OUTPUT_FILE (optional) is a relative path in the data space used to save the results in a CSV file.
+$OUTPUT_TYPE (optional) if set to HTML, it allows to preview the results in Scheduler Portal in an HTML format. Default is CSV
+This task uses also the task variable RMDB_DRIVER as a driver to connect to the database. The specified default driver "cx_oracle" is already provided for this task. To use another driver, make sure you have it properly installed before.
+The imported data is exported in a JSON format using the variable $DATAFRAME_JSON. ]]>
+      </description>
+      <variables>
+        <variable name="ORACLE_QUERY" value="select * from diabetes" inherited="false" />
+        <variable name="OUTPUT_FILE" value="" inherited="false" />
+        <variable name="OUTPUT_TYPE" value="CSV" inherited="false" model="PA:List(CSV,HTML)"/>
+      </variables>
+      <genericInformation>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/oracle.png"/>
+        <info name="task.documentation" value="https://doc.activeeon.com/latest/user/ProActiveUserGuide.html#_sql"/>
+      </genericInformation>
+      <depends>
+        <task ref="Export_to_oracle"/>
+      </depends>
+      <forkEnvironment javaHome="/usr" >
+        <envScript>
+          <script>
+            <code language="python">
+              <![CDATA[
+# In the Java Home location field, use the value: "/usr" to force using the JRE provided in the docker image below (Recommended).
+# Be aware, that the prefix command is internally split by spaces. So paths with spaces won't work.
+# Prepare Docker parameters 
+containerName = 'activeeon/dbconnectors' 
+dockerRunCommand =  'docker run ' 
+dockerParameters = '--rm ' 
+# Prepare ProActive home volume 
+paHomeHost = variables.get("PA_SCHEDULER_HOME") 
+paHomeContainer = variables.get("PA_SCHEDULER_HOME") 
+proActiveHomeVolume = '-v '+paHomeHost +':'+paHomeContainer+' ' 
+# Prepare working directory (For Dataspaces and serialized task file) 
+workspaceHost = localspace 
+workspaceContainer = localspace 
+workspaceVolume = '-v '+localspace +':'+localspace+' ' 
+# Prepare container working directory 
+containerWorkingDirectory = '-w '+workspaceContainer+' ' 
+# Save pre execution command into magic variable 'preJavaHomeCmd', which is picked up by the node 
+preJavaHomeCmd = dockerRunCommand + dockerParameters + proActiveHomeVolume + workspaceVolume + containerWorkingDirectory + containerName
+]]>
+            </code>
+          </script>
+        </envScript>
+      </forkEnvironment>
+      <scriptExecutable>
+        <script>
+          <file url="${PA_CATALOG_REST_URL}/buckets/data-connector-scripts/resources/ImportFromSqlDB/raw" language="cpython">
+            <arguments>
+              <argument value="Oracle"/>
+            </arguments>
+          </file>
+        </script>
+      </scriptExecutable>
+      <outputFiles>
+        <files  includes="$OUTPUT_FILE" accessMode="transferToGlobalSpace"/>
+      </outputFiles>
+    </task>
+    <task name="Export_to_oracle" >
+      <description>
+        <![CDATA[ This task allows to export data to Oracle database.
+It requires the following third-party credential: {key: oracle://<username>@<host>:<port>, value: ORACLE_PASSWORD}. Please refer to the User documentation to learn how to add third-party credentials.
+It uses the following variables: 
+$ORACLE_TABLE (required) is the table name.
+$INSERT_MODE (required) indicates the behavior to follow when the table exists in the database amongst: 
+. fail: If table exists, do nothing.
+. replace: If table exists, drop it, recreate it, and insert data.
+. append: (default) If table exists, insert data. Create if does not exist.
+$INPUT_FILE (required) is the relative path in the data space of the CSV file that contains data to be imported. The string could also be a URL. Valid URL schemes include http, ftp, s3, and file. 
+This task uses also the task variable RMDB_DRIVER as a driver to connect to the database. The specified default driver "cx_oracle" is already provided for this task. To use another driver, make sure you have it properly installed before. ]]>
+      </description>
+      <variables>
+        <variable name="ORACLE_TABLE" value="diabetes" inherited="false" />
+        <variable name="INSERT_MODE" value="append" inherited="false" model="PA:LIST(fail, replace, append)"/>
+        <variable name="INPUT_FILE" value="pima-indians-diabetes.csv" inherited="false" />
+      </variables>
+      <genericInformation>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/oracle.png"/>
+        <info name="task.documentation" value="https://doc.activeeon.com/latest/user/ProActiveUserGuide.html#_sql"/>
+      </genericInformation>
+      <depends>
+        <task ref="Parse_Endpoint"/>
+      </depends>
+      <inputFiles>
+        <files  includes="$INPUT_FILE" accessMode="transferFromGlobalSpace"/>
+      </inputFiles>
+      <forkEnvironment javaHome="/usr" >
+        <envScript>
+          <script>
+            <code language="python">
+              <![CDATA[
+# In the Java Home location field, use the value: "/usr" to force using the JRE provided in the docker image below (Recommended).
+# Be aware, that the prefix command is internally split by spaces. So paths with spaces won't work.
+# Prepare Docker parameters 
+containerName = 'activeeon/dbconnectors' 
+dockerRunCommand =  'docker run ' 
+dockerParameters = '--rm ' 
+# Prepare ProActive home volume 
+paHomeHost = variables.get("PA_SCHEDULER_HOME") 
+paHomeContainer = variables.get("PA_SCHEDULER_HOME") 
+proActiveHomeVolume = '-v '+paHomeHost +':'+paHomeContainer+' ' 
+# Prepare working directory (For Dataspaces and serialized task file) 
+workspaceHost = localspace 
+workspaceContainer = localspace 
+workspaceVolume = '-v '+localspace +':'+localspace+' ' 
+# Prepare container working directory 
+containerWorkingDirectory = '-w '+workspaceContainer+' ' 
+# Save pre execution command into magic variable 'preJavaHomeCmd', which is picked up by the node 
+preJavaHomeCmd = dockerRunCommand + dockerParameters + proActiveHomeVolume + workspaceVolume + containerWorkingDirectory + containerName
+]]>
+            </code>
+          </script>
+        </envScript>
+      </forkEnvironment>
+      <scriptExecutable>
+        <script>
+          <file url="${PA_CATALOG_REST_URL}/buckets/data-connector-scripts/resources/ExportToSqlDB/raw" language="cpython">
+            <arguments>
+              <argument value="Oracle"/>
+            </arguments>
+          </file>
+        </script>
+      </scriptExecutable>
+    </task>
+    <task name="Oracle_Service_Action" 
+    
+    onTaskError="cancelJob" >
+      <variables>
+        <variable name="INSTANCE_ID" value="" inherited="false" />
+        <variable name="INSTANCE_NAME" value="oracle-server" inherited="false" />
+        <variable name="ACTION" value="Finish_Oracle" inherited="false" model="PA:LIST(Pause_Oracle, Resume_Oracle, Finish_Oracle)"/>
+      </variables>
+      <genericInformation>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/oracle.png"/>
+        <info name="task.documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+      </genericInformation>
+      <depends>
+        <task ref="import_from_oracle"/>
+      </depends>
+      <scriptExecutable>
+        <script>
+          <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Service_Action/raw" language="groovy"></file>
+        </script>
+      </scriptExecutable>
+      <controlFlow block="none"></controlFlow>
+    </task>
+  </taskFlow>
+  <metadata>
+    <visualization>
+      <![CDATA[ <html><head><link rel="stylesheet" href="/studio/styles/studio-standalone.css"><style>
+        #workflow-designer {
+            left:0 !important;
+            top:0 !important;
+            width:2144px;
+            height:2528px;
+            }
+        </style></head><body><div id="workflow-visualization-view"><div id="workflow-visualization" style="position:relative;top:-171px;left:-616.25px"><div class="task ui-draggable _jsPlumb_endpoint_anchor_" id="jsPlumb_1_670" style="top: 304px; left: 622.25px;"><a class="task-name"><img src="/studio/images/Groovy.png" width="20px">&nbsp;<span class="name">Parse_Endpoint</span></a></div><div class="task _jsPlumb_endpoint_anchor_ ui-draggable active-task" id="jsPlumb_1_673" style="top: 176px; left: 621.25px;"><a class="task-name"><img src="/automation-dashboard/styles/patterns/img/wf-icons/oracle.png" width="20px">&nbsp;<span class="name">Start_Oracle</span></a></div><div class="task ui-draggable _jsPlumb_endpoint_anchor_" id="jsPlumb_1_676" style="top: 560px; left: 621.25px;"><a class="task-name"><img src="/automation-dashboard/styles/patterns/img/wf-icons/oracle.png" width="20px">&nbsp;<span class="name">import_from_oracle</span></a></div><div class="task ui-draggable _jsPlumb_endpoint_anchor_" id="jsPlumb_1_679" style="top: 432px; left: 621.25px;"><a class="task-name"><img src="/automation-dashboard/styles/patterns/img/wf-icons/oracle.png" width="20px">&nbsp;<span class="name">Export_to_oracle</span></a></div><div class="task ui-draggable _jsPlumb_endpoint_anchor_" id="jsPlumb_1_682" style="top: 688px; left: 621.25px;"><a class="task-name"><img src="/automation-dashboard/styles/patterns/img/wf-icons/oracle.png" width="20px">&nbsp;<span class="name">Oracle_Service_Action</span></a></div><svg style="position:absolute;left:660.5px;top:215.5px" width="25" height="89" pointer-events="none" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" class="_jsPlumb_connector "><path d="M 4 88 C 14 38 -10 50 0 0 " transform="translate(10.5,0.5)" pointer-events="visibleStroke" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="none" stroke="#666" style=""></path><path pointer-events="all" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" d="M6.4906875,66.78168750000002 L11.866605249283193,46.285358356640174 L5.369566595211646,52.82664941632405 L-2.0884328343927736,47.40647926142853 L6.4906875,66.78168750000002" class="" stroke="#666" fill="#666" transform="translate(10.5,0.5)"></path><path pointer-events="all" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" d="M6.4906875,66.78168750000002 L11.866605249283193,46.285358356640174 L5.369566595211646,52.82664941632405 L-2.0884328343927736,47.40647926142853 L6.4906875,66.78168750000002" class="" stroke="#666" fill="#666" transform="translate(10.5,0.5)"></path></svg><svg style="position:absolute;left:666px;top:471.5px" width="26" height="89" pointer-events="none" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" class="_jsPlumb_connector "><path d="M 5 88 C 15 38 -10 50 0 0 " transform="translate(10.5,0.5)" pointer-events="visibleStroke" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="none" stroke="#666" style=""></path><path pointer-events="all" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" d="M7.409531250000001,66.78168750000002 L12.520990380459518,46.21781175738666 L6.108748919827519,52.84224829573104 L-1.4184488238094648,47.518594087559144 L7.409531250000001,66.78168750000002" class="" stroke="#666" fill="#666" transform="translate(10.5,0.5)"></path><path pointer-events="all" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" d="M7.409531250000001,66.78168750000002 L12.520990380459518,46.21781175738666 L6.108748919827519,52.84224829573104 L-1.4184488238094648,47.518594087559144 L7.409531250000001,66.78168750000002" class="" stroke="#666" fill="#666" transform="translate(10.5,0.5)"></path></svg><svg style="position:absolute;left:664.5px;top:343.5px" width="22.5" height="89" pointer-events="none" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" class="_jsPlumb_connector "><path d="M 1.5 88 C 11.5 38 -10 50 0 0 " transform="translate(10.5,0.5)" pointer-events="visibleStroke" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="none" stroke="#666" style=""></path><path pointer-events="all" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" d="M4.193578125,66.78168750000002 L10.22883008187672,46.46972713628781 L3.5238641657164487,52.79771513115072 L-3.755142286972582,47.139441095571364 L4.193578125,66.78168750000002" class="" stroke="#666" fill="#666" transform="translate(10.5,0.5)"></path><path pointer-events="all" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" d="M4.193578125,66.78168750000002 L10.22883008187672,46.46972713628781 L3.5238641657164487,52.79771513115072 L-3.755142286972582,47.139441095571364 L4.193578125,66.78168750000002" class="" stroke="#666" fill="#666" transform="translate(10.5,0.5)"></path></svg><svg style="position:absolute;left:671px;top:599.5px" width="29" height="89" pointer-events="none" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" class="_jsPlumb_connector "><path d="M 8 88 C 18 38 -10 50 0 0 " transform="translate(10.5,0.5)" pointer-events="visibleStroke" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="none" stroke="#666" style=""></path><path pointer-events="all" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" d="M10.149632,66.303232 L14.370633382220372,45.538282028201515 L8.249666052974282,52.43275510120006 L0.5001564834204357,47.438247975227235 L10.149632,66.303232" class="" stroke="#666" fill="#666" transform="translate(10.5,0.5)"></path><path pointer-events="all" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" d="M10.149632,66.303232 L14.370633382220372,45.538282028201515 L8.249666052974282,52.43275510120006 L0.5001564834204357,47.438247975227235 L10.149632,66.303232" class="" stroke="#666" fill="#666" transform="translate(10.5,0.5)"></path></svg><div class="_jsPlumb_endpoint source-endpoint dependency-source-endpoint connected _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 665px; top: 334px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint target-endpoint dependency-target-endpoint _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 665px; top: 294px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint source-endpoint dependency-source-endpoint connected _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 661px; top: 206px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint source-endpoint dependency-source-endpoint connected _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 671.5px; top: 590px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint target-endpoint dependency-target-endpoint _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 671.5px; top: 550px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint source-endpoint dependency-source-endpoint connected _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 666.5px; top: 462px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint target-endpoint dependency-target-endpoint _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 666.5px; top: 422px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint source-endpoint dependency-source-endpoint connected _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable" style="position: absolute; height: 20px; width: 20px; left: 679.5px; top: 718px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint target-endpoint dependency-target-endpoint _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 679.5px; top: 678px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div></div></div></body></html>
+ ]]>
+    </visualization>
+  </metadata>
+</job>

--- a/DatabaseServices/resources/catalog/Oracle_Service_Actions.xml
+++ b/DatabaseServices/resources/catalog/Oracle_Service_Actions.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:proactive:jobdescriptor:3.11" xsi:schemaLocation="urn:proactive:jobdescriptor:3.11 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.11/schedulerjob.xsd"  name="Oracle_Service_Actions" projectName="Oracle" priority="normal" onTaskError="continueJobExecution"  maxNumberOfExecution="2" >
+  <description>
+    <![CDATA[ This workflow manages the life-cycle of Oracle PCA service. It allows to trigger three possible actions: Pause_Oracle, Resume_Oracle and Finish_Oracle. ]]>
+  </description>
+  <genericInformation>
+    <info name="bucketName" value="database-services"/>
+    <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/oracle.png"/>
+    <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+    <info name="group" value="public-objects"/>
+  </genericInformation>
+  <taskFlow>
+    <task name="Oracle_Service_Action" 
+    
+    onTaskError="cancelJob" >
+      <variables>
+        <variable name="INSTANCE_ID" value="" inherited="false" />
+        <variable name="INSTANCE_NAME" value="oracle-server" inherited="false" />
+        <variable name="ACTION" value="Finish_Oracle" inherited="false" model="PA:LIST(Pause_Oracle, Resume_Oracle, Finish_Oracle)"/>
+      </variables>
+      <genericInformation>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/oracle.png"/>
+        <info name="task.documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+      </genericInformation>
+      <scriptExecutable>
+        <script>
+          <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Service_Action/raw" language="groovy"></file>
+        </script>
+      </scriptExecutable>
+      <controlFlow block="none"></controlFlow>
+    </task>
+  </taskFlow>
+  <metadata>
+    <visualization>
+      <![CDATA[ <html><head><link rel="stylesheet" href="/studio/styles/studio-standalone.css"><style>
+        #workflow-designer {
+            left:0 !important;
+            top:0 !important;
+            width:2144px;
+            height:2528px;
+            }
+        </style></head><body><div id="workflow-visualization-view"><div id="workflow-visualization" style="position:relative;top:-554px;left:-436.25px"><div class="task _jsPlumb_endpoint_anchor_ ui-draggable active-task" id="jsPlumb_1_640" style="top: 559px; left: 441.25px;"><a class="task-name"><img src="/automation-dashboard/styles/patterns/img/wf-icons/oracle.png" width="20px">&nbsp;<span class="name">Oracle_Service_Action</span></a></div><div class="_jsPlumb_endpoint source-endpoint dependency-source-endpoint connected _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable" style="position: absolute; height: 20px; width: 20px; left: 499.5px; top: 589px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div></div></div></body></html>
+ ]]>
+    </visualization>
+  </metadata>
+</job>

--- a/DatabaseServices/resources/catalog/Oracle_Service_Start.xml
+++ b/DatabaseServices/resources/catalog/Oracle_Service_Start.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:proactive:jobdescriptor:3.11" xsi:schemaLocation="urn:proactive:jobdescriptor:3.11 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.11/schedulerjob.xsd"  name="Oracle_Service_Start" projectName="Oracle" priority="normal" onTaskError="continueJobExecution"  maxNumberOfExecution="2" >
+  <description>
+    <![CDATA[ Start the Oracle server as a service. ]]>
+  </description>
+  <genericInformation>
+    <info name="bucketName" value="database-services"/>
+    <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/oracle.png"/>
+    <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+    <info name="group" value="public-objects"/>
+  </genericInformation>
+  <taskFlow>
+    <task name="Start_Oracle" 
+    
+    onTaskError="cancelJob" >
+      <description>
+        <![CDATA[ Start the Oracle server as a service. ]]>
+      </description>
+      <variables>
+        <variable name="SERVICE_ID" value="Oracle" inherited="false" />
+        <variable name="INSTANCE_NAME" value="oracle-server" inherited="false" />
+        <variable name="ENV_VARS" value="" inherited="false" />
+      </variables>
+      <genericInformation>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/oracle.png"/>
+        <info name="task.documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+      </genericInformation>
+      <scriptExecutable>
+        <script>
+          <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Service_Start/raw" language="groovy">
+            <arguments>
+              <argument value="ENV_VARS"/>
+            </arguments>
+          </file>
+        </script>
+      </scriptExecutable>
+      <controlFlow block="none"></controlFlow>
+    </task>
+  </taskFlow>
+  <metadata>
+    <visualization>
+      <![CDATA[ <html><head><link rel="stylesheet" href="/studio/styles/studio-standalone.css"><style>
+        #workflow-designer {
+            left:0 !important;
+            top:0 !important;
+            width:2864px;
+            height:3444px;
+            }
+        </style></head><body><div id="workflow-visualization-view"><div id="workflow-visualization" style="position:relative;top:-228px;left:-535px"><div class="task _jsPlumb_endpoint_anchor_ ui-draggable" id="jsPlumb_1_784" style="top: 233px; left: 540px;"><a class="task-name"><img src="/automation-dashboard/styles/patterns/img/wf-icons/oracle.png" width="20px">&nbsp;<span class="name">Start_Oracle</span></a></div><div class="_jsPlumb_endpoint source-endpoint dependency-source-endpoint connected _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable" style="position: absolute; height: 20px; width: 20px; left: 580px; top: 263px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div></div></div></body></html>
+ ]]>
+    </visualization>
+  </metadata>
+</job>

--- a/DatabaseServices/resources/test/scenarios.json
+++ b/DatabaseServices/resources/test/scenarios.json
@@ -18,5 +18,9 @@
   {
     "workflow":"Cassandra_Database_Interaction",
     "variables": {}
+  },
+  {
+    "workflow":"Oracle_Database_Interaction",
+    "variables": {}
   }
 ]

--- a/Oracle/METADATA.json
+++ b/Oracle/METADATA.json
@@ -1,0 +1,51 @@
+{
+	"metadata": {
+		"slug": "Oracle",
+		"name": "Oracle Service",
+		"short_description": "Lifecycle management workflow of Oracle Server for Cloud Automation",
+		"author": "ActiveEon's Team",
+		"tags": ["Cloud Automation", "Oracle", "Database", "SQL"],
+		"version": "1.0"
+	},
+	"catalog" : {
+		"bucket" : "cloud-automation",
+		"objects" : [
+			{
+				"name" : "Oracle",
+				"metadata" : {
+					"kind": "Workflow/pca",
+					"commitMessage": "First commit",
+					"contentType": "application/xml"
+				},
+				"file" : "resources/catalog/Oracle.xml"
+			},
+			{
+				"name" : "Finish_Oracle",
+				"metadata" : {
+					"kind": "Workflow/pca",
+					"commitMessage": "First commit",
+					"contentType": "application/xml"
+				},
+				"file" : "resources/catalog/Finish_Oracle.xml"
+			},
+			{
+				"name" : "Resume_Oracle",
+				"metadata" : {
+					"kind": "Workflow/pca",
+					"commitMessage": "First commit",
+					"contentType": "application/xml"
+				},
+				"file" : "resources/catalog/Resume_Oracle.xml"
+			},
+			{
+				"name" : "Pause_Oracle",
+				"metadata" : {
+					"kind": "Workflow/pca",
+					"commitMessage": "First commit",
+					"contentType": "application/xml"
+				},
+				"file" : "resources/catalog/Pause_Oracle.xml"
+			}
+		]
+	}
+}

--- a/Oracle/resources/catalog/Finish_Oracle.xml
+++ b/Oracle/resources/catalog/Finish_Oracle.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:proactive:jobdescriptor:3.11" xsi:schemaLocation="urn:proactive:jobdescriptor:3.11 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.11/schedulerjob.xsd"  name="Finish_Oracle" projectName="Cloud Automation - Lifecycle" priority="normal" onTaskError="continueJobExecution"  maxNumberOfExecution="2" >
+  <description>
+    <![CDATA[ Delete Oracle instance. ]]>
+  </description>
+  <genericInformation>
+    <info name="bucketName" value="cloud-automation"/>
+    <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/oracle.png"/>
+    <info name="pca.states" value="(RUNNING,FINISHED)(PAUSED,FINISHED)(ERROR,FINISHED)"/>
+    <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+    <info name="pca.service.id" value="Oracle"/>
+    <info name="group" value="public-objects"/>
+  </genericInformation>
+  <taskFlow>
+    <task name="Finish_Oracle" >
+      <description>
+        <![CDATA[ Finish Oracle instance and remove its docker container ]]>
+      </description>
+      <genericInformation>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/oracle.png"/>
+        <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+      </genericInformation>
+      <pre>
+        <script>
+          <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Pre_Trigger_Action/raw" language="groovy">
+            <arguments>
+              <argument value="FINISH_LAUNCHED"/>
+            </arguments>
+          </file>
+        </script>
+      </pre>
+      <scriptExecutable>
+        <script>
+          <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Finish_Action/raw" language="bash"></file>
+        </script>
+      </scriptExecutable>
+      <post>
+        <script>
+          <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Post_Trigger_Action/raw" language="groovy">
+            <arguments>
+              <argument value="FINISHED"/>
+            </arguments>
+          </file>
+        </script>
+      </post>
+      <metadata>
+        <positionTop>
+            602
+        </positionTop>
+        <positionLeft>
+            928
+        </positionLeft>
+      </metadata>
+    </task>
+  </taskFlow>
+  <metadata>
+    <visualization>
+      <![CDATA[ <html><head><link rel="stylesheet" href="/studio/styles/studio-standalone.css"><style>
+        #workflow-designer {
+            left:0 !important;
+            top:0 !important;
+            width:2864px;
+            height:3248px;
+            }
+        </style></head><body><div id="workflow-visualization-view"><div id="workflow-visualization" style="position:relative;top:-597px;left:-923px"><div class="task _jsPlumb_endpoint_anchor_ ui-draggable" id="jsPlumb_1_157" style="top: 602px; left: 928px;"><a class="task-name"><img src="/automation-dashboard/styles/patterns/img/wf-icons/oracle.png" width="20px">&nbsp;<span class="name">Finish_Oracle</span></a></div><div class="_jsPlumb_endpoint source-endpoint dependency-source-endpoint connected _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable" style="position: absolute; height: 20px; width: 20px; left: 968px; top: 632px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div></div></div></body></html>
+ ]]>
+    </visualization>
+  </metadata>
+</job>

--- a/Oracle/resources/catalog/Finish_Oracle.xml
+++ b/Oracle/resources/catalog/Finish_Oracle.xml
@@ -45,14 +45,6 @@
           </file>
         </script>
       </post>
-      <metadata>
-        <positionTop>
-            602
-        </positionTop>
-        <positionLeft>
-            928
-        </positionLeft>
-      </metadata>
     </task>
   </taskFlow>
   <metadata>

--- a/Oracle/resources/catalog/Oracle.xml
+++ b/Oracle/resources/catalog/Oracle.xml
@@ -7,10 +7,14 @@
     <variable name="ENV_VARS" value="" />
   </variables>
   <description>
-    <![CDATA[ Deploy a Oracle Database server.
+    <![CDATA[ Deploy an Oracle Database server.
 The service can be started using the following variables:
 $INSTANCE_NAME (Required): service instance name.
-$ENV_VARS (Optional): List of the environment variables. Each environment variable should be preceded by -e. ]]>
+$ENV_VARS (Optional): List of the environment variables. Each environment variable should be preceded by -e.
+This service is based on this docker image: https://hub.docker.com/r/wnameless/oracle-xe-11g/ where the default settings are:
+sid: xe
+username: system
+password: oracle ]]>
   </description>
   <genericInformation>
     <info name="bucketName" value="cloud-automation"/>
@@ -127,6 +131,15 @@ def instanceName = variables.get("INSTANCE_NAME")
 def hostname = new URL(paSchedulerRestUrl).getHost()
 def port = new File(instanceName+"_port").text.trim()
 def endpoint = 'http://'+ hostname + ":" + port
+    
+// Add any credentials to 3rd party credentials if they apply:
+def username = "system"
+def password = "oracle"
+if (!username.isEmpty()){
+    def PASSWORD_KEY = variables.get("PA_JOB_NAME").toLowerCase() + "://" + username + "@" + hostname+ ":" + port
+    schedulerapi.connect()
+    schedulerapi.putThirdPartyCredential(PASSWORD_KEY, password)
+}
 
 /*********************************************************************************
 * THIS PART IS IMAGE SPECIFIC. IF YOU NEED TO MODIFY SOMETHING, DO IT HERE       *
@@ -168,14 +181,6 @@ println("END " + variables.get("PA_TASK_NAME"))
           </code>
         </script>
       </post>
-      <metadata>
-        <positionTop>
-            595
-        </positionTop>
-        <positionLeft>
-            935
-        </positionLeft>
-      </metadata>
     </task>
     <task name="Loop_Over_Instance_Status" >
       <description>
@@ -201,14 +206,6 @@ It will run every minute. ]]>
           </script>
         </loop>
       </controlFlow>
-      <metadata>
-        <positionTop>
-            723
-        </positionTop>
-        <positionLeft>
-            935
-        </positionLeft>
-      </metadata>
     </task>
   </taskFlow>
   <metadata>
@@ -217,26 +214,26 @@ It will run every minute. ]]>
         #workflow-designer {
             left:0 !important;
             top:0 !important;
-            width:2864px;
-            height:3444px;
+            width:2144px;
+            height:2528px;
             }
-        </style></head><body><div id="workflow-visualization-view"><div id="workflow-visualization" style="position:relative;top:-590px;left:-930px"><div class="task _jsPlumb_endpoint_anchor_ ui-draggable" id="jsPlumb_1_142" style="top: 595px; left: 935px;"><a class="task-name"><img src="/automation-dashboard/styles/patterns/img/wf-icons/oracle.png" width="20px">&nbsp;<span class="name">Start_Oracle</span></a></div><div class="task ui-draggable _jsPlumb_endpoint_anchor_" id="jsPlumb_1_145" style="top: 723px; left: 935px;"><a class="task-name"><img src="/automation-dashboard/styles/patterns/img/wf-icons/oracle.png" width="20px">&nbsp;<span class="name">Loop_Over_Instance_Status</span></a></div><svg style="position:absolute;left:974.5px;top:634.5px" width="52" height="89" pointer-events="none" position="absolute" version="1.1"
-      xmlns="http://www.w3.org/1999/xhtml" class="_jsPlumb_connector "><path d="M 31 88 C 41 38 -10 50 0 0 " transform="translate(10.5,0.5)" pointer-events="visibleStroke" version="1.1"
+        </style></head><body><div id="workflow-visualization-view"><div id="workflow-visualization" style="position:relative;top:-273px;left:-417.5px"><div class="task _jsPlumb_endpoint_anchor_ ui-draggable" id="jsPlumb_1_697" style="top: 278px; left: 422.5px;"><a class="task-name"><img src="/automation-dashboard/styles/patterns/img/wf-icons/oracle.png" width="20px">&nbsp;<span class="name">Start_Oracle</span></a></div><div class="task ui-draggable _jsPlumb_endpoint_anchor_" id="jsPlumb_1_700" style="top: 406px; left: 422.5px;"><a class="task-name"><img src="/automation-dashboard/styles/patterns/img/wf-icons/oracle.png" width="20px">&nbsp;<span class="name">Loop_Over_Instance_Status</span></a></div><svg style="position:absolute;left:462.5px;top:317.5px" width="51.5" height="89" pointer-events="none" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" class="_jsPlumb_connector "><path d="M 30.5 88 C 40.5 38 -10 50 0 0 " transform="translate(10.5,0.5)" pointer-events="visibleStroke" version="1.1"
       xmlns="http://www.w3.org/1999/xhtml" fill="none" stroke="#666" style=""></path><path pointer-events="all" version="1.1"
-      xmlns="http://www.w3.org/1999/xhtml" d="M31.05928325,65.8307285 L29.258040903283344,44.71780530096396 L25.327848215286867,53.05768452282437 L16.484996926107705,50.44924033567709 L31.05928325,65.8307285" class="" stroke="#666" fill="#666" transform="translate(10.5,0.5)"></path><path pointer-events="all" version="1.1"
-      xmlns="http://www.w3.org/1999/xhtml" d="M31.05928325,65.8307285 L29.258040903283344,44.71780530096396 L25.327848215286867,53.05768452282437 L16.484996926107705,50.44924033567709 L31.05928325,65.8307285" class="" stroke="#666" fill="#666" transform="translate(10.5,0.5)"></path></svg><svg style="position:absolute;left:1077.0266769263776px;top:672.5px" width="20.473323073622403" height="141" pointer-events="none" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" d="M30.604289125,65.8307285 L28.92065780914319,44.70810116360394 L24.944079219862537,53.025962831320875 L16.11589214046406,50.368311068741406 L30.604289125,65.8307285" class="" stroke="#666" fill="#666" transform="translate(10.5,0.5)"></path><path pointer-events="all" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" d="M30.604289125,65.8307285 L28.92065780914319,44.70810116360394 L24.944079219862537,53.025962831320875 L16.11589214046406,50.368311068741406 L30.604289125,65.8307285" class="" stroke="#666" fill="#666" transform="translate(10.5,0.5)"></path></svg><svg style="position:absolute;left:564.0266769263776px;top:355.5px" width="20.473323073622403" height="141" pointer-events="none" position="absolute" version="1.1"
       xmlns="http://www.w3.org/1999/xhtml" class="_jsPlumb_connector "><path d="M 0 40 C -10 90 -10 -50 0 0 " transform="translate(19.973323073622403,50.5)" pointer-events="visibleStroke" version="1.1"
       xmlns="http://www.w3.org/1999/xhtml" fill="none" stroke="#316b31" style=""></path><path pointer-events="all" version="1.1"
       xmlns="http://www.w3.org/1999/xhtml" d="M-2.4569999999999963,49.16001999999999 L-8.714346841294152,28.91537600442066 L-10.77778447022079,37.90104376767174 L-19.973323073622403,37.23616047464146 L-2.4569999999999963,49.16001999999999" class="" stroke="#316b31" fill="#316b31" transform="translate(19.973323073622403,50.5)"></path><path pointer-events="all" version="1.1"
-      xmlns="http://www.w3.org/1999/xhtml" d="M-2.4569999999999963,49.16001999999999 L-8.714346841294152,28.91537600442066 L-10.77778447022079,37.90104376767174 L-19.973323073622403,37.23616047464146 L-2.4569999999999963,49.16001999999999" class="" stroke="#316b31" fill="#316b31" transform="translate(19.973323073622403,50.5)"></path></svg><div class="_jsPlumb_overlay l1 component label" id="jsPlumb_1_156" style="position: absolute; transform: translate(-50%, -50%); left: 1089px; top: 742.5px;">loop</div><div class="_jsPlumb_endpoint source-endpoint dependency-source-endpoint connected _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 975px; top: 625px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" d="M-2.4569999999999963,49.16001999999999 L-8.714346841294152,28.91537600442066 L-10.77778447022079,37.90104376767174 L-19.973323073622403,37.23616047464146 L-2.4569999999999963,49.16001999999999" class="" stroke="#316b31" fill="#316b31" transform="translate(19.973323073622403,50.5)"></path></svg><div class="_jsPlumb_overlay l1 component label" id="jsPlumb_1_711" style="position: absolute; transform: translate(-50%, -50%); left: 576px; top: 425.5px;">loop</div><div class="_jsPlumb_endpoint source-endpoint dependency-source-endpoint connected _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 463px; top: 308px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
       xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
-      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint source-endpoint dependency-source-endpoint connected _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable" style="position: absolute; height: 20px; width: 20px; left: 1006px; top: 753px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint source-endpoint dependency-source-endpoint connected _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable" style="position: absolute; height: 20px; width: 20px; left: 493.5px; top: 436px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
       xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
-      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint target-endpoint dependency-target-endpoint _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 1006px; top: 713px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint target-endpoint dependency-target-endpoint _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 493.5px; top: 396px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
       xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
-      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint source-endpoint loop-source-endpoint _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected _jsPlumb_endpoint_full" style="position: absolute; height: 20px; width: 20px; left: 1087px; top: 713px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint source-endpoint loop-source-endpoint _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected _jsPlumb_endpoint_full" style="position: absolute; height: 20px; width: 20px; left: 574px; top: 396px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
       xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
-      xmlns="http://www.w3.org/1999/xhtml" fill="#316b31" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint target-endpoint loop-target-endpoint _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected _jsPlumb_endpoint_full" style="position: absolute; height: 20px; width: 20px; left: 1087px; top: 753px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="#316b31" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint target-endpoint loop-target-endpoint _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected _jsPlumb_endpoint_full" style="position: absolute; height: 20px; width: 20px; left: 574px; top: 436px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
       xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
       xmlns="http://www.w3.org/1999/xhtml" fill="#316b31" stroke="none" style=""></circle></svg></div></div></div></body></html>
  ]]>

--- a/Oracle/resources/catalog/Oracle.xml
+++ b/Oracle/resources/catalog/Oracle.xml
@@ -1,0 +1,245 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:proactive:jobdescriptor:3.11" xsi:schemaLocation="urn:proactive:jobdescriptor:3.11 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.11/schedulerjob.xsd"  name="Oracle" projectName="Cloud Automation - Deployment" priority="normal" onTaskError="continueJobExecution"  maxNumberOfExecution="2" >
+  <variables>
+    <variable name="INSTANCE_NAME" value="oracle-server" />
+    <variable name="ENV_VARS" value="" />
+  </variables>
+  <description>
+    <![CDATA[ Deploy a Oracle Database server.
+The service can be started using the following variables:
+$INSTANCE_NAME (Required): service instance name.
+$ENV_VARS (Optional): List of the environment variables. Each environment variable should be preceded by -e. ]]>
+  </description>
+  <genericInformation>
+    <info name="bucketName" value="cloud-automation"/>
+    <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/oracle.png"/>
+    <info name="pca.states" value="(VOID,RUNNING)"/>
+    <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+    <info name="pca.service.id" value="Oracle"/>
+    <info name="group" value="public-objects"/>
+  </genericInformation>
+  <taskFlow>
+    <task name="Start_Oracle" >
+      <description>
+        <![CDATA[ Pull Oracle image and start a container. 
+For more info about the image please refer to https://hub.docker.com/r/wnameless/oracle-xe-11g/ ]]>
+      </description>
+      <genericInformation>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/oracle.png"/>
+        <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+      </genericInformation>
+      <scriptExecutable>
+        <script>
+          <code language="bash">
+            <![CDATA[
+echo BEGIN "$variables_PA_TASK_NAME"
+
+################################################################################
+### THIS PART IS IMAGE SPECIFIC. IF YOU NEED TO MODIFY SOMETHING, DO IT HERE ###
+DOCKER_IMAGE=activeeon/oracle-xe-11g
+PORT=1521
+ENV_VARS=$variables_ENV_VARS
+################################################################################
+
+# Manually find a free random port to preserve it in case if docker (re)start (Pause/Resume)
+GET_RANDOM_PORT(){
+    read LOWERPORT UPPERPORT < /proc/sys/net/ipv4/ip_local_port_range
+    while :
+    do
+        RND_PORT="`shuf -i $LOWERPORT-$UPPERPORT -n 1`"
+        ss -lpn | grep -q ":$RND_PORT " || break
+    done
+    echo $RND_PORT
+}
+
+echo "Pulling "$variables_PA_JOB_NAME" image"
+docker pull $DOCKER_IMAGE
+
+INSTANCE_NAME=$variables_INSTANCE_NAME
+
+if [ -z "$INSTANCE_NAME" ]; then
+    echo ERROR: The INSTANCE_NAME is not provided by the user. Empty value is not allowed.
+    exit 1
+fi
+
+if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
+    RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)
+    STOPPED=$(docker inspect --format="{{ .State.Status }}" $INSTANCE_NAME 2> /dev/null)
+    if [ "$RUNNING" == "true" ]; then
+        echo "$INSTANCE_NAME" container is running
+        echo $INSTANCE_NAME > $INSTANCE_NAME"_status"
+	elif [ "$STOPPED" == "exited" ]; then
+		echo Starting docker container: "$INSTANCE_NAME"
+        INSTANCE_STATUS=$(docker start $INSTANCE_NAME 2>&1)
+        echo $INSTANCE_STATUS > $INSTANCE_NAME"_status"
+    fi
+else
+    ################################################################################
+    ### THIS PART IS IMAGE SPECIFIC. IF YOU NEED TO MODIFY SOMETHING, DO IT HERE ###
+    echo "Running $INSTANCE_NAME container"
+    F_PORT=$(GET_RANDOM_PORT)
+    if [ -z "$ENV_VARS" ]; then
+        INSTANCE_STATUS=$( eval "docker run --name $INSTANCE_NAME -p $F_PORT:$PORT -d $DOCKER_IMAGE" 2>&1)
+    else
+        INSTANCE_STATUS=$( eval "docker run --name $INSTANCE_NAME -p $F_PORT:$PORT "$ENV_VARS" -d $DOCKER_IMAGE" 2>&1)
+    fi
+    ################################################################################
+    if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
+        RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)
+        if [ "$RUNNING" == "true" ]; then
+            echo $INSTANCE_NAME > $INSTANCE_NAME"_status"
+        fi
+    else
+        echo $INSTANCE_STATUS > $INSTANCE_NAME"_status"
+    fi
+fi
+
+port=$(docker inspect --format='{{(index (index .NetworkSettings.Ports "'$PORT'/tcp") 0).HostPort}}' $INSTANCE_NAME)
+echo "$port" > $INSTANCE_NAME"_port"
+
+# Endpoint added to the job variables using a groovy post-script
+]]>
+          </code>
+        </script>
+      </scriptExecutable>
+      <post>
+        <script>
+          <code language="groovy">
+            <![CDATA[
+/*********************************************************************************
+* THIS POSTSCRIPT PROPAGATES USEFUL INFORMATION SUCH AS:                         *
+* 1) SERVICE ENDPOINT (PROTOCOL://HOSTNAME:PORT)                                 *
+* 2) CREDENTIALS (IF THERE ARE ANY) BY ADDING THEM TO 3RD PARTY CREDENTIALS      *
+*********************************************************************************/
+
+import org.ow2.proactive.pca.service.client.ApiClient
+import org.ow2.proactive.pca.service.client.api.ServiceInstanceRestApi
+import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
+
+def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
+def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
+// Acquire service instance id and instance name
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
+def instanceName = variables.get("INSTANCE_NAME")
+
+def hostname = new URL(paSchedulerRestUrl).getHost()
+def port = new File(instanceName+"_port").text.trim()
+def endpoint = 'http://'+ hostname + ":" + port
+
+/*********************************************************************************
+* THIS PART IS IMAGE SPECIFIC. IF YOU NEED TO MODIFY SOMETHING, DO IT HERE       *
+/********************************************************************************/
+
+/********************************************************************************/
+
+// Connect to Cloud Automation API
+def apiClient = new ApiClient()
+apiClient.setBasePath(pcaUrl)
+def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
+
+// Update service instance data : (status, endpoint)
+def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
+def status = new File(instanceName+"_status").text.trim()
+def currentStatus = (!status.equals(instanceName)) ? "ERROR" : "RUNNING"
+serviceInstanceData.setInstanceStatus(currentStatus)
+serviceInstanceData = serviceInstanceData.putInstanceEndpointsItem(instanceName, endpoint)
+serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+
+// Print warning or error messages and force job to exit with error if there are any.
+if (!status.equals(instanceName)){
+    println("[ERROR] Could not start docker container: " + instanceName + ". Docker output: " + status)
+    System.exit(1)
+}
+
+// Inform other platforms that service is running through Synchronization API
+def channel = "Service_Instance_" + instanceId
+synchronizationapi.createChannelIfAbsent(channel, false)
+synchronizationapi.put(channel, "RUNNING", true)
+synchronizationapi.put(channel, "INSTANCE_NAME", instanceName)
+
+// LOG OUTPUT
+println(variables.get("PA_JOB_NAME") + "_INSTANCE_ID: " + instanceId)
+println(variables.get("PA_JOB_NAME") + "_ENDPOINT: " + endpoint)
+
+println("END " + variables.get("PA_TASK_NAME"))
+]]>
+          </code>
+        </script>
+      </post>
+      <metadata>
+        <positionTop>
+            595
+        </positionTop>
+        <positionLeft>
+            935
+        </positionLeft>
+      </metadata>
+    </task>
+    <task name="Loop_Over_Instance_Status" >
+      <description>
+        <![CDATA[ Loop over service instance status and fetch docker container logs.
+It will run every minute. ]]>
+      </description>
+      <genericInformation>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/oracle.png"/>
+        <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+      </genericInformation>
+      <depends>
+        <task ref="Start_Oracle"/>
+      </depends>
+      <scriptExecutable>
+        <script>
+          <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Check_Instance_Status/raw" language="groovy"></file>
+        </script>
+      </scriptExecutable>
+      <controlFlow >
+        <loop target="Loop_Over_Instance_Status">
+          <script>
+            <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Fetch_Logs/raw" language="groovy"></file>
+          </script>
+        </loop>
+      </controlFlow>
+      <metadata>
+        <positionTop>
+            723
+        </positionTop>
+        <positionLeft>
+            935
+        </positionLeft>
+      </metadata>
+    </task>
+  </taskFlow>
+  <metadata>
+    <visualization>
+      <![CDATA[ <html><head><link rel="stylesheet" href="/studio/styles/studio-standalone.css"><style>
+        #workflow-designer {
+            left:0 !important;
+            top:0 !important;
+            width:2864px;
+            height:3444px;
+            }
+        </style></head><body><div id="workflow-visualization-view"><div id="workflow-visualization" style="position:relative;top:-590px;left:-930px"><div class="task _jsPlumb_endpoint_anchor_ ui-draggable" id="jsPlumb_1_142" style="top: 595px; left: 935px;"><a class="task-name"><img src="/automation-dashboard/styles/patterns/img/wf-icons/oracle.png" width="20px">&nbsp;<span class="name">Start_Oracle</span></a></div><div class="task ui-draggable _jsPlumb_endpoint_anchor_" id="jsPlumb_1_145" style="top: 723px; left: 935px;"><a class="task-name"><img src="/automation-dashboard/styles/patterns/img/wf-icons/oracle.png" width="20px">&nbsp;<span class="name">Loop_Over_Instance_Status</span></a></div><svg style="position:absolute;left:974.5px;top:634.5px" width="52" height="89" pointer-events="none" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" class="_jsPlumb_connector "><path d="M 31 88 C 41 38 -10 50 0 0 " transform="translate(10.5,0.5)" pointer-events="visibleStroke" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="none" stroke="#666" style=""></path><path pointer-events="all" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" d="M31.05928325,65.8307285 L29.258040903283344,44.71780530096396 L25.327848215286867,53.05768452282437 L16.484996926107705,50.44924033567709 L31.05928325,65.8307285" class="" stroke="#666" fill="#666" transform="translate(10.5,0.5)"></path><path pointer-events="all" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" d="M31.05928325,65.8307285 L29.258040903283344,44.71780530096396 L25.327848215286867,53.05768452282437 L16.484996926107705,50.44924033567709 L31.05928325,65.8307285" class="" stroke="#666" fill="#666" transform="translate(10.5,0.5)"></path></svg><svg style="position:absolute;left:1077.0266769263776px;top:672.5px" width="20.473323073622403" height="141" pointer-events="none" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" class="_jsPlumb_connector "><path d="M 0 40 C -10 90 -10 -50 0 0 " transform="translate(19.973323073622403,50.5)" pointer-events="visibleStroke" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="none" stroke="#316b31" style=""></path><path pointer-events="all" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" d="M-2.4569999999999963,49.16001999999999 L-8.714346841294152,28.91537600442066 L-10.77778447022079,37.90104376767174 L-19.973323073622403,37.23616047464146 L-2.4569999999999963,49.16001999999999" class="" stroke="#316b31" fill="#316b31" transform="translate(19.973323073622403,50.5)"></path><path pointer-events="all" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" d="M-2.4569999999999963,49.16001999999999 L-8.714346841294152,28.91537600442066 L-10.77778447022079,37.90104376767174 L-19.973323073622403,37.23616047464146 L-2.4569999999999963,49.16001999999999" class="" stroke="#316b31" fill="#316b31" transform="translate(19.973323073622403,50.5)"></path></svg><div class="_jsPlumb_overlay l1 component label" id="jsPlumb_1_156" style="position: absolute; transform: translate(-50%, -50%); left: 1089px; top: 742.5px;">loop</div><div class="_jsPlumb_endpoint source-endpoint dependency-source-endpoint connected _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 975px; top: 625px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint source-endpoint dependency-source-endpoint connected _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable" style="position: absolute; height: 20px; width: 20px; left: 1006px; top: 753px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint target-endpoint dependency-target-endpoint _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 1006px; top: 713px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint source-endpoint loop-source-endpoint _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected _jsPlumb_endpoint_full" style="position: absolute; height: 20px; width: 20px; left: 1087px; top: 713px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="#316b31" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint target-endpoint loop-target-endpoint _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected _jsPlumb_endpoint_full" style="position: absolute; height: 20px; width: 20px; left: 1087px; top: 753px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="#316b31" stroke="none" style=""></circle></svg></div></div></div></body></html>
+ ]]>
+    </visualization>
+  </metadata>
+</job>

--- a/Oracle/resources/catalog/Pause_Oracle.xml
+++ b/Oracle/resources/catalog/Pause_Oracle.xml
@@ -45,14 +45,6 @@
           </file>
         </script>
       </post>
-      <metadata>
-        <positionTop>
-            649
-        </positionTop>
-        <positionLeft>
-            902
-        </positionLeft>
-      </metadata>
     </task>
   </taskFlow>
   <metadata>

--- a/Oracle/resources/catalog/Pause_Oracle.xml
+++ b/Oracle/resources/catalog/Pause_Oracle.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:proactive:jobdescriptor:3.11" xsi:schemaLocation="urn:proactive:jobdescriptor:3.11 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.11/schedulerjob.xsd"  name="Pause_Oracle" projectName="Cloud Automation - Lifecycle" priority="normal" onTaskError="continueJobExecution"  maxNumberOfExecution="2" >
+  <description>
+    <![CDATA[ Pause Oracle instance. ]]>
+  </description>
+  <genericInformation>
+    <info name="bucketName" value="cloud-automation"/>
+    <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/oracle.png"/>
+    <info name="pca.states" value="(RUNNING,PAUSED)"/>
+    <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+    <info name="pca.service.id" value="Oracle"/>
+    <info name="group" value="public-objects"/>
+  </genericInformation>
+  <taskFlow>
+    <task name="Pause_Oracle" >
+      <description>
+        <![CDATA[ Pause Oracle instance ]]>
+      </description>
+      <genericInformation>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/oracle.png"/>
+        <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+      </genericInformation>
+      <pre>
+        <script>
+          <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Pre_Trigger_Action/raw" language="groovy">
+            <arguments>
+              <argument value="PAUSE_LAUNCHED"/>
+            </arguments>
+          </file>
+        </script>
+      </pre>
+      <scriptExecutable>
+        <script>
+          <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Pause_Action/raw" language="bash"></file>
+        </script>
+      </scriptExecutable>
+      <post>
+        <script>
+          <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Post_Trigger_Action/raw" language="groovy">
+            <arguments>
+              <argument value="PAUSED"/>
+            </arguments>
+          </file>
+        </script>
+      </post>
+      <metadata>
+        <positionTop>
+            649
+        </positionTop>
+        <positionLeft>
+            902
+        </positionLeft>
+      </metadata>
+    </task>
+  </taskFlow>
+  <metadata>
+    <visualization>
+      <![CDATA[ <html><head><link rel="stylesheet" href="/studio/styles/studio-standalone.css"><style>
+        #workflow-designer {
+            left:0 !important;
+            top:0 !important;
+            width:2864px;
+            height:3248px;
+            }
+        </style></head><body><div id="workflow-visualization-view"><div id="workflow-visualization" style="position:relative;top:-644px;left:-897px"><div class="task _jsPlumb_endpoint_anchor_ ui-draggable" id="jsPlumb_1_160" style="top: 649px; left: 902px;"><a class="task-name"><img src="/automation-dashboard/styles/patterns/img/wf-icons/oracle.png" width="20px">&nbsp;<span class="name">Pause_Oracle</span></a></div><div class="_jsPlumb_endpoint source-endpoint dependency-source-endpoint connected _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable" style="position: absolute; height: 20px; width: 20px; left: 942px; top: 679px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div></div></div></body></html>
+ ]]>
+    </visualization>
+  </metadata>
+</job>

--- a/Oracle/resources/catalog/Resume_Oracle.xml
+++ b/Oracle/resources/catalog/Resume_Oracle.xml
@@ -38,14 +38,6 @@ It will run every minute. ]]>
           </script>
         </loop>
       </controlFlow>
-      <metadata>
-        <positionTop>
-            756
-        </positionTop>
-        <positionLeft>
-            909
-        </positionLeft>
-      </metadata>
     </task>
     <task name="Resume_Oracle" >
       <description>
@@ -78,14 +70,6 @@ It will run every minute. ]]>
           </file>
         </script>
       </post>
-      <metadata>
-        <positionTop>
-            628
-        </positionTop>
-        <positionLeft>
-            909
-        </positionLeft>
-      </metadata>
     </task>
   </taskFlow>
   <metadata>

--- a/Oracle/resources/catalog/Resume_Oracle.xml
+++ b/Oracle/resources/catalog/Resume_Oracle.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:proactive:jobdescriptor:3.11" xsi:schemaLocation="urn:proactive:jobdescriptor:3.11 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.11/schedulerjob.xsd"  name="Resume_Oracle" projectName="Cloud Automation - Lifecycle" priority="normal" onTaskError="continueJobExecution"  maxNumberOfExecution="2" >
+  <description>
+    <![CDATA[ Resume Oracle instance. ]]>
+  </description>
+  <genericInformation>
+    <info name="bucketName" value="cloud-automation"/>
+    <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/oracle.png"/>
+    <info name="pca.states" value="(PAUSED,RUNNING)"/>
+    <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+    <info name="pca.service.id" value="Oracle"/>
+    <info name="group" value="public-objects"/>
+  </genericInformation>
+  <taskFlow>
+    <task name="Loop_Over_Instance_Status" >
+      <description>
+        <![CDATA[ Loop over service instance status and fetch docker container logs.
+It will run every minute. ]]>
+      </description>
+      <genericInformation>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/oracle.png"/>
+        <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+      </genericInformation>
+      <depends>
+        <task ref="Resume_Oracle"/>
+      </depends>
+      <scriptExecutable>
+        <script>
+          <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Check_Instance_Status/raw" language="groovy"></file>
+        </script>
+      </scriptExecutable>
+      <controlFlow >
+        <loop target="Loop_Over_Instance_Status">
+          <script>
+            <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Fetch_Logs/raw" language="groovy"></file>
+          </script>
+        </loop>
+      </controlFlow>
+      <metadata>
+        <positionTop>
+            756
+        </positionTop>
+        <positionLeft>
+            909
+        </positionLeft>
+      </metadata>
+    </task>
+    <task name="Resume_Oracle" >
+      <description>
+        <![CDATA[ Resume Oracle instance ]]>
+      </description>
+      <genericInformation>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/oracle.png"/>
+        <info name="Documentation" value="https://doc.activeeon.com/latest/PCA/PCAUserGuide.html"/>
+      </genericInformation>
+      <pre>
+        <script>
+          <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Pre_Trigger_Action/raw" language="groovy">
+            <arguments>
+              <argument value="RESUME_LAUNCHED"/>
+            </arguments>
+          </file>
+        </script>
+      </pre>
+      <scriptExecutable>
+        <script>
+          <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Resume_Action/raw" language="bash"></file>
+        </script>
+      </scriptExecutable>
+      <post>
+        <script>
+          <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Post_Trigger_Action/raw" language="groovy">
+            <arguments>
+              <argument value="RUNNING"/>
+            </arguments>
+          </file>
+        </script>
+      </post>
+      <metadata>
+        <positionTop>
+            628
+        </positionTop>
+        <positionLeft>
+            909
+        </positionLeft>
+      </metadata>
+    </task>
+  </taskFlow>
+  <metadata>
+    <visualization>
+      <![CDATA[ <html><head><link rel="stylesheet" href="/studio/styles/studio-standalone.css"><style>
+        #workflow-designer {
+            left:0 !important;
+            top:0 !important;
+            width:2864px;
+            height:3248px;
+            }
+        </style></head><body><div id="workflow-visualization-view"><div id="workflow-visualization" style="position:relative;top:-623px;left:-904px"><div class="task ui-draggable _jsPlumb_endpoint_anchor_" id="jsPlumb_1_163" style="top: 756px; left: 909px;"><a class="task-name"><img src="/automation-dashboard/styles/patterns/img/wf-icons/oracle.png" width="20px">&nbsp;<span class="name">Loop_Over_Instance_Status</span></a></div><div class="task _jsPlumb_endpoint_anchor_ ui-draggable" id="jsPlumb_1_166" style="top: 628px; left: 909px;"><a class="task-name"><img src="/automation-dashboard/styles/patterns/img/wf-icons/oracle.png" width="20px">&nbsp;<span class="name">Resume_Oracle</span></a></div><svg style="position:absolute;left:952px;top:667.5px" width="48.5" height="89" pointer-events="none" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" class="_jsPlumb_connector "><path d="M 27.5 88 C 37.5 38 -10 50 0 0 " transform="translate(10.5,0.5)" pointer-events="visibleStroke" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="none" stroke="#666" style=""></path><path pointer-events="all" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" d="M27.874324375,65.8307285 L26.909461410455734,44.66308717037495 L22.65251929621236,52.841011346838144 L13.919744257293866,49.88489224916259 L27.874324375,65.8307285" class="" stroke="#666" fill="#666" transform="translate(10.5,0.5)"></path><path pointer-events="all" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" d="M27.874324375,65.8307285 L26.909461410455734,44.66308717037495 L22.65251929621236,52.841011346838144 L13.919744257293866,49.88489224916259 L27.874324375,65.8307285" class="" stroke="#666" fill="#666" transform="translate(10.5,0.5)"></path></svg><svg style="position:absolute;left:1051.0266769263776px;top:705.5px" width="20.473323073622403" height="141" pointer-events="none" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" class="_jsPlumb_connector "><path d="M 0 40 C -10 90 -10 -50 0 0 " transform="translate(19.973323073622403,50.5)" pointer-events="visibleStroke" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="none" stroke="#316b31" style=""></path><path pointer-events="all" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" d="M-2.4569999999999963,49.16001999999999 L-8.714346841294152,28.91537600442066 L-10.77778447022079,37.90104376767174 L-19.973323073622403,37.23616047464146 L-2.4569999999999963,49.16001999999999" class="" stroke="#316b31" fill="#316b31" transform="translate(19.973323073622403,50.5)"></path><path pointer-events="all" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" d="M-2.4569999999999963,49.16001999999999 L-8.714346841294152,28.91537600442066 L-10.77778447022079,37.90104376767174 L-19.973323073622403,37.23616047464146 L-2.4569999999999963,49.16001999999999" class="" stroke="#316b31" fill="#316b31" transform="translate(19.973323073622403,50.5)"></path></svg><div class="_jsPlumb_overlay l1 component label" id="jsPlumb_1_177" style="position: absolute; transform: translate(-50%, -50%); left: 1063px; top: 775.5px;">loop</div><div class="_jsPlumb_endpoint source-endpoint dependency-source-endpoint connected _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable" style="position: absolute; height: 20px; width: 20px; left: 980px; top: 786px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint target-endpoint dependency-target-endpoint _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 980px; top: 746px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint source-endpoint loop-source-endpoint _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected _jsPlumb_endpoint_full" style="position: absolute; height: 20px; width: 20px; left: 1061px; top: 746px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="#316b31" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint target-endpoint loop-target-endpoint _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected _jsPlumb_endpoint_full" style="position: absolute; height: 20px; width: 20px; left: 1061px; top: 786px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="#316b31" stroke="none" style=""></circle></svg></div><div class="_jsPlumb_endpoint source-endpoint dependency-source-endpoint connected _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable _jsPlumb_endpoint_connected" style="position: absolute; height: 20px; width: 20px; left: 952.5px; top: 658px;"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1"
+      xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div></div></div></body></html>
+ ]]>
+    </visualization>
+  </metadata>
+</job>


### PR DESCRIPTION
In this PR, we:
1- Add oracle as a PCA service to cloud-automation bucket
2- Remove all useless ML related stuff from Cassandra workflow and update Cassandra-database-interaction workflow accordingly.
3- Remove the unused `RDBMS_DRIVER` task variable from all SQL data connector workflows 
4- Adapt Oracle jdbc Url in SQL_Pooled_Connection_Update and SQL_Pooled_Connection_Query workflows
5- Add Oracle_Service_Start, Oracle_Service_Actions and Oracle_Database_Interaction workflow to the database-service bucket
6- Add SQL_Pooled_Connection_Update, SQL_Pooled_Connection_Query and Oracle_Database_Interaction to workflow-test