### PR TITLE
remove '$' from the name of variables in the description tag

### DIFF
--- a/Cassandra/resources/catalog/Cassandra.xml
+++ b/Cassandra/resources/catalog/Cassandra.xml
@@ -12,8 +12,8 @@
   <description>
     <![CDATA[ Deploy a Cassandra Database server.
 The service can be started using the following variables:
-$INSTANCE_NAME (Required): service instance name.
-$ENV_VARS (Optional): List of the environment variables. Each environment variable should be preceded by -e. ]]>
+INSTANCE_NAME (Required): service instance name.
+ENV_VARS (Optional): List of the environment variables. Each environment variable should be preceded by -e. ]]>
   </description>
   <genericInformation>
     <info name="bucketName" value="cloud-automation"/>

--- a/Controls/resources/catalog/execute_action_PCA_service.xml
+++ b/Controls/resources/catalog/execute_action_PCA_service.xml
@@ -10,9 +10,9 @@
     </variables>
     <description>
         <![CDATA[ This workflow allows to manage the life-cycle of an active PCA service by executing an action such as Finish_XXXX, Pause_XXX... from the client side. It requires the following variables:
-$INSTANCED_ID is the instance id of the active service (to be retrieved from the Activated Service list in the cloud-automation portal)
-$ACTION is the name of the action to be executed. Possible actions are listed in the Full Services View of the started service in the cloud-automation portal.
-$ACTION_VARS (optional) is a map as a String (['k1': 'v1', 'k2': 'v2', ....]) that contains a set of initialized variables used to execute the action. Note that only variables of the corresponding PCA service on the cloud automation side can be initialized. ]]>
+INSTANCED_ID is the instance id of the active service (to be retrieved from the Activated Service list in the cloud-automation portal)
+ACTION is the name of the action to be executed. Possible actions are listed in the Full Services View of the started service in the cloud-automation portal.
+ACTION_VARS (optional) is a map as a String (['k1': 'v1', 'k2': 'v2', ....]) that contains a set of initialized variables used to execute the action. Note that only variables of the corresponding PCA service on the cloud automation side can be initialized. ]]>
     </description>
     <genericInformation>
         <info name="workflow.icon"

--- a/Controls/resources/catalog/trigger_PCA_service.xml
+++ b/Controls/resources/catalog/trigger_PCA_service.xml
@@ -9,9 +9,9 @@
     </variables>
     <description>
         <![CDATA[ This task allows to start a PCA service from the client side. It uses the following variables:
-$SERVICE_ID (required) is the service id. You have to provide an existing SERVICE_ID from the Service Activation list in the Cloud Automation portal e.g. MongoDB, MySQL, Kibana ... .
-$SERVICE_VARS (optional) is a map as a String (['k1': 'v1', 'k2': 'v2', ....]) that contains a set of initialized variables used to start the service. Note that only variables of the corresponding PCA service on the cloud automation side can be initialized.
-$STARTING_STATE (optional) indicates the starting state of the service. The default value is `RUNNING`. ]]>
+SERVICE_ID (required) is the service id. You have to provide an existing SERVICE_ID from the Service Activation list in the Cloud Automation portal e.g. MongoDB, MySQL, Kibana ... .
+SERVICE_VARS (optional) is a map as a String (['k1': 'v1', 'k2': 'v2', ....]) that contains a set of initialized variables used to start the service. Note that only variables of the corresponding PCA service on the cloud automation side can be initialized.
+STARTING_STATE (optional) indicates the starting state of the service. The default value is `RUNNING`. ]]>
     </description>
     <genericInformation>
         <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/start_PCA_service.png"/>

--- a/DataConnectors/resources/catalog/AWS_S3.xml
+++ b/DataConnectors/resources/catalog/AWS_S3.xml
@@ -26,11 +26,11 @@
         <![CDATA[ This task allows to export data to S3.
 The task requires the following third-party credential: {key: ACCESS_KEY, value: SECRET_KEY} Please refer to the User documentation to learn how to add third-party credentials.
 It uses the following variables:
-$BUCKET (required) is the bucket name.
-$REGION (required) is the region where your bucket resides.
-$LOCAL_RELATIVE_PATH (optional) is the local relative path from which we upload file(s). LOCAL_RELATIVE_PATH can contain either a path to a file, a directory terminated by / or an empty value if you want to upload the entire localspace (user or global).
-$REMOTE_RELATIVE_PATH (optional) is the remote relative path to which we upload file(s). Empty value is allowed.
-$ACCESS_KEY (required) is the s3 user access key. ]]>
+BUCKET (required) is the bucket name.
+REGION (required) is the region where your bucket resides.
+LOCAL_RELATIVE_PATH (optional) is the local relative path from which we upload file(s). LOCAL_RELATIVE_PATH can contain either a path to a file, a directory terminated by / or an empty value if you want to upload the entire localspace (user or global).
+REMOTE_RELATIVE_PATH (optional) is the remote relative path to which we upload file(s). Empty value is allowed.
+ACCESS_KEY (required) is the s3 user access key. ]]>
       </description>
       <variables>
         <variable name="BUCKET" value="" inherited="false" />
@@ -369,10 +369,10 @@ def checkParametersAndReturnSecretKey() {
         <![CDATA[ This task allows to export data to S3.
 The task requires the following third-party credential: {key: ACCESS_KEY, value: SECRET_KEY} Please refer to the User documentation to learn how to add third-party credentials.
 It uses the following variables:
-$URL (required) is the s3 Url that should respect a certain format.
-$LOCAL_RELATIVE_PATH (required) is the local relative path to which we download file(s). LOCAL_RELATIVE_PATH can contain either a path to a file, a directory terminated by / or an empty value for the root.
-$LOCAL_RELATIVE_PATH (optional) is the local relative path to which we download file(s). LOCAL_RELATIVE_PATH can contain either a path to a file, a directory terminated by / or an empty value if you want to download file(s) to the root of the localspace (user or global).
-$ACCESS_KEY (required) is the s3 user access key. ]]>
+URL (required) is the s3 Url that should respect a certain format.
+LOCAL_RELATIVE_PATH (required) is the local relative path to which we download file(s). LOCAL_RELATIVE_PATH can contain either a path to a file, a directory terminated by / or an empty value for the root.
+LOCAL_RELATIVE_PATH (optional) is the local relative path to which we download file(s). LOCAL_RELATIVE_PATH can contain either a path to a file, a directory terminated by / or an empty value if you want to download file(s) to the root of the localspace (user or global).
+ACCESS_KEY (required) is the s3 user access key. ]]>
       </description>
       <variables>
         <variable name="LOCAL_RELATIVE_PATH" value="" inherited="false" />

--- a/DataConnectors/resources/catalog/Azure_Blob_Storage.xml
+++ b/DataConnectors/resources/catalog/Azure_Blob_Storage.xml
@@ -27,10 +27,10 @@ Besides, this workflow template requires the following third-party credential: {
         <![CDATA[ This task allows to export data to Azure Blob Storage.
 The task requires the following third-party credential: {key: STORAGE_ACCOUNT, value: ACCOUNT_KEY}. Please refer to the User documentation to learn how to add third-party credentials.
 It uses the following variables:
-$INPUT_PATH (optional) is the local relative path in the data space from which we upload file(s). INPUT_PATH can contain either a path to a file, a directory terminated by / or an empty value for the root.
-$CONTAINER_NAME (required) is a new or an existing container name under which your uploaded data will be stored.
-$BLOB_NAME (optional) is the blob name or the directory to which file(s) are uploaded. It can be empty if the INPUT_PATH contains a path to a directory.
-$STORAGE_ACCOUNT (required) is the storage account name. ]]>
+INPUT_PATH (optional) is the local relative path in the data space from which we upload file(s). INPUT_PATH can contain either a path to a file, a directory terminated by / or an empty value for the root.
+CONTAINER_NAME (required) is a new or an existing container name under which your uploaded data will be stored.
+BLOB_NAME (optional) is the blob name or the directory to which file(s) are uploaded. It can be empty if the INPUT_PATH contains a path to a directory.
+STORAGE_ACCOUNT (required) is the storage account name. ]]>
       </description>
       <variables>
         <variable name="INPUT_PATH" value="" inherited="false" />
