### PR TITLE
fix: change example awsec2 nodesource ram size 

### DIFF
--- a/NodeSources/resources/catalog/AwsEC2Cloud.json
+++ b/NodeSources/resources/catalog/AwsEC2Cloud.json
@@ -95,7 +95,7 @@
       },
       {
         "name": "ram",
-        "value": "2048",
+        "value": "4096",
         "meta": {
           "type": "NONE",
           "description": "(optional) The minimum RAM required (in Mega Bytes) for each VM",

--- a/NodeSources/resources/catalog/AwsEC2CloudElastic.json
+++ b/NodeSources/resources/catalog/AwsEC2CloudElastic.json
@@ -95,7 +95,7 @@
       },
       {
         "name": "ram",
-        "value": "2048",
+        "value": "4096",
         "meta": {
           "type": "NONE",
           "description": "(optional) The minimum RAM required (in Mega Bytes) for each VM",


### PR DESCRIPTION
Change example AWSEC2Infrastructure nodesource ram size (2048->4096) to fix the nodes connection pb because of OutOfMemoryError.