@@ -277,10 +277,10 @@ def checkParametersAndReturnAccountKey() {
         <![CDATA[ This task allows to import data from Azure Blob Storage.
 The task requires the following third-party credential: {key: STORAGE_ACCOUNT, value: ACCOUNT_KEY}. Please refer to the User documentation to learn how to add third-party credentials.
 It uses the following variables:
-$OUTPUT_PATH (optional) is the local relative path in the data space in which the downloaded data are stored. OUTPUT_PATH can contain either a path to a file, a directory terminated by / or an empty value for the root.
-$CONTAINER_NAME (required) is an existing container name from which you download blob(s).
-$BLOB_NAME (optional) is the blob name to be downloaded. If it is empty, the entire container is downloaded.
-$STORAGE_ACCOUNT (required) is the storage account name. ]]>
+OUTPUT_PATH (optional) is the local relative path in the data space in which the downloaded data are stored. OUTPUT_PATH can contain either a path to a file, a directory terminated by / or an empty value for the root.
+CONTAINER_NAME (required) is an existing container name from which you download blob(s).
+BLOB_NAME (optional) is the blob name to be downloaded. If it is empty, the entire container is downloaded.
+STORAGE_ACCOUNT (required) is the storage account name. ]]>
       </description>
       <variables>
         <variable name="OUTPUT_PATH" value="" inherited="false" />

--- a/DataConnectors/resources/catalog/Cassandra.xml
+++ b/DataConnectors/resources/catalog/Cassandra.xml
@@ -22,9 +22,9 @@
         <![CDATA[ This task allows importing data from Cassandra.
 The task requires the following third-party credentials: CASSANDRA_USERNAME and CASSANDRA_PASSWORD. Please refer to the User documentation to learn how to add third-party credentials.
 It requires the following variables:
-$CASSANDRA_KEYSPACE: Keyspace to use.
-$CASSANDRA_QUERY: Query to fetch data.
-$CASSANDRA_OUPUT: Relative path in the data space used to save the results in a CSV file. ]]>
+CASSANDRA_KEYSPACE: Keyspace to use.
+CASSANDRA_QUERY: Query to fetch data.
+CASSANDRA_OUPUT: Relative path in the data space used to save the results in a CSV file. ]]>
       </description>
       <variables>
         <variable name="LABEL" value="" inherited="false" />
@@ -154,9 +154,9 @@ print("END Import_Data")
         <![CDATA[ This task allows exporting data to Cassandra.
 The task requires the following third-party credentials: CASSANDRA_USERNAME and CASSANDRA_PASSWORD. Please refer to the User documentation to learn how to add third-party credentials.
 It requires the following variables:
-$CASSANDRA_TABLE (required) Data is stored in tables containing rows of columns, similar to SQL definitions.. It is created if it does not exist
-$CASSANDRA_KEY (required) A primary key identifies the location and order of stored data. The primary key is defined when the table is created and cannot be altered.
-$CASSANDRA_INPUT (required) is the relative path of the CSV file that contains data to be imported. This variable can:
+CASSANDRA_TABLE (required) Data is stored in tables containing rows of columns, similar to SQL definitions.. It is created if it does not exist
+CASSANDRA_KEY (required) A primary key identifies the location and order of stored data. The primary key is defined when the table is created and cannot be altered.
+CASSANDRA_INPUT (required) is the relative path of the CSV file that contains data to be imported. This variable can:
  - An URL. Valid URL schemes include http, ftp, s3, and file. 
  - A relative path in the data space of a csv file. ]]>
       </description>

--- a/DataConnectors/resources/catalog/ElasticSearch.xml
+++ b/DataConnectors/resources/catalog/ElasticSearch.xml
@@ -136,10 +136,10 @@ print("END Import Data from Elasticsearch")
       <description>
         <![CDATA[ This task allows exporting data to ElasticSearch.
 It uses the following variables:
-$ELASTICSEARCH_USER (optional) If your server requires authentification, then please add the corresponding password to 3rd party credentials under the key: elasticsearch://<ELASTICSEARCH_USER>@<ELASTICSEARCH_HOST>:<ELASTICSEARCH_PORT>
-$ELASTICSEARCH_INDEX (required) the index to use. It is created if it does not exist
-$ELASTICSEARCH_DOC_TYPE (required) the documents type.
-$ELASTICSEARCH_INPUT (required) A JSON Object/Array to be indexed in ElasticSearch. This variable can:
+ELASTICSEARCH_USER (optional) If your server requires authentification, then please add the corresponding password to 3rd party credentials under the key: elasticsearch://<ELASTICSEARCH_USER>@<ELASTICSEARCH_HOST>:<ELASTICSEARCH_PORT>
+ELASTICSEARCH_INDEX (required) the index to use. It is created if it does not exist
+ELASTICSEARCH_DOC_TYPE (required) the documents type.
+ELASTICSEARCH_INPUT (required) A JSON Object/Array to be indexed in ElasticSearch. This variable can:
  - A String describing the JSON Object/Array
  - A relative path in the data space of a JSON file. ]]>
       </description>

--- a/DataConnectors/resources/catalog/FTP.xml
+++ b/DataConnectors/resources/catalog/FTP.xml
@@ -11,9 +11,9 @@
   <description>
     <![CDATA[ Import /Export file(s) from/to an FTP server.
 Before the execution, the user has to provide the following variables:
-$HOST (required) is the FTP server host. Default value is localhost.
-$USERNAME (required) is the username used for accessing the FTP server.
-$PORT (optional) is the listening port.]]>
+HOST (required) is the FTP server host. Default value is localhost.
+USERNAME (required) is the username used for accessing the FTP server.
+PORT (optional) is the listening port.]]>
   </description>
   <genericInformation>
     <info name="bucketName" value="data-connectors"/>

--- a/DataConnectors/resources/catalog/Greenplum.xml
+++ b/DataConnectors/resources/catalog/Greenplum.xml
@@ -11,10 +11,10 @@
   </variables>
   <description>
     <![CDATA[ Import data from (or export data to) Greenplum database. Before the execution, the user has to provide the following variables:
-$DATABASE (required) is the database name.
-$HOST (required) is the hostname or the IP of the machine hosting the DB.
-$PORT (required) is the listening port.
-$USER (required) is the user.]]>
+DATABASE (required) is the database name.
+HOST (required) is the hostname or the IP of the machine hosting the DB.
+PORT (required) is the listening port.
+USER (required) is the user.]]>
   </description>
   <genericInformation>
     <info name="bucketName" value="data-connectors"/>
@@ -28,13 +28,13 @@ $USER (required) is the user.]]>
         <![CDATA[ This task allows to import data from Greenplum database.
 It requires the following third-party credential:  {key: greenplum://<username>@<host>:<port>, value: GREENPLUM_PASSWORD}. Please refer to the User documentation to learn how to add third-party credentials.
 It uses the following variables:
-$DATABASE (required) is the database name.
-$HOST (required) is the hostname or the IP of the machine hosting the DB.
-$PORT (required) is the listening port.
-$USER (required) is the user.
-$SQL_QUERY (required) is the user's sql query.
-$OUTPUT_FILE (optional) is a relative path in the data space used to save the results in a CSV file.
-$OUTPUT_TYPE (optional) if set to HTML, it allows to preview the results in Scheduler Portal in an HTML format. Default is HTML. ]]>
+DATABASE (required) is the database name.
+HOST (required) is the hostname or the IP of the machine hosting the DB.
+PORT (required) is the listening port.
+USER (required) is the user.
+SQL_QUERY (required) is the user's sql query.
+OUTPUT_FILE (optional) is a relative path in the data space used to save the results in a CSV file.
+OUTPUT_TYPE (optional) if set to HTML, it allows to preview the results in Scheduler Portal in an HTML format. Default is HTML. ]]>
       </description>
       <variables>
         <variable name="DATABASE" value="" inherited="true" />
@@ -78,16 +78,16 @@ $OUTPUT_TYPE (optional) if set to HTML, it allows to preview the results in Sche
         <![CDATA[ This task allows to export data to Greenplum database.
 It requires the following third-party credential:  {key: greenplum://<username>@<host>:<port>, value: GREENPLUM_PASSWORD}. Please refer to the User documentation to learn how to add third-party credentials.
 It uses the following variables:
-$DATABASE (required) is the database name.
-$HOST (required) is the hostname or the IP of the machine hosting the DB.
-$PORT (required) is the listening port.
-$USER (required) is the user.
-$TABLE (required) is the table name.
-$INSERT_MODE (required) indicates the behavior to follow when the table exists in the database amongst:
+DATABASE (required) is the database name.
+HOST (required) is the hostname or the IP of the machine hosting the DB.
+PORT (required) is the listening port.
+USER (required) is the user.
+TABLE (required) is the table name.
+INSERT_MODE (required) indicates the behavior to follow when the table exists in the database amongst:
 . fail: If table exists, do nothing.
 . replace: If table exists, drop it, recreate it, and insert data.
 . append: (default) If table exists, insert data. Create if does not exist.
-$INPUT_FILE (required) is the relative path in the data space of the CSV file that contains data to be imported. The string could also be a URL. Valid URL schemes include http, ftp, s3, and file. ]]>
+INPUT_FILE (required) is the relative path in the data space of the CSV file that contains data to be imported. The string could also be a URL. Valid URL schemes include http, ftp, s3, and file. ]]>
       </description>
       <variables>
         <variable name="DATABASE" value="" inherited="true" />

--- a/DataConnectors/resources/catalog/MongoDB.xml
+++ b/DataConnectors/resources/catalog/MongoDB.xml
@@ -22,9 +22,9 @@
         <![CDATA[ This task allows exporting data to MongoDB.
 The task requires the following third-party credentials: {key: mongodb://<username>@<hostname>:<port>, value: MONGODB_PASSWORD}. Please refer to the User documentation to learn how to add third-party credentials.
 It uses the following variables:
-$MONGODB_DATABASE (required) the database to use. It is created if it does not exist
-$MONGODB_COLLECTION (required) the collection to use. It is created if it does not exist
-$MONGODB_INPUT (required) A JSON Object/Array to be inserted in MongoDB. This variable can:
+MONGODB_DATABASE (required) the database to use. It is created if it does not exist
+MONGODB_COLLECTION (required) the collection to use. It is created if it does not exist
+MONGODB_INPUT (required) A JSON Object/Array to be inserted in MongoDB. This variable can:
  - A String describing the JSON Object/Array
  - A relative path in the data space of a JSON file. ]]>
       </description>
@@ -161,10 +161,10 @@ print("END Export Data")
         <![CDATA[ This task allows importing data from MongoDB.
 The task requires the following third-party credentials: MONGODB_USERNAME and MONGODB_PASSWORD. Please refer to the User documentation to learn how to add third-party credentials.
 It uses the following variables:
-$MONGODB_DATABASE (required) the database to use. It is created if it does not exist
-$MONGODB_COLLECTION (required) the collection to use. It is created if it does not exist
-$MONGODB_QUERY (optional) A query used to find documents in MongoDB.
-$MONGODB_OUTPUT (optional) is a relative path in the data space used to save the results in a CSV file.
+MONGODB_DATABASE (required) the database to use. It is created if it does not exist
+MONGODB_COLLECTION (required) the collection to use. It is created if it does not exist
+MONGODB_QUERY (optional) A query used to find documents in MongoDB.
+MONGODB_OUTPUT (optional) is a relative path in the data space used to save the results in a CSV file.
 The output of this task is saved to the local space in a JSON file (result.json) containing a JSON array of the results. It can be aquired in the depending tasks using the result[0] scheme. ]]>
       </description>
       <variables>

--- a/DataConnectors/resources/catalog/MySQL.xml
+++ b/DataConnectors/resources/catalog/MySQL.xml
@@ -11,10 +11,10 @@
   </variables>
   <description>
     <![CDATA[ Import data from (or export data to) MySQL database. Before the execution, the user has to provide the following variables:
-$DATABASE (required) is the database name.
-$HOST (required) is the hostname or the IP of the machine hosting the DB.
-$PORT (required) is the listening port.
-$USER (required) is the user.
+DATABASE (required) is the database name.
+HOST (required) is the hostname or the IP of the machine hosting the DB.
+PORT (required) is the listening port.
+USER (required) is the user.
 ]]>
   </description>
   <genericInformation>
@@ -29,13 +29,13 @@ $USER (required) is the user.
         <![CDATA[ This task allows to import data from MySQL database.
 It requires the following third-party credential:  {key: mysql://<username>@<host>:<port>, value: MYSQL_PASSWORD}. Please refer to the User documentation to learn how to add third-party credentials.
 It uses the following variables:
-$DATABASE (required) is the database name.
-$HOST (required) is the hostname or the IP of the machine hosting the DB.
-$PORT (required) is the listening port.
-$USER (required) is the user.
-$SQL_QUERY (required) is the user's sql query.
-$OUTPUT_FILE (optional) is a relative path in the data space used to save the results in a CSV file.
-$OUTPUT_TYPE (optional) if set to HTML, it allows to preview the results in Scheduler Portal in an HTML format. Default is HTML. ]]>
+DATABASE (required) is the database name.
+HOST (required) is the hostname or the IP of the machine hosting the DB.
+PORT (required) is the listening port.
+USER (required) is the user.
+SQL_QUERY (required) is the user's sql query.
+OUTPUT_FILE (optional) is a relative path in the data space used to save the results in a CSV file.
+OUTPUT_TYPE (optional) if set to HTML, it allows to preview the results in Scheduler Portal in an HTML format. Default is HTML. ]]>
       </description>
       <variables>
         <variable name="DATABASE" value="" inherited="true" />
@@ -79,16 +79,16 @@ $OUTPUT_TYPE (optional) if set to HTML, it allows to preview the results in Sche
         <![CDATA[ This task allows to export data to MySQL database.
 It requires the following third-party credential: {key: mysql://<username>@<host>:<port>, value: MYSQL_PASSWORD}. Please refer to the User documentation to learn how to add third-party credentials.
 It uses the following variables:
-$DATABASE (required) is the database name.
-$HOST (required) is the hostname or the IP of the machine hosting the DB.
-$PORT (required) is the listening port.
-$USER (required) is the user.
-$TABLE (required) is the table name.
-$INSERT_MODE (required) indicates the behavior to follow when the table exists in the database amongst:
+DATABASE (required) is the database name.
+HOST (required) is the hostname or the IP of the machine hosting the DB.
+PORT (required) is the listening port.
+USER (required) is the user.
+TABLE (required) is the table name.
+INSERT_MODE (required) indicates the behavior to follow when the table exists in the database amongst:
 . fail: If table exists, do nothing.
 . replace: If table exists, drop it, recreate it, and insert data.
 . append: (default) If table exists, insert data. Create if does not exist.
-$INPUT_FILE (required) is the relative path in the data space of the CSV file that contains data to be imported. The string could also be a URL. Valid URL schemes include http, ftp, s3, and file. ]]>
+INPUT_FILE (required) is the relative path in the data space of the CSV file that contains data to be imported. The string could also be a URL. Valid URL schemes include http, ftp, s3, and file. ]]>
       </description>
       <variables>
         <variable name="DATABASE" value="" inherited="true" />

--- a/DataConnectors/resources/catalog/Oracle.xml
+++ b/DataConnectors/resources/catalog/Oracle.xml
@@ -11,10 +11,10 @@
   </variables>
   <description>
     <![CDATA[ Import data from (or export data to) Oracle database. Before the execution, the user has to provide the following variables:
-$DATABASE (required) is the database name.
-$HOST (required) is the hostname or the IP of the machine hosting the DB.
-$PORT (required) is the listening port.
-$USER (required) is the user.]]>
+DATABASE (required) is the database name.
+HOST (required) is the hostname or the IP of the machine hosting the DB.
+PORT (required) is the listening port.
+USER (required) is the user.]]>
   </description>
   <genericInformation>
     <info name="bucketName" value="data-connectors"/>
@@ -77,16 +77,16 @@ $OUTPUT_TYPE (optional) if set to HTML, it allows to preview the results in Sche
         <![CDATA[ This task allows to export data to Oracle database.
 It requires the following third-party credential: {key: oracle://<username>@<host>:<port>, value: ORACLE_PASSWORD}. Please refer to the User documentation to learn how to add third-party credentials.
 It uses the following variables:
-$DATABASE (required) is the database name.
-$HOST (required) is the hostname or the IP of the machine hosting the DB.
-$PORT (required) is the listening port.
-$USER (required) is the user.
-$TABLE (required) is the table name.
-$INSERT_MODE (required) indicates the behavior to follow when the table exists in the database amongst:
+DATABASE (required) is the database name.
+HOST (required) is the hostname or the IP of the machine hosting the DB.
+PORT (required) is the listening port.
+USER (required) is the user.
+TABLE (required) is the table name.
+INSERT_MODE (required) indicates the behavior to follow when the table exists in the database amongst:
 . fail: If table exists, do nothing.
 . replace: If table exists, drop it, recreate it, and insert data.
 . append: (default) If table exists, insert data. Create if does not exist.
-$INPUT_FILE (required) is the relative path in the data space of the CSV file that contains data to be imported. The string could also be a URL. Valid URL schemes include http, ftp, s3, and file. ]]>
+INPUT_FILE (required) is the relative path in the data space of the CSV file that contains data to be imported. The string could also be a URL. Valid URL schemes include http, ftp, s3, and file. ]]>
       </description>
       <variables>
         <variable name="DATABASE" value="" inherited="true" />

--- a/DataConnectors/resources/catalog/PostgreSQL.xml
+++ b/DataConnectors/resources/catalog/PostgreSQL.xml
@@ -11,10 +11,10 @@
   </variables>
   <description>
     <![CDATA[ Import data from (or export data to) PostgreSQL database. Before the execution, the user has to provide the following variables:
-$DATABASE (required) is the database name.
-$HOST (required) is the hostname or the IP of the machine hosting the DB.
-$PORT (required) is the listening port.
-$USER (required) is the user.]]>
+DATABASE (required) is the database name.
+HOST (required) is the hostname or the IP of the machine hosting the DB.
+PORT (required) is the listening port.
+USER (required) is the user.]]>
   </description>
   <genericInformation>
     <info name="bucketName" value="data-connectors"/>
@@ -77,16 +77,16 @@ $OUTPUT_TYPE (optional) if set to HTML, it allows to preview the results in Sche
         <![CDATA[ This task allows to export data to PostgreSQL database.
 It requires the following third-party credential: {key: postgresql://<username>@<host>:<port>, value: POSTGRESQL_PASSWORD}. Please refer to the User documentation to learn how to add third-party credentials.
 It uses the following variables:
-$DATABASE (required) is the database name.
-$HOST (required) is the hostname or the IP of the machine hosting the DB.
-$PORT (required) is the listening port.
-$USER (required) is the user.
-$TABLE (required) is the table name.
-$INSERT_MODE (required) indicates the behavior to follow when the table exists in the database amongst:
+DATABASE (required) is the database name.
+HOST (required) is the hostname or the IP of the machine hosting the DB.
+PORT (required) is the listening port.
+USER (required) is the user.
+TABLE (required) is the table name.
+INSERT_MODE (required) indicates the behavior to follow when the table exists in the database amongst:
 . fail: If table exists, do nothing.
 . replace: If table exists, drop it, recreate it, and insert data.
 . append: (default) If table exists, insert data. Create if does not exist.
-$INPUT_FILE (required) is the relative path in the data space of the CSV file that contains data to be imported. The string could also be a URL. Valid URL schemes include http, ftp, s3, and file. ]]>
+INPUT_FILE (required) is the relative path in the data space of the CSV file that contains data to be imported. The string could also be a URL. Valid URL schemes include http, ftp, s3, and file. ]]>
       </description>
       <variables>
         <variable name="DATABASE" value="" inherited="true" />

--- a/DataConnectors/resources/catalog/SFTP.xml
+++ b/DataConnectors/resources/catalog/SFTP.xml
@@ -11,9 +11,9 @@
   <description>
     <![CDATA[ Import /Export file(s) from/to an SFTP server.
 Before the execution, the user has to provide the following variables:
-$HOST (required) is the SFTP server host. Default value is localhost.
-$USERNAME (required) is the username used for accessing the SFTP server.
-$PORT (optional) is the listening port. ]]>
+HOST (required) is the SFTP server host. Default value is localhost.
+USERNAME (required) is the username used for accessing the SFTP server.
+PORT (optional) is the listening port. ]]>
   </description>
   <genericInformation>
     <info name="bucketName" value="data-connectors"/>

--- a/DataConnectors/resources/catalog/SQL_Pooled_Connection_Query.xml
+++ b/DataConnectors/resources/catalog/SQL_Pooled_Connection_Query.xml
@@ -17,16 +17,16 @@
     <![CDATA[ This workflow is a template that demonstrates how to use pooled connections to SQL databases across multiple SQL tasks (basically when running several tasks concurrently on the same machine). The workflow is composed of a single task Open_Pooled_connection_and_Execute_Query.
 
 Before the execution, the user has to provide the following variables:
-$RDBMS_NAME is the relational database management system name e.g. PostgreSQL, MySQL, Greenplum, HSQLDB, Oracle...
-$HOST (required) is the server host. Default value is localhost.
-$USERNAME (required) is the username used for accessing the SQL database.
-$PORT (optional) is the listening port.
-$DATABASE (required) is the database name.
-$POOL_PROPERTY (optional) HikariCP offers many data source properties that can be used to configure the DB pooled connection such as autoCommit, maximumPoolSize, maxLifetime, idleTimeout .... You can add as many properties as you want. For each one, add a new task variable where the variable name is the property name having "POOL_"  as a prefix (e.g. POOL_autoCommit, POOL_maximumPoolSize) and the variable value is the property value. For more info, please refer to https://github.com/brettwooldridge/HikariCP.
-$SQL_STATEMENTS (required) is a string composed of a set of query statements (SELECT statement).
-$OUTPUT_TYPE (optional) if set to HTML, it allows to preview the results in the Scheduler Portal in a HTML format. if set to CSV,  it allows to download the results from the Scheduler Portal in a CSV format.
+RDBMS_NAME is the relational database management system name e.g. PostgreSQL, MySQL, Greenplum, HSQLDB, Oracle...
+HOST (required) is the server host. Default value is localhost.
+USERNAME (required) is the username used for accessing the SQL database.
+PORT (optional) is the listening port.
+DATABASE (required) is the database name.
+POOL_PROPERTY (optional) HikariCP offers many data source properties that can be used to configure the DB pooled connection such as autoCommit, maximumPoolSize, maxLifetime, idleTimeout .... You can add as many properties as you want. For each one, add a new task variable where the variable name is the property name having "POOL_"  as a prefix (e.g. POOL_autoCommit, POOL_maximumPoolSize) and the variable value is the property value. For more info, please refer to https://github.com/brettwooldridge/HikariCP.
+SQL_STATEMENTS (required) is a string composed of a set of query statements (SELECT statement).
+OUTPUT_TYPE (optional) if set to HTML, it allows to preview the results in the Scheduler Portal in a HTML format. if set to CSV,  it allows to download the results from the Scheduler Portal in a CSV format.
 Default value is HTML
-$STORE_RESULT_VARIABLE (optional) if not empty, the value will be the name of a variable that contains the resultSet (converted into a List of Maps) of the query. This variable can be used in other tasks.
+STORE_RESULT_VARIABLE (optional) if not empty, the value will be the name of a variable that contains the resultSet (converted into a List of Maps) of the query. This variable can be used in other tasks.
 
 To allow the persistence of a single connection across multiple tasks executions, the scheduler should be configured in non-forked mode to execute tasks in a single JVM rather than starting a dedicated JVM to run the task (In $PROACTIVE_HOME/config/scheduler/settings.ini, please set pa.scheduler.task.fork=false).
 

--- a/DataConnectors/resources/catalog/SQL_Server.xml
+++ b/DataConnectors/resources/catalog/SQL_Server.xml
@@ -12,10 +12,10 @@
   </variables>
   <description>
     <![CDATA[ Import data from (or export data to) SQL Server database. Before the execution, the user has to provide the following variables:
-$DATABASE (required) is the database name.
-$HOST (required) is the hostname or the IP of the machine hosting the DB.
-$PORT (required) is the listening port.
-$USER (required) is the user.]]>
+DATABASE (required) is the database name.
+HOST (required) is the hostname or the IP of the machine hosting the DB.
+PORT (required) is the listening port.
+USER (required) is the user.]]>
   </description>
   <genericInformation>
     <info name="bucketName" value="data-connectors"/>
@@ -29,13 +29,13 @@ $USER (required) is the user.]]>
         <![CDATA[ This task allows to import data from SQL Server database.
 It requires the following third-party credential:  {key: sqlserver://<username>@<host>:<port>, value: SQL_SERVER_PASSWORD}. Please refer to the User documentation to learn how to add third-party credentials.
 It uses the following variables:
-$DATABASE (required) is the database name.
-$HOST (required) is the hostname or the IP of the machine hosting the DB.
-$PORT (required) is the listening port.
-$USER (required) is the user.
-$SQL_QUERY (required) is the user's sql query.
-$OUTPUT_FILE (optional) is a relative path in the data space used to save the results in a CSV file.
-$OUTPUT_TYPE (optional) if set to HTML, it allows to preview the results in Scheduler Portal in an HTML format. Default is HTML. ]]>
+DATABASE (required) is the database name.
+HOST (required) is the hostname or the IP of the machine hosting the DB.
+PORT (required) is the listening port.
+USER (required) is the user.
+SQL_QUERY (required) is the user's sql query.
+OUTPUT_FILE (optional) is a relative path in the data space used to save the results in a CSV file.
+OUTPUT_TYPE (optional) if set to HTML, it allows to preview the results in Scheduler Portal in an HTML format. Default is HTML. ]]>
       </description>
         <variables>
             <variable name="DATABASE" value="" inherited="true" />
@@ -79,16 +79,16 @@ $OUTPUT_TYPE (optional) if set to HTML, it allows to preview the results in Sche
         <![CDATA[ This task allows to export data to SQL Server database.
 It requires the following third-party credential:  {key: sqlserver://<username>@<host>:<port>, value: SQL_SERVER_PASSWORD}. Please refer to the User documentation to learn how to add third-party credentials.
 It uses the following variables:
-$DATABASE (required) is the database name.
-$HOST (required) is the hostname or the IP of the machine hosting the DB.
-$PORT (required) is the listening port.
-$USER (required) is the user.
-$TABLE (required) is the table name.
-$INSERT_MODE (required) indicates the behavior to follow when the table exists in the database amongst:
+DATABASE (required) is the database name.
+HOST (required) is the hostname or the IP of the machine hosting the DB.
+PORT (required) is the listening port.
+USER (required) is the user.
+TABLE (required) is the table name.
+INSERT_MODE (required) indicates the behavior to follow when the table exists in the database amongst:
 . fail: If table exists, do nothing.
 . replace: If table exists, drop it, recreate it, and insert data.
 . append: (default) If table exists, insert data. Create if does not exist.
-$INPUT_FILE (required) is the relative path in the data space of the CSV file that contains data to be imported. The string could also be a URL. Valid URL schemes include http, ftp, s3, and file. ]]>
+INPUT_FILE (required) is the relative path in the data space of the CSV file that contains data to be imported. The string could also be a URL. Valid URL schemes include http, ftp, s3, and file. ]]>
       </description>
         <variables>
             <variable name="DATABASE" value="" inherited="true" />

--- a/DataConnectors/resources/catalog/SQL_Statements.xml
+++ b/DataConnectors/resources/catalog/SQL_Statements.xml
@@ -17,14 +17,14 @@
         <![CDATA[ This task enables to execute any SQL statement (SQL query, trigger, procedure..) on an SQL database.
 It requires the following third-party credential: {key: <dbms>://<username>@<host>:<port>, value: DATABASE_PASSWORD}. Please refer to the User documentation to learn how to add third-party credentials.
 It uses the following variables: 
-$DBMS (required) is the database management system. . It can be one of these values {PostgreSQL, MySQL, Oracle, SQL Server, Greenplum}. The default value is "PostgreSQL".
-$DATABASE (required) is the database name
-$HOST (required) is the database host
-$PORT (required) is the listening database port
-$USER (required) is the database user
-$INPUT_TYPE (required) is the type of the input statements. It can be either "File" or "String". The default value is "String".
-$SQL_STATEMENTS is a string composed of a set of SQL statements. If INPUT_TYPE is equals to String then SQL_STATEMENTS is required.
-$INPUT_FILE is the file that contains the SQL statements which is stored in the dataspace (user, global..). If INPUT_TYPE is equals to File then INPUT_FILE is required. ]]>
+DBMS (required) is the database management system. . It can be one of these values {PostgreSQL, MySQL, Oracle, SQL Server, Greenplum}. The default value is "PostgreSQL".
+DATABASE (required) is the database name
+HOST (required) is the database host
+PORT (required) is the listening database port
+USER (required) is the database user
+INPUT_TYPE (required) is the type of the input statements. It can be either "File" or "String". The default value is "String".
+SQL_STATEMENTS is a string composed of a set of SQL statements. If INPUT_TYPE is equals to String then SQL_STATEMENTS is required.
+INPUT_FILE is the file that contains the SQL statements which is stored in the dataspace (user, global..). If INPUT_TYPE is equals to File then INPUT_FILE is required. ]]>
       </description>
       <variables>
         <variable name="DBMS" value="PostgreSQL" inherited="false" model="PA:List(PostgreSQL,MySQL,Oracle,SQL Server,Greenplum)"/>

--- a/DatabaseServices/resources/catalog/Cassandra_Database_Interaction.xml
+++ b/DatabaseServices/resources/catalog/Cassandra_Database_Interaction.xml
@@ -151,9 +151,9 @@ session.execute("""CREATE KEYSPACE IF NOT EXISTS %s WITH replication = { 'class'
         <![CDATA[ This task allows importing data from Cassandra.
 The task requires the following third-party credentials: CASSANDRA_USERNAME and CASSANDRA_PASSWORD. Please refer to the User documentation to learn how to add third-party credentials.
 It requires the following variables:
-$CASSANDRA_KEYSPACE: Keyspace to use.
-$CASSANDRA_QUERY: Query to fetch data.
-$CASSANDRA_OUPUT: Relative path in the data space used to save the results in a CSV file. ]]>
+CASSANDRA_KEYSPACE: Keyspace to use.
+CASSANDRA_QUERY: Query to fetch data.
+CASSANDRA_OUPUT: Relative path in the data space used to save the results in a CSV file. ]]>
       </description>
       <variables>
         <variable name="CASSANDRA_QUERY" value="SELECT * FROM diabetes" inherited="false" />
@@ -282,9 +282,9 @@ print("END Import_Data")
         <![CDATA[ This task allows exporting data to Cassandra.
 The task requires the following third-party credentials: CASSANDRA_USERNAME and CASSANDRA_PASSWORD. Please refer to the User documentation to learn how to add third-party credentials.
 It requires the following variables:
-$CASSANDRA_TABLE (required) Data is stored in tables containing rows of columns, similar to SQL definitions.. It is created if it does not exist
-$CASSANDRA_KEY (required) A primary key identifies the location and order of stored data. The primary key is defined when the table is created and cannot be altered.
-$CASSANDRA_INPUT (required) is the relative path of the CSV file that contains data to be imported. This variable can:
+CASSANDRA_TABLE (required) Data is stored in tables containing rows of columns, similar to SQL definitions.. It is created if it does not exist
+CASSANDRA_KEY (required) A primary key identifies the location and order of stored data. The primary key is defined when the table is created and cannot be altered.
+CASSANDRA_INPUT (required) is the relative path of the CSV file that contains data to be imported. This variable can:
  - An URL. Valid URL schemes include http, ftp, s3, and file. 
  - A relative path in the data space of a csv file. ]]>
       </description>

--- a/DatabaseServices/resources/catalog/Elasticsearch_Database_Interaction.xml
+++ b/DatabaseServices/resources/catalog/Elasticsearch_Database_Interaction.xml
@@ -175,10 +175,10 @@ print("END Import Data from Elasticsearch")
       <description>
         <![CDATA[ This task allows exporting data to ElasticSearch.
 It uses the following variables:
-$ELASTICSEARCH_USER (optional) If your server requires authentification, then please add the corresponding password to 3rd party credentials under the key: elasticsearch://<ELASTICSEARCH_USER>@<ELASTICSEARCH_HOST>:<ELASTICSEARCH_PORT>
-$ELASTICSEARCH_INDEX (required) the index to use. It is created if it does not exist
-$ELASTICSEARCH_DOC_TYPE (required) the documents type.
-$ELASTICSEARCH_INPUT (required) A JSON Object/Array to be indexed in ElasticSearch. This variable can:
+ELASTICSEARCH_USER (optional) If your server requires authentification, then please add the corresponding password to 3rd party credentials under the key: elasticsearch://<ELASTICSEARCH_USER>@<ELASTICSEARCH_HOST>:<ELASTICSEARCH_PORT>
+ELASTICSEARCH_INDEX (required) the index to use. It is created if it does not exist
+ELASTICSEARCH_DOC_TYPE (required) the documents type.
+ELASTICSEARCH_INPUT (required) A JSON Object/Array to be indexed in ElasticSearch. This variable can:
  - A String describing the JSON Object/Array
  - A relative path in the data space of a JSON file. ]]>
       </description>

--- a/DatabaseServices/resources/catalog/MongoDB_Database_Interaction.xml
+++ b/DatabaseServices/resources/catalog/MongoDB_Database_Interaction.xml
@@ -45,9 +45,9 @@ sleep(3000)
         <![CDATA[ This task allows exporting data to MongoDB.
 The task requires the following third-party credentials: {key: mongodb://<username>@<hostname>:<port>, value: MONGODB_PASSWORD}. Please refer to the User documentation to learn how to add third-party credentials.
 It uses the following variables:
-$MONGODB_DATABASE (required) the database to use. It is created if it does not exist
-$MONGODB_COLLECTION (required) the collection to use. It is created if it does not exist
-$MONGODB_INPUT (required) A JSON Object/Array to be inserted in MongoDB. This variable can:
+MONGODB_DATABASE (required) the database to use. It is created if it does not exist
+MONGODB_COLLECTION (required) the collection to use. It is created if it does not exist
+MONGODB_INPUT (required) A JSON Object/Array to be inserted in MongoDB. This variable can:
  - A String describing the JSON Object/Array
  - A relative path in the data space of a JSON file. ]]>
       </description>
@@ -187,10 +187,10 @@ print("END Export Data")
         <![CDATA[ This task allows importing data from MongoDB.
 The task requires the following third-party credentials: MONGODB_USERNAME and MONGODB_PASSWORD. Please refer to the User documentation to learn how to add third-party credentials.
 It uses the following variables:
-$MONGODB_DATABASE (required) the database to use. It is created if it does not exist
-$MONGODB_COLLECTION (required) the collection to use. It is created if it does not exist
-$MONGODB_QUERY (optional) A query used to find documents in MongoDB.
-$MONGODB_OUTPUT (optional) is a relative path in the data space used to save the results in a CSV file.
+MONGODB_DATABASE (required) the database to use. It is created if it does not exist
+MONGODB_COLLECTION (required) the collection to use. It is created if it does not exist
+MONGODB_QUERY (optional) A query used to find documents in MongoDB.
+MONGODB_OUTPUT (optional) is a relative path in the data space used to save the results in a CSV file.
 The output of this task is saved to the local space in a JSON file (result.json) containing a JSON array of the results. It can be aquired in the depending tasks using the result[0] scheme. ]]>
       </description>
       <variables>

--- a/DatabaseServices/resources/catalog/MySQL_Database_Interaction.xml
+++ b/DatabaseServices/resources/catalog/MySQL_Database_Interaction.xml
@@ -24,9 +24,9 @@
         <![CDATA[ This task allows to import data from MySQL database.
 It requires the following third-party credential:  {key: mysql://<username>@<host>:<port>, value: MYSQL_PASSWORD}. Please refer to the User documentation to learn how to add third-party credentials.
 It uses the following variables:
-$SQL_QUERY (required) is the user's sql query.
-$OUTPUT_FILE (optional) is a relative path in the data space used to save the results in a CSV file.
-$OUTPUT_TYPE (optional) if set to HTML, it allows to preview the results in Scheduler Portal in an HTML format. Default is HTML ]]>
+SQL_QUERY (required) is the user's sql query.
+OUTPUT_FILE (optional) is a relative path in the data space used to save the results in a CSV file.
+OUTPUT_TYPE (optional) if set to HTML, it allows to preview the results in Scheduler Portal in an HTML format. Default is HTML ]]>
       </description>
       <variables>
         <variable name="SQL_QUERY" value="SELECT * FROM diabetes" inherited="false" />
@@ -65,12 +65,12 @@ $OUTPUT_TYPE (optional) if set to HTML, it allows to preview the results in Sche
         <![CDATA[ This task allows to export data to MySQL database.
 It requires the following third-party credential: {key: mysql://<username>@<host>:<port>, value: MYSQL_PASSWORD}. Please refer to the User documentation to learn how to add third-party credentials.
 It uses the following variables:
-$TABLE (required) is the table name.
-$INSERT_MODE (required) indicates the behavior to follow when the table exists in the database amongst:
+TABLE (required) is the table name.
+INSERT_MODE (required) indicates the behavior to follow when the table exists in the database amongst:
 . fail: If table exists, do nothing.
 . replace: If table exists, drop it, recreate it, and insert data.
 . append: (default) If table exists, insert data. Create if does not exist.
-$INPUT_FILE (required) is the relative path in the data space of the CSV file that contains data to be imported. The string could also be a URL. Valid URL schemes include http, ftp, s3, and file. ]]>
+INPUT_FILE (required) is the relative path in the data space of the CSV file that contains data to be imported. The string could also be a URL. Valid URL schemes include http, ftp, s3, and file. ]]>
       </description>
       <variables>
         <variable name="TABLE" value="diabetes" inherited="false" />

--- a/DatabaseServices/resources/catalog/Oracle_Database_Interaction.xml
+++ b/DatabaseServices/resources/catalog/Oracle_Database_Interaction.xml
@@ -66,9 +66,9 @@ It demonstrates how to start a Oracle database server using the PCA client API, 
         <![CDATA[ Load data from an Oracle SQL database.
 It requires the following third-party credential: {key: oracle://<username>@<host>:<port>, value: ORACLE_PASSWORD}. Please refer to the User documentation to learn how to add third-party credentials.
 It uses the following variables:
-$SQL_QUERY (required) is the user's sql query.
-$OUTPUT_FILE (optional) is a relative path in the data space used to save the results in a CSV file.
-$OUTPUT_TYPE (optional) if set to HTML, it allows to preview the results in Scheduler Portal in an HTML format. Default is HTML. ]]>
+SQL_QUERY (required) is the user's sql query.
+OUTPUT_FILE (optional) is a relative path in the data space used to save the results in a CSV file.
+OUTPUT_TYPE (optional) if set to HTML, it allows to preview the results in Scheduler Portal in an HTML format. Default is HTML. ]]>
       </description>
       <variables>
         <variable name="SQL_QUERY" value="select * from diabetes" inherited="false" />
@@ -107,12 +107,12 @@ $OUTPUT_TYPE (optional) if set to HTML, it allows to preview the results in Sche
         <![CDATA[ This task allows to export data to Oracle database.
 It requires the following third-party credential: {key: oracle://<username>@<host>:<port>, value: ORACLE_PASSWORD}. Please refer to the User documentation to learn how to add third-party credentials.
 It uses the following variables: 
-$TABLE (required) is the table name.
-$INSERT_MODE (required) indicates the behavior to follow when the table exists in the database amongst: 
+TABLE (required) is the table name.
+INSERT_MODE (required) indicates the behavior to follow when the table exists in the database amongst:
 . fail: If table exists, do nothing.
 . replace: If table exists, drop it, recreate it, and insert data.
 . append: (default) If table exists, insert data. Create if does not exist.
-$INPUT_FILE (required) is the relative path in the data space of the CSV file that contains data to be imported. The string could also be a URL. Valid URL schemes include http, ftp, s3, and file. ]]>
+INPUT_FILE (required) is the relative path in the data space of the CSV file that contains data to be imported. The string could also be a URL. Valid URL schemes include http, ftp, s3, and file. ]]>
       </description>
       <variables>
         <variable name="TABLE" value="diabetes" inherited="false" />

--- a/DatabaseServices/resources/catalog/PostgreSQL_Database_Interaction.xml
+++ b/DatabaseServices/resources/catalog/PostgreSQL_Database_Interaction.xml
@@ -40,10 +40,10 @@ It demonstrates how to start a PostgreSQL database server using the PCA client A
         <![CDATA[ This task allows to import data from PostgreSQL database.
 It requires the following third-party credential: {key: postgresql://<username>@<host>:<port>, value: POSTGRESQL_PASSWORD}. Please refer to the User documentation to learn how to add third-party credentials.
 It uses the following variables:
-$LABEL (optional) used when the imported data is labeled. Then, the user can specify the label column name.
-$SQL_QUERY (required) is the user's sql query.
-$OUTPUT_FILE (optional) is a relative path in the data space used to save the results in a CSV file.
-$OUTPUT_TYPE (optional) if set to HTML, it allows to preview the results in Scheduler Portal in an HTML format. Default is HTML. ]]>
+LABEL (optional) used when the imported data is labeled. Then, the user can specify the label column name.
+SQL_QUERY (required) is the user's sql query.
+OUTPUT_FILE (optional) is a relative path in the data space used to save the results in a CSV file.
+OUTPUT_TYPE (optional) if set to HTML, it allows to preview the results in Scheduler Portal in an HTML format. Default is HTML. ]]>
       </description>
       <variables>
         <variable name="SQL_QUERY" value="SELECT * FROM diabetes" inherited="false" />
@@ -82,12 +82,12 @@ $OUTPUT_TYPE (optional) if set to HTML, it allows to preview the results in Sche
         <![CDATA[ This task allows to export data to PostgreSQL database.
 It requires the following third-party credential: {key: postgresql://<username>@<host>:<port>, value: POSTGRESQL_PASSWORD}. Please refer to the User documentation to learn how to add third-party credentials.
 It uses the following variables: 
-$TABLE (required) is the table name.
-$INSERT_MODE (required) indicates the behavior to follow when the table exists in the database amongst: 
+TABLE (required) is the table name.
+INSERT_MODE (required) indicates the behavior to follow when the table exists in the database amongst:
 . fail: If table exists, do nothing.
 . replace: If table exists, drop it, recreate it, and insert data.
 . append: (default) If table exists, insert data. Create if does not exist.
-$INPUT_FILE (required) is the relative path in the data space of the CSV file that contains data to be imported. The string could also be a URL. Valid URL schemes include http, ftp, s3, and file. ]]>
+INPUT_FILE (required) is the relative path in the data space of the CSV file that contains data to be imported. The string could also be a URL. Valid URL schemes include http, ftp, s3, and file. ]]>
       </description>
       <variables>
         <variable name="TABLE" value="diabetes" inherited="false" />

--- a/Docker/resources/catalog/Docker.xml
+++ b/Docker/resources/catalog/Docker.xml
@@ -19,11 +19,11 @@ The underlying docker command is the following:
 docker run -- name $DOCKER_CONTAINER_NAME -p $DOCKER_PORT $DOCKER_OPTIONS -d $DOCKER_IMAGE $DOCKER_COMMAND
 
 The service can be started using the following variables:
-$DOCKER_IMAGE: Docker image name. It can include a tag as well.
-$DOCKER_PORT: The main image port. Please note that it will be forwarded to a random port that will be returned by this service.
-$DOCKER_CONTAINER: If you desire to stop this container and restart it later.
-$DOCKER_OPTIONS (OPTIONAL): options like environment variables, etc.
-$DOCKER_COMMAND (OPTIONAL) ]]>
+DOCKER_IMAGE: Docker image name. It can include a tag as well.
+DOCKER_PORT: The main image port. Please note that it will be forwarded to a random port that will be returned by this service.
+DOCKER_CONTAINER: If you desire to stop this container and restart it later.
+DOCKER_OPTIONS (OPTIONAL): options like environment variables, etc.
+DOCKER_COMMAND (OPTIONAL) ]]>
   </description>
   <genericInformation>
     <info name="bucketName" value="cloud-automation"/>
@@ -47,11 +47,11 @@ The underlying docker command is the following:
 docker run -- name $DOCKER_CONTAINER_NAME -p $DOCKER_PORT $DOCKER_OPTIONS -d $DOCKER_IMAGE $DOCKER_COMMAND
 
 The service can be started using the following variables:
-$DOCKER_IMAGE: Docker image name. It can include a tag as well.
-$DOCKER_PORT: The main image port. Please note that it will be forwarded to a random port that will be returned by this service.
-$DOCKER_CONTAINER: If you desire to stop this container and restart it later.
-$DOCKER_OPTIONS (OPTIONAL): options like environment variables, etc.
-$DOCKER_COMMAND (OPTIONAL) ]]>
+DOCKER_IMAGE: Docker image name. It can include a tag as well.
+DOCKER_PORT: The main image port. Please note that it will be forwarded to a random port that will be returned by this service.
+DOCKER_CONTAINER: If you desire to stop this container and restart it later.
+DOCKER_OPTIONS (OPTIONAL): options like environment variables, etc.
+DOCKER_COMMAND (OPTIONAL) ]]>
       </description>
       <variables>
         <variable name="DOCKER_IMAGE" value="" inherited="true" />
@@ -293,11 +293,11 @@ The underlying docker command is the following:
 docker run -- name $DOCKER_CONTAINER_NAME -p $DOCKER_PORT $DOCKER_OPTIONS -d $DOCKER_IMAGE $DOCKER_COMMAND
 
 The service can be started using the following variables:
-$DOCKER_IMAGE: Docker image name. It can include a tag as well.
-$DOCKER_PORT: The main image port. Please note that it will be forwarded to a random port that will be returned by this service.
-$DOCKER_CONTAINER: If you desire to stop this container and restart it later.
-$DOCKER_OPTIONS (OPTIONAL): options like environment variables, etc.
-$DOCKER_COMMAND (OPTIONAL)"><img src="/automation-dashboard/styles/patterns/img/wf-icons/docker.png" width="20px">&nbsp;<span class="name">Start_Docker</span></a></div><div class="task ui-draggable _jsPlumb_endpoint_anchor_" id="jsPlumb_1_253" style="top: 515px; left: 496.5px;"><a class="task-name" data-toggle="tooltip" data-placement="right" title="Loop over service instance status and fetch docker container logs"><img src="/automation-dashboard/styles/patterns/img/wf-icons/docker.png" width="20px">&nbsp;<span class="name">Loop_Over_Instance_Status</span></a></div><svg style="position:absolute;left:536.5px;top:426.5px" width="51.5" height="89" pointer-events="none" position="absolute" version="1.1"
+DOCKER_IMAGE: Docker image name. It can include a tag as well.
+DOCKER_PORT: The main image port. Please note that it will be forwarded to a random port that will be returned by this service.
+DOCKER_CONTAINER: If you desire to stop this container and restart it later.
+DOCKER_OPTIONS (OPTIONAL): options like environment variables, etc.
+DOCKER_COMMAND (OPTIONAL)"><img src="/automation-dashboard/styles/patterns/img/wf-icons/docker.png" width="20px">&nbsp;<span class="name">Start_Docker</span></a></div><div class="task ui-draggable _jsPlumb_endpoint_anchor_" id="jsPlumb_1_253" style="top: 515px; left: 496.5px;"><a class="task-name" data-toggle="tooltip" data-placement="right" title="Loop over service instance status and fetch docker container logs"><img src="/automation-dashboard/styles/patterns/img/wf-icons/docker.png" width="20px">&nbsp;<span class="name">Loop_Over_Instance_Status</span></a></div><svg style="position:absolute;left:536.5px;top:426.5px" width="51.5" height="89" pointer-events="none" position="absolute" version="1.1"
       xmlns="http://www.w3.org/1999/xhtml" class="_jsPlumb_connector "><path d="M 30.5 88 C 40.5 38 -10 50 0 0 " transform="translate(10.5,0.5)" pointer-events="visibleStroke" version="1.1"
       xmlns="http://www.w3.org/1999/xhtml" fill="none" stroke="#666" style=""></path><path pointer-events="all" version="1.1"
       xmlns="http://www.w3.org/1999/xhtml" d="M30.604289125,65.8307285 L28.92065780914319,44.70810116360394 L24.944079219862537,53.025962831320875 L16.11589214046406,50.368311068741406 L30.604289125,65.8307285" class="" stroke="#666" fill="#666" transform="translate(10.5,0.5)"></path><path pointer-events="all" version="1.1"

--- a/Docker/resources/catalog/Docker.xml
+++ b/Docker/resources/catalog/Docker.xml
@@ -16,7 +16,7 @@
     <![CDATA[ Deploy a Docker image as a PCA service.
 The underlying docker command is the following:
 
-docker run -- name $DOCKER_CONTAINER_NAME -p $DOCKER_PORT $DOCKER_OPTIONS -d $DOCKER_IMAGE $DOCKER_COMMAND
+docker run -- name DOCKER_CONTAINER_NAME -p DOCKER_PORT DOCKER_OPTIONS -d DOCKER_IMAGE DOCKER_COMMAND
 
 The service can be started using the following variables:
 DOCKER_IMAGE: Docker image name. It can include a tag as well.
@@ -44,7 +44,7 @@ DOCKER_COMMAND (OPTIONAL) ]]>
         <![CDATA[ Pull the given $DOCKER_IMAGE and start a container as a PCA Service.
 The underlying docker command is the following:
 
-docker run -- name $DOCKER_CONTAINER_NAME -p $DOCKER_PORT $DOCKER_OPTIONS -d $DOCKER_IMAGE $DOCKER_COMMAND
+docker run -- name DOCKER_CONTAINER_NAME -p DOCKER_PORT $DOCKER_OPTIONS -d DOCKER_IMAGE DOCKER_COMMAND
 
 The service can be started using the following variables:
 DOCKER_IMAGE: Docker image name. It can include a tag as well.
@@ -290,7 +290,7 @@ variables.put("LAST_TIME_MARKER",new Date().format("yyyy-MM-dd'T'HH:mm:ssXXX"))
         </style></head><body><div id="workflow-visualization-view"><div id="workflow-visualization" style="position:relative;top:-382px;left:-491.5px"><div class="task _jsPlumb_endpoint_anchor_ ui-draggable active-task" id="jsPlumb_1_250" style="top: 387px; left: 496.5px;"><a class="task-name" data-toggle="tooltip" data-placement="right" title="Pull the given $DOCKER_IMAGE and start a container as a PCA Service.
 The underlying docker command is the following:
 
-docker run -- name $DOCKER_CONTAINER_NAME -p $DOCKER_PORT $DOCKER_OPTIONS -d $DOCKER_IMAGE $DOCKER_COMMAND
+docker run -- name DOCKER_CONTAINER_NAME -p DOCKER_PORT DOCKER_OPTIONS -d DOCKER_IMAGE DOCKER_COMMAND
 
 The service can be started using the following variables:
 DOCKER_IMAGE: Docker image name. It can include a tag as well.

--- a/MongoDB/resources/catalog/MongoDB.xml
+++ b/MongoDB/resources/catalog/MongoDB.xml
@@ -13,9 +13,9 @@
   <description>
     <![CDATA[ Deploy a MongoDB Database server.
 The service can be started using the following variables:
-$INSTANCE_NAME (Required): service instance name
-$USER (Optional): Username for the root user.
-$PASSWORD (Optional): Password for the root user. ]]>
+INSTANCE_NAME (Required): service instance name
+USER (Optional): Username for the root user.
+PASSWORD (Optional): Password for the root user. ]]>
   </description>
   <genericInformation>
     <info name="bucketName" value="cloud-automation"/>

--- a/MySQL/resources/catalog/MySQL.xml
+++ b/MySQL/resources/catalog/MySQL.xml
@@ -14,10 +14,10 @@
   <description>
     <![CDATA[ Deploy a MySQL Database server.
 The service can be started using the following variables:
-$INSTANCE_NAME (Required): service instance name.
-$DATABASE (Optional): Name of a database to be created on start.
-$USER (Optional): Username for the root user.
-$PASSWORD (Optional): Password for the root user. ]]>
+INSTANCE_NAME (Required): service instance name.
+DATABASE (Optional): Name of a database to be created on start.
+USER (Optional): Username for the root user.
+PASSWORD (Optional): Password for the root user. ]]>
   </description>
   <genericInformation>
     <info name="bucketName" value="cloud-automation"/>

--- a/Oracle/resources/catalog/Oracle.xml
+++ b/Oracle/resources/catalog/Oracle.xml
@@ -12,8 +12,8 @@
   <description>
     <![CDATA[ Deploy an Oracle Database server.
 The service can be started using the following variables:
-$INSTANCE_NAME (Required): service instance name.
-$ENV_VARS (Optional): List of the environment variables. Each environment variable should be preceded by -e.
+INSTANCE_NAME (Required): service instance name.
+ENV_VARS (Optional): List of the environment variables. Each environment variable should be preceded by -e.
 This service is based on this docker image: https://hub.docker.com/r/wnameless/oracle-xe-11g/ where the default settings are:
 sid: xe
 username: system

--- a/PostgreSQL/resources/catalog/PostgreSQL.xml
+++ b/PostgreSQL/resources/catalog/PostgreSQL.xml
@@ -14,10 +14,10 @@
   <description>
     <![CDATA[ Deploy a PostgreSQL Database server.
 The service can be started using the following variables:
-$INSTANCE_NAME (Required): service instance name.
-$USER: (Optional) "postgres" value is used if left empty. Otherwise, provide a value if you want a different root username.
-$PASSWORD (Required) : Password for the root user.
-$DATABASE (Optional) : Name of a database to be created on start. ]]>
+INSTANCE_NAME (Required): service instance name.
+USER: (Optional) "postgres" value is used if left empty. Otherwise, provide a value if you want a different root username.
+PASSWORD (Required) : Password for the root user.
+DATABASE (Optional) : Name of a database to be created on start. ]]>
   </description>
   <genericInformation>
     <info name="bucketName" value="cloud-automation"/>

--- a/Visdom/resources/catalog/Visdom.xml
+++ b/Visdom/resources/catalog/Visdom.xml
@@ -14,7 +14,7 @@
   <description>
     <![CDATA[ Deployment of the Visdom server.
 The service can be started using the following variables:
-$INSTANCE_NAME (Required): service instance name ]]>
+INSTANCE_NAME (Required): service instance name ]]>
   </description>
   <genericInformation>
     <info name="bucketName" value="cloud-automation"/>


### PR DESCRIPTION
According to Scheduler workflow parser: all the variables represented in format $var are replaced by the variable values inside the whole workflow content (in the description and other parts of the workflow). This behavior gives issue in showing variable names in description of the workflow in the portals.
 So the solution is to remove '$' from the name of variables in the description tag