### PR TITLE
Improve PCA instance name unicity check

### DIFF
--- a/Cassandra/resources/catalog/Cassandra.xml
+++ b/Cassandra/resources/catalog/Cassandra.xml
@@ -24,10 +24,10 @@ ENV_VARS (Optional): List of the environment variables. Each environment variabl
     <info name="group" value="public-objects"/>
   </genericInformation>
   <taskFlow>
-    <task name="Start_Cassandra" 
-    
-    
-    
+    <task name="Start_Cassandra"
+
+
+    onTaskError="cancelJob"
     
     fork="true">
       <description>
@@ -71,17 +71,9 @@ if [ -z "$INSTANCE_NAME" ]; then
     exit 1
 fi
 
-if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
-    RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)
-    STOPPED=$(docker inspect --format="{{ .State.Status }}" $INSTANCE_NAME 2> /dev/null)
-    if [ "$RUNNING" == "true" ]; then
-        echo "$INSTANCE_NAME" container is running
-        echo $INSTANCE_NAME > $INSTANCE_NAME"_status"
-	elif [ "$STOPPED" == "exited" ]; then
-		echo Starting docker container: "$INSTANCE_NAME"
-        INSTANCE_STATUS=$(docker start $INSTANCE_NAME 2>&1)
-        echo $INSTANCE_STATUS > $INSTANCE_NAME"_status"
-    fi
+if [ "$(docker ps --format '{{.Names}}' | grep "^$INSTANCE_NAME$")" ]; then
+    echo [ERROR] "$INSTANCE_NAME" is already used by another service instance.
+    exit 128
 else
     ################################################################################
     ### THIS PART IS IMAGE SPECIFIC. IF YOU NEED TO MODIFY SOMETHING, DO IT HERE ###
@@ -119,6 +111,11 @@ echo "$containerID" > $INSTANCE_NAME"_containerID"
           <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Post_Start_Service/raw" language="groovy"></file>
         </script>
       </post>
+      <cleaning>
+        <script>
+          <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Clean_Start_Service/raw" language="groovy"></file>
+        </script>
+      </cleaning>
       <metadata>
         <positionTop>
             276

--- a/Cassandra/resources/catalog/Cassandra.xml
+++ b/Cassandra/resources/catalog/Cassandra.xml
@@ -85,7 +85,7 @@ else
         INSTANCE_STATUS=$( eval "docker run --name $INSTANCE_NAME -p $F_PORT:$PORT "$ENV_VARS" -d $DOCKER_IMAGE" 2>&1)
     fi
     ################################################################################
-    if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
+    if [ "$(docker ps --format '{{.Names}}' | grep "^$INSTANCE_NAME$")" ]; then
         RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)
         if [ "$RUNNING" == "true" ]; then
             echo $INSTANCE_NAME > $INSTANCE_NAME"_status"

--- a/CloudAutomationDockerTemplate/resources/catalog/PCA_Template.xml
+++ b/CloudAutomationDockerTemplate/resources/catalog/PCA_Template.xml
@@ -102,17 +102,9 @@ if [ -z "$INSTANCE_NAME" ]; then
     exit 1
 fi
 
-if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
-    RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)
-    STOPPED=$(docker inspect --format="{{ .State.Status }}" $INSTANCE_NAME 2> /dev/null)
-    if [ "$RUNNING" == "true" ]; then
-        echo "$INSTANCE_NAME" container is running
-        echo $INSTANCE_NAME > $INSTANCE_NAME"_status"
-	elif [ "$STOPPED" == "exited" ]; then
-		echo Starting docker container: "$INSTANCE_NAME"
-        INSTANCE_STATUS=$(docker start $INSTANCE_NAME 2>&1)
-        echo $INSTANCE_STATUS > $INSTANCE_NAME"_status"
-    fi
+if [ "$(docker ps --format '{{.Names}}' | grep "^$INSTANCE_NAME$")" ]; then
+    echo [ERROR] "$INSTANCE_NAME" is already used by another service instance.
+    exit 128
 else
     echo "Running docker container: $INSTANCE_NAME with command:"
     echo "docker run --name $INSTANCE_NAME $DOCKER_PORT "$DOCKER_OPTIONS" -d $DOCKER_IMAGE "$DOCKER_COMMAND""
@@ -147,6 +139,11 @@ echo "$containerID" > $INSTANCE_NAME"_containerID"
           <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Post_Start_Service/raw" language="groovy"></file>
         </script>
       </post>
+      <cleaning>
+        <script>
+          <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Clean_Start_Service/raw" language="groovy"></file>
+        </script>
+      </cleaning>
       <metadata>
         <positionTop>
             478

--- a/CloudAutomationDockerTemplate/resources/catalog/PCA_Template.xml
+++ b/CloudAutomationDockerTemplate/resources/catalog/PCA_Template.xml
@@ -110,7 +110,7 @@ else
     echo "docker run --name $INSTANCE_NAME $DOCKER_PORT "$DOCKER_OPTIONS" -d $DOCKER_IMAGE "$DOCKER_COMMAND""
     INSTANCE_STATUS=$(eval "docker run --name $INSTANCE_NAME $DOCKER_PORT "$DOCKER_OPTIONS" -d $DOCKER_IMAGE "$DOCKER_COMMAND"" 2>&1)
 
-    if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
+    if [ "$(docker ps --format '{{.Names}}' | grep "^$INSTANCE_NAME$")" ]; then
         RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)
         if [ "$RUNNING" == "true" ]; then
             echo $INSTANCE_NAME > $INSTANCE_NAME"_status"

--- a/CloudAutomationDockerTemplate/resources/catalog/Resume_PCA_Template.xml
+++ b/CloudAutomationDockerTemplate/resources/catalog/Resume_PCA_Template.xml
@@ -55,7 +55,7 @@ synchronizationapi.put(channel, "PAUSE_LAUNCHED", false)
             <![CDATA[
 INSTANCE_NAME=$variables_INSTANCE_NAME
 
-if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
+if [ "$(docker ps --format '{{.Names}}' | grep "^$INSTANCE_NAME$")" ]; then
  RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)
  STOPPED=$(docker inspect --format="{{ .State.Status }}" $INSTANCE_NAME 2> /dev/null)
 	if [ "$RUNNING" == "true" ]; then

--- a/Docker/resources/catalog/Docker.xml
+++ b/Docker/resources/catalog/Docker.xml
@@ -143,7 +143,7 @@ else
         INSTANCE_STATUS=$(eval "docker run --name $INSTANCE_NAME -p $F_PORT:$PORT "$DOCKER_OPTIONS" -d $DOCKER_IMAGE "$DOCKER_COMMAND"" 2>&1)
     fi
     ################################################################################
-    if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
+    if [ "$(docker ps --format '{{.Names}}' | grep "^$INSTANCE_NAME$")" ]; then
         RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)
         if [ "$RUNNING" == "true" ]; then
             echo $INSTANCE_NAME > $INSTANCE_NAME"_status"

--- a/Docker/resources/catalog/Docker.xml
+++ b/Docker/resources/catalog/Docker.xml
@@ -125,17 +125,9 @@ if [ -z "$INSTANCE_NAME" ]; then
     exit 1
 fi
 
-if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
-    RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)
-    STOPPED=$(docker inspect --format="{{ .State.Status }}" $INSTANCE_NAME 2> /dev/null)
-    if [ "$RUNNING" == "true" ]; then
-        echo "$INSTANCE_NAME" container is running
-        echo $INSTANCE_NAME > $INSTANCE_NAME"_status"
-	elif [ "$STOPPED" == "exited" ]; then
-		echo Starting docker container: "$INSTANCE_NAME"
-        INSTANCE_STATUS=$(docker start $INSTANCE_NAME 2>&1)
-        echo $INSTANCE_STATUS > $INSTANCE_NAME"_status"
-    fi
+if [ "$(docker ps --format '{{.Names}}' | grep "^$INSTANCE_NAME$")" ]; then
+    echo [ERROR] "$INSTANCE_NAME" is already used by another service instance.
+    exit 128
 else
     ################################################################################
     ### THIS PART IS IMAGE SPECIFIC. IF YOU NEED TO MODIFY SOMETHING, DO IT HERE ###
@@ -177,6 +169,11 @@ echo "$containerID" > $INSTANCE_NAME"_containerID"
           <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Post_Start_Service/raw" language="groovy"></file>
         </script>
       </post>
+      <cleaning>
+        <script>
+          <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Clean_Start_Service/raw" language="groovy"></file>
+        </script>
+      </cleaning>
       <metadata>
         <positionTop>
             387

--- a/Docker/resources/catalog/Resume_Docker.xml
+++ b/Docker/resources/catalog/Resume_Docker.xml
@@ -53,7 +53,7 @@ synchronizationapi.put(channel, "PAUSE_LAUNCHED", false)
             <![CDATA[
 INSTANCE_NAME=$variables_INSTANCE_NAME
 
-if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
+if [ "$(docker ps --format '{{.Names}}' | grep "^$INSTANCE_NAME$")" ]; then
  RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)
  STOPPED=$(docker inspect --format="{{ .State.Status }}" $INSTANCE_NAME 2> /dev/null)
 	if [ "$RUNNING" == "true" ]; then

--- a/Elasticsearch/resources/catalog/Elasticsearch.xml
+++ b/Elasticsearch/resources/catalog/Elasticsearch.xml
@@ -78,7 +78,7 @@ else
     F_PORT=$(GET_RANDOM_PORT)
     docker run -d --name $INSTANCE_NAME -p $F_PORT:$PORT -e "discovery.type=single-node" $DOCKER_IMAGE
     ################################################################################
-    if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
+    if [ "$(docker ps --format '{{.Names}}' | grep "^$INSTANCE_NAME$")" ]; then
         RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)
         if [ "$RUNNING" == "true" ]; then
             echo $INSTANCE_NAME > $INSTANCE_NAME"_status"

--- a/Elasticsearch/resources/catalog/Elasticsearch.xml
+++ b/Elasticsearch/resources/catalog/Elasticsearch.xml
@@ -23,10 +23,10 @@ $INSTANCE_NAME (Required): service instance name ]]>
   </genericInformation>
   <taskFlow>
     <task name="Start_Elasticsearch" 
-    
-    
-    
-    
+
+
+    onTaskError="cancelJob"
+
     fork="true">
       <description>
         <![CDATA[ Pull Elasticsearch image and start a container ]]>
@@ -68,15 +68,9 @@ if [ -z "$INSTANCE_NAME" ]; then
     exit 1
 fi
 
-if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
-    RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)
-    STOPPED=$(docker inspect --format="{{ .State.Status }}" $INSTANCE_NAME 2> /dev/null)
-    if [ "$RUNNING" == "true" ]; then
-        echo "$INSTANCE_NAME container is running"
-    elif [ "$STOPPED" == "exited" ]; then
-        echo "Starting $INSTANCE_NAME container"
-        docker start $INSTANCE_NAME
-    fi
+if [ "$(docker ps --format '{{.Names}}' | grep "^$INSTANCE_NAME$")" ]; then
+    echo [ERROR] "$INSTANCE_NAME" is already used by another service instance.
+    exit 128
 else
     ################################################################################
     ### THIS PART IS IMAGE SPECIFIC. IF YOU NEED TO MODIFY SOMETHING, DO IT HERE ###
@@ -111,6 +105,11 @@ echo END "$variables_PA_TASK_NAME"
           <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Post_Start_Service/raw" language="groovy"></file>
         </script>
       </post>
+      <cleaning>
+        <script>
+          <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Clean_Start_Service/raw" language="groovy"></file>
+        </script>
+      </cleaning>
       <metadata>
         <positionTop>
             167.203125

--- a/H2O/resources/catalog/H2O.xml
+++ b/H2O/resources/catalog/H2O.xml
@@ -22,10 +22,10 @@ $INSTANCE_NAME (Required): service instance name. ]]>
     <info name="group" value="public-objects"/>
   </genericInformation>
   <taskFlow>
-    <task name="Start_H2O" 
-    
-    
-    
+    <task name="Start_H2O"
+
+
+    onTaskError="cancelJob"
     
     fork="true">
       <description>
@@ -69,17 +69,9 @@ if [ -z "$INSTANCE_NAME" ]; then
     exit 1
 fi
 
-if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
-    RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)
-    STOPPED=$(docker inspect --format="{{ .State.Status }}" $INSTANCE_NAME 2> /dev/null)
-    if [ "$RUNNING" == "true" ]; then
-        echo "$INSTANCE_NAME" container is running
-        echo $INSTANCE_NAME > $INSTANCE_NAME"_status"
-	elif [ "$STOPPED" == "exited" ]; then
-		echo Starting docker container: "$INSTANCE_NAME"
-        INSTANCE_STATUS=$(docker start $INSTANCE_NAME 2>&1)
-        echo $INSTANCE_STATUS > $INSTANCE_NAME"_status"
-    fi
+if [ "$(docker ps --format '{{.Names}}' | grep "^$INSTANCE_NAME$")" ]; then
+    echo [ERROR] "$INSTANCE_NAME" is already used by another service instance.
+    exit 128
 else
     ################################################################################
     ### THIS PART IS IMAGE SPECIFIC. IF YOU NEED TO MODIFY SOMETHING, DO IT HERE ###
@@ -113,6 +105,11 @@ echo END "$variables_PA_TASK_NAME"
           <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Post_Start_Service/raw" language="groovy"></file>
         </script>
       </post>
+      <cleaning>
+        <script>
+          <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Clean_Start_Service/raw" language="groovy"></file>
+        </script>
+      </cleaning>
       <metadata>
         <positionTop>
             202.015625

--- a/H2O/resources/catalog/H2O.xml
+++ b/H2O/resources/catalog/H2O.xml
@@ -78,7 +78,7 @@ else
     echo "Running $INSTANCE_NAME container"
     INSTANCE_STATUS=$(docker run -d --name $INSTANCE_NAME -p 54321 "$DOCKER_IMAGE" /bin/bash -c ./start-h2o-docker.sh)
     ################################################################################
-    if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
+    if [ "$(docker ps --format '{{.Names}}' | grep "^$INSTANCE_NAME$")" ]; then
         RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)
         if [ "$RUNNING" == "true" ]; then
             echo $INSTANCE_NAME > $INSTANCE_NAME"_status"

--- a/Kafka/resources/catalog/Kafka.xml
+++ b/Kafka/resources/catalog/Kafka.xml
@@ -25,9 +25,9 @@ $INSTANCE_NAME (Required): service instance name ]]>
   </genericInformation>
   <taskFlow>
     <task name="Loop_Over_Instance_Status" 
-    
-    
-    
+
+
+    onTaskError="cancelJob"
     
     fork="true">
       <description>
@@ -126,9 +126,9 @@ if [ -z "$INSTANCE_NAME" ]; then
     exit 1
 fi
 
-if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
-     echo [ERROR] "$INSTANCE_NAME" is already used by another service instance.
-     exit 128
+if [ "$(docker ps --format '{{.Names}}' | grep "^$INSTANCE_NAME$")" ]; then
+    echo [ERROR] "$INSTANCE_NAME" is already used by another service instance.
+    exit 128
 else
     ################################################################################
     ### THIS PART IS IMAGE SPECIFIC. IF YOU NEED TO MODIFY SOMETHING, DO IT HERE ###
@@ -169,6 +169,11 @@ echo "$containerID" > $INSTANCE_NAME"_containerID"
           <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Post_Start_Service/raw" language="groovy"></file>
         </script>
       </post>
+      <cleaning>
+        <script>
+          <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Clean_Start_Service/raw" language="groovy"></file>
+        </script>
+      </cleaning>
       <metadata>
         <positionTop>
             436.67613220214844

--- a/Kafka/resources/catalog/Kafka.xml
+++ b/Kafka/resources/catalog/Kafka.xml
@@ -143,7 +143,7 @@ else
            --env KAFKA_BROKER_ID="$BROKER_ID" \
            "$DOCKER_IMAGE"
           
-    if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
+    if [ "$(docker ps --format '{{.Names}}' | grep "^$INSTANCE_NAME$")" ]; then
         RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)
         if [ "$RUNNING" == "true" ]; then
             echo $INSTANCE_NAME > $INSTANCE_NAME"_status"

--- a/Kibana/resources/catalog/Kibana.xml
+++ b/Kibana/resources/catalog/Kibana.xml
@@ -23,10 +23,10 @@ $INSTANCE_NAME (Required): service instance name ]]>
     <info name="group" value="public-objects"/>
   </genericInformation>
   <taskFlow>
-    <task name="Start_Kibana" 
-    
-    
-    
+    <task name="Start_Kibana"
+
+
+    onTaskError="cancelJob"
     
     fork="true">
       <description>
@@ -72,15 +72,9 @@ if [ -z "$INSTANCE_NAME" ]; then
     exit 1
 fi
 
-if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
-    RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)
-    STOPPED=$(docker inspect --format="{{ .State.Status }}" $INSTANCE_NAME 2> /dev/null)
-    if [ "$RUNNING" == "true" ]; then
-        echo "$INSTANCE_NAME container is running"
-    elif [ "$STOPPED" == "exited" ]; then
-        echo "Starting $INSTANCE_NAME container"
-        docker start $INSTANCE_NAME
-    fi
+if [ "$(docker ps --format '{{.Names}}' | grep "^$INSTANCE_NAME$")" ]; then
+    echo [ERROR] "$INSTANCE_NAME" is already used by another service instance.
+    exit 128
 else
     ################################################################################
     ### THIS PART IS IMAGE SPECIFIC. IF YOU NEED TO MODIFY SOMETHING, DO IT HERE ###
@@ -116,6 +110,11 @@ echo END "$variables_PA_TASK_NAME"
           <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Post_Start_Service/raw" language="groovy"></file>
         </script>
       </post>
+      <cleaning>
+        <script>
+          <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Clean_Start_Service/raw" language="groovy"></file>
+        </script>
+      </cleaning>
       <metadata>
         <positionTop>
             196.984375

--- a/Kibana/resources/catalog/Kibana.xml
+++ b/Kibana/resources/catalog/Kibana.xml
@@ -83,7 +83,7 @@ else
     echo "docker run -d --name $INSTANCE_NAME -p $F_PORT:$PORT -e "discovery.type=single-node" -e ELASTICSEARCH_URL=$ENDPOINT_ELASTICSEARCH $DOCKER_IMAGE"
     docker run -d --name $INSTANCE_NAME -p $F_PORT:$PORT -e "discovery.type=single-node" -e ELASTICSEARCH_URL=$ENDPOINT_ELASTICSEARCH $DOCKER_IMAGE
     ################################################################################
-    if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
+    if [ "$(docker ps --format '{{.Names}}' | grep "^$INSTANCE_NAME$")" ]; then
         RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)
         if [ "$RUNNING" == "true" ]; then
             echo $INSTANCE_NAME > $INSTANCE_NAME"_status"

--- a/Logstash/resources/catalog/Logstash.xml
+++ b/Logstash/resources/catalog/Logstash.xml
@@ -23,10 +23,10 @@ $INSTANCE_NAME (Required): service instance name ]]>
     <info name="group" value="public-objects"/>
   </genericInformation>
   <taskFlow>
-    <task name="Start_Logstash" 
-    
-    
-    
+    <task name="Start_Logstash"
+
+
+    onTaskError="cancelJob"
     
     fork="true">
       <description>
@@ -69,15 +69,9 @@ if [ -z "$INSTANCE_NAME" ]; then
     exit 1
 fi
 
-if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
-    RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)
-    STOPPED=$(docker inspect --format="{{ .State.Status }}" $INSTANCE_NAME 2> /dev/null)
-    if [ "$RUNNING" == "true" ]; then
-        echo "$INSTANCE_NAME container is running"
-    elif [ "$STOPPED" == "exited" ]; then
-        echo "Starting $INSTANCE_NAME container"
-        docker start $INSTANCE_NAME
-    fi
+if [ "$(docker ps --format '{{.Names}}' | grep "^$INSTANCE_NAME$")" ]; then
+    echo [ERROR] "$INSTANCE_NAME" is already used by another service instance.
+    exit 128
 else
     ################################################################################
     ### THIS PART IS IMAGE SPECIFIC. IF YOU NEED TO MODIFY SOMETHING, DO IT HERE ###
@@ -113,6 +107,11 @@ echo END "$variables_PA_TASK_NAME"
           <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Post_Start_Service/raw" language="groovy"></file>
         </script>
       </post>
+      <cleaning>
+        <script>
+          <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Clean_Start_Service/raw" language="groovy"></file>
+        </script>
+      </cleaning>
       <metadata>
         <positionTop>
             161.015625

--- a/Logstash/resources/catalog/Logstash.xml
+++ b/Logstash/resources/catalog/Logstash.xml
@@ -80,7 +80,7 @@ else
     echo "docker run -dit --name $INSTANCE_NAME -p $F_PORT:$PORT -e ELASTICSEARCH_URL=$ENDPOINT_ELASTICSEARCH $DOCKER_IMAGE"
     docker run -dit --name $INSTANCE_NAME -p $F_PORT:$PORT -e ELASTICSEARCH_URL=$ENDPOINT_ELASTICSEARCH $DOCKER_IMAGE
     ################################################################################
-    if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
+    if [ "$(docker ps --format '{{.Names}}' | grep "^$INSTANCE_NAME$")" ]; then
         RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)
         if [ "$RUNNING" == "true" ]; then
             echo $INSTANCE_NAME > $INSTANCE_NAME"_status"

--- a/ModelAsServicePCA/resources/catalog/Model_Service.xml
+++ b/ModelAsServicePCA/resources/catalog/Model_Service.xml
@@ -26,10 +26,10 @@ $INSTANCE_NAME (Required): service instance name ]]>
     <info name="group" value="public-objects"/>
   </genericInformation>
   <taskFlow>
-    <task name="Start_Model_Service" 
-    
-    
-    
+    <task name="Start_Model_Service"
+
+
+    onTaskError="cancelJob"
     
     fork="true">
       <description>
@@ -177,9 +177,9 @@ if [ -z "$INSTANCE_NAME" ]; then
     exit 1
 fi
 
-if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then   
-        echo [ERROR] "$INSTANCE_NAME" is already used by another service instance.
-        exit 128
+if [ "$(docker ps --format '{{.Names}}' | grep "^$INSTANCE_NAME$")" ]; then
+    echo [ERROR] "$INSTANCE_NAME" is already used by another service instance.
+    exit 128
 else
     ################################################################################
     ### THIS PART IS IMAGE SPECIFIC. IF YOU NEED TO MODIFY SOMETHING, DO IT HERE ###
@@ -338,6 +338,11 @@ println("END " + variables.get("PA_TASK_NAME"))
           </code>
         </script>
       </post>
+      <cleaning>
+        <script>
+          <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Clean_Start_Service/raw" language="groovy"></file>
+        </script>
+      </cleaning>
       <metadata>
         <positionTop>
             442.20703125

--- a/ModelAsServicePCA/resources/catalog/Model_Service.xml
+++ b/ModelAsServicePCA/resources/catalog/Model_Service.xml
@@ -200,7 +200,7 @@ else
     echo "docker exec -dit $INSTANCE_NAME bash -c python /model_as_a_service/ml_service.py >> /proc/1/fd/1"
     docker exec -dit $INSTANCE_NAME bash -c "python /model_as_a_service/ml_service.py >> /proc/1/fd/1"
     ################################################################################
-    if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
+    if [ "$(docker ps --format '{{.Names}}' | grep "^$INSTANCE_NAME$")" ]; then
         RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)
         if [ "$RUNNING" == "true" ]; then
             echo $INSTANCE_NAME > $INSTANCE_NAME"_status"

--- a/ModelAsServicePCA/resources/catalog/Resume_Model_Service.xml
+++ b/ModelAsServicePCA/resources/catalog/Resume_Model_Service.xml
@@ -42,7 +42,7 @@
             <![CDATA[
 INSTANCE_NAME=$variables_INSTANCE_NAME
 
-if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
+if [ "$(docker ps --format '{{.Names}}' | grep "^$INSTANCE_NAME$")" ]; then
  RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)
  STOPPED=$(docker inspect --format="{{ .State.Status }}" $INSTANCE_NAME 2> /dev/null)
 	if [ "$RUNNING" == "true" ]; then

--- a/MongoDB/resources/catalog/MongoDB.xml
+++ b/MongoDB/resources/catalog/MongoDB.xml
@@ -92,7 +92,7 @@ else
         INSTANCE_STATUS=$(docker run --name $INSTANCE_NAME -p $F_PORT:$PORT -e MONGO_INITDB_ROOT_USERNAME=$USER -e MONGO_INITDB_ROOT_PASSWORD=$PASSWORD -d $DOCKER_IMAGE)
     fi
     ################################################################################
-    if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
+    if [ "$(docker ps --format '{{.Names}}' | grep "^$INSTANCE_NAME$")" ]; then
         RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)
         if [ "$RUNNING" == "true" ]; then
             echo $INSTANCE_NAME > $INSTANCE_NAME"_status"

--- a/MongoDB/resources/catalog/MongoDB.xml
+++ b/MongoDB/resources/catalog/MongoDB.xml
@@ -26,10 +26,10 @@ PASSWORD (Optional): Password for the root user. ]]>
     <info name="group" value="public-objects"/>
   </genericInformation>
   <taskFlow>
-    <task name="Start_MongoDB" 
-    
-    
-    
+    <task name="Start_MongoDB"
+
+
+    onTaskError="cancelJob"
     
     fork="true">
       <description>
@@ -78,17 +78,9 @@ if [ -z "$INSTANCE_NAME" ]; then
     exit 1
 fi
 
-if [ "$(docker ps --format '{{.Names}}' | grep ^$INSTANCE_NAME$)" ]; then
-    RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)
-    STOPPED=$(docker inspect --format="{{ .State.Status }}" $INSTANCE_NAME 2> /dev/null)
-    if [ "$RUNNING" == "true" ]; then
-        echo "$INSTANCE_NAME" container is running
-        echo $INSTANCE_NAME > $INSTANCE_NAME"_status"
-	elif [ "$STOPPED" == "exited" ]; then
-		echo Starting docker container: "$INSTANCE_NAME"
-        INSTANCE_STATUS=$(docker start $INSTANCE_NAME 2>&1)
-        echo $INSTANCE_STATUS > $INSTANCE_NAME"_status"
-    fi
+if [ "$(docker ps --format '{{.Names}}' | grep "^$INSTANCE_NAME$")" ]; then
+    echo [ERROR] "$INSTANCE_NAME" is already used by another service instance.
+    exit 128
 else
     ################################################################################
     ### THIS PART IS IMAGE SPECIFIC. IF YOU NEED TO MODIFY SOMETHING, DO IT HERE ###
@@ -127,6 +119,11 @@ echo "$containerID" > $INSTANCE_NAME"_containerID"
           <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Post_Start_Service/raw" language="groovy"></file>
         </script>
       </post>
+      <cleaning>
+        <script>
+          <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Clean_Start_Service/raw" language="groovy"></file>
+        </script>
+      </cleaning>
       <metadata>
         <positionTop>
             359

--- a/MySQL/resources/catalog/MySQL.xml
+++ b/MySQL/resources/catalog/MySQL.xml
@@ -102,7 +102,7 @@ else
         INSTANCE_STATUS=$(docker run --name "$INSTANCE_NAME" -p $F_PORT:$PORT -e MYSQL_ROOT_PASSWORD="$ROOT_PASSWORD" -e MYSQL_USER="$USER" -e MYSQL_PASSWORD=$PASSWORD -e MYSQL_DATABASE="$DATABASE" -d "$DOCKER_IMAGE")
     fi
     ################################################################################
-    if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
+    if [ "$(docker ps --format '{{.Names}}' | grep "^$INSTANCE_NAME$")" ]; then
         RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)
         if [ "$RUNNING" == "true" ]; then
             echo $INSTANCE_NAME > $INSTANCE_NAME"_status"

--- a/MySQL/resources/catalog/MySQL.xml
+++ b/MySQL/resources/catalog/MySQL.xml
@@ -28,10 +28,10 @@ PASSWORD (Optional): Password for the root user. ]]>
     <info name="group" value="public-objects"/>
   </genericInformation>
   <taskFlow>
-    <task name="Start_MySQL" 
-    
-    
-    
+    <task name="Start_MySQL"
+
+
+    onTaskError="cancelJob"
     
     fork="true">
       <description>
@@ -85,17 +85,9 @@ if [ -z "$INSTANCE_NAME" ]; then
     exit 1
 fi
 
-if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
-    RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)
-    STOPPED=$(docker inspect --format="{{ .State.Status }}" $INSTANCE_NAME 2> /dev/null)
-    if [ "$RUNNING" == "true" ]; then
-        echo "$INSTANCE_NAME" container is running
-        echo $INSTANCE_NAME > $INSTANCE_NAME"_status"
-	elif [ "$STOPPED" == "exited" ]; then
-		echo Starting docker container: "$INSTANCE_NAME"
-        INSTANCE_STATUS=$(docker start $INSTANCE_NAME 2>&1)
-        echo $INSTANCE_STATUS > $INSTANCE_NAME"_status"
-    fi
+if [ "$(docker ps --format '{{.Names}}' | grep "^$INSTANCE_NAME$")" ]; then
+    echo [ERROR] "$INSTANCE_NAME" is already used by another service instance.
+    exit 128
 else
     ################################################################################
     ### THIS PART IS IMAGE SPECIFIC. IF YOU NEED TO MODIFY SOMETHING, DO IT HERE ###
@@ -137,6 +129,11 @@ echo "$containerID" > $INSTANCE_NAME"_containerID"
           <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Post_Start_Service/raw" language="groovy"></file>
         </script>
       </post>
+      <cleaning>
+        <script>
+          <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Clean_Start_Service/raw" language="groovy"></file>
+        </script>
+      </cleaning>
       <metadata>
         <positionTop>
             136

--- a/Oracle/resources/catalog/Oracle.xml
+++ b/Oracle/resources/catalog/Oracle.xml
@@ -90,7 +90,7 @@ else
         INSTANCE_STATUS=$( eval "docker run --name $INSTANCE_NAME -p $F_PORT:$PORT "$ENV_VARS" -d $DOCKER_IMAGE" 2>&1)
     fi
     ################################################################################
-    if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
+    if [ "$(docker ps --format '{{.Names}}' | grep "^$INSTANCE_NAME$")" ]; then
         RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)
         if [ "$RUNNING" == "true" ]; then
             echo $INSTANCE_NAME > $INSTANCE_NAME"_status"

--- a/Oracle/resources/catalog/Oracle.xml
+++ b/Oracle/resources/catalog/Oracle.xml
@@ -28,10 +28,10 @@ password: oracle ]]>
     <info name="group" value="public-objects"/>
   </genericInformation>
   <taskFlow>
-    <task name="Start_Oracle" 
-    
-    
-    
+    <task name="Start_Oracle"
+
+
+    onTaskError="cancelJob"
     
     fork="true">
       <description>
@@ -76,17 +76,9 @@ if [ -z "$INSTANCE_NAME" ]; then
     exit 1
 fi
 
-if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
-    RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)
-    STOPPED=$(docker inspect --format="{{ .State.Status }}" $INSTANCE_NAME 2> /dev/null)
-    if [ "$RUNNING" == "true" ]; then
-        echo "$INSTANCE_NAME" container is running
-        echo $INSTANCE_NAME > $INSTANCE_NAME"_status"
-	elif [ "$STOPPED" == "exited" ]; then
-		echo Starting docker container: "$INSTANCE_NAME"
-        INSTANCE_STATUS=$(docker start $INSTANCE_NAME 2>&1)
-        echo $INSTANCE_STATUS > $INSTANCE_NAME"_status"
-    fi
+if [ "$(docker ps --format '{{.Names}}' | grep "^$INSTANCE_NAME$")" ]; then
+    echo [ERROR] "$INSTANCE_NAME" is already used by another service instance.
+    exit 128
 else
     ################################################################################
     ### THIS PART IS IMAGE SPECIFIC. IF YOU NEED TO MODIFY SOMETHING, DO IT HERE ###
@@ -124,6 +116,11 @@ echo "$containerID" > $INSTANCE_NAME"_containerID"
           <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Post_Start_Service/raw" language="groovy"></file>
         </script>
       </post>
+      <cleaning>
+        <script>
+          <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Clean_Start_Service/raw" language="groovy"></file>
+        </script>
+      </cleaning>
       <metadata>
         <positionTop>
             283

--- a/PcaScripts/resources/catalog/Clean_Start_Service.groovy
+++ b/PcaScripts/resources/catalog/Clean_Start_Service.groovy
@@ -1,0 +1,32 @@
+/*********************************************************************************
+ * THIS CLEANCRIPT MAKE SURE THAT THE PCA INSTANCE STATUS IS IN ERROR IN CASE THE *
+ * SERVICE HAS NOT STARTED PROPERLY                                               *
+ *********************************************************************************/
+
+import org.ow2.proactive.pca.service.client.ApiClient
+import org.ow2.proactive.pca.service.client.api.ServiceInstanceRestApi
+import org.ow2.proactive.pca.service.client.model.ServiceInstanceData
+
+// Acquire variables
+def instanceId = variables.get("PCA_INSTANCE_ID") as long
+
+// Determine Cloud Automation URL
+def paSchedulerRestUrl = variables.get('PA_SCHEDULER_REST_URL')
+def pcaUrl = paSchedulerRestUrl.replaceAll("/rest\\z", "/cloud-automation-service")
+
+// Connect to Cloud Automation API
+def apiClient = new ApiClient()
+apiClient.setBasePath(pcaUrl)
+def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
+
+
+// Update service instance model (add Deployment, Groups)
+def serviceInstanceData = serviceInstanceRestApi.getServiceInstanceUsingGET(instanceId)
+
+// If service instance is NOT RUNNING then it should be in ERROR
+def currentStatus = serviceInstanceData.getInstanceStatus()
+if (!currentStatus.equals("RUNNING")) {
+    serviceInstanceData.setInstanceStatus("ERROR")
+    serviceInstanceData = serviceInstanceRestApi.updateServiceInstanceUsingPUT(instanceId, serviceInstanceData)
+    println(serviceInstanceData)
+}

--- a/PcaScripts/resources/catalog/Resume_Action.bash
+++ b/PcaScripts/resources/catalog/Resume_Action.bash
@@ -1,6 +1,6 @@
 INSTANCE_NAME=$variables_INSTANCE_NAME
 
-if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
+if [ "$(docker ps --format '{{.Names}}' | grep "^$INSTANCE_NAME$")" ]; then
  RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)
  STOPPED=$(docker inspect --format="{{ .State.Status }}" $INSTANCE_NAME 2> /dev/null)
 	if [ "$RUNNING" == "true" ]; then

--- a/PostgreSQL/resources/catalog/PostgreSQL.xml
+++ b/PostgreSQL/resources/catalog/PostgreSQL.xml
@@ -168,7 +168,7 @@ else
         docker run --name "$INSTANCE_NAME" -p $F_PORT:"$PORT" -e POSTGRES_USER="$USER" -e POSTGRES_PASSWORD="$PASSWORD" -e POSTGRES_DB="$DATABASE" -d "$DOCKER_IMAGE" -c 'listen_addresses=0.0.0.0'
     fi
     ################################################################################
-    if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
+    if [ "$(docker ps --format '{{.Names}}' | grep "^$INSTANCE_NAME$")" ]; then
     	RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)
     	if [ "$RUNNING" == "true" ]; then
         	echo $INSTANCE_NAME > $INSTANCE_NAME"_status"

--- a/PostgreSQL/resources/catalog/PostgreSQL.xml
+++ b/PostgreSQL/resources/catalog/PostgreSQL.xml
@@ -150,17 +150,9 @@ if [ -z "$INSTANCE_NAME" ]; then
     exit 1
 fi
 
-if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
-    RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)
-    STOPPED=$(docker inspect --format="{{ .State.Status }}" $INSTANCE_NAME 2> /dev/null)
-    if [ "$RUNNING" == "true" ]; then
-        echo "$INSTANCE_NAME" container is running
-        echo $INSTANCE_NAME > $INSTANCE_NAME"_status"
-	elif [ "$STOPPED" == "exited" ]; then
-		echo Starting docker container: "$INSTANCE_NAME"
-        INSTANCE_STATUS=$(docker start $INSTANCE_NAME 2>&1)
-        echo $INSTANCE_STATUS > $INSTANCE_NAME"_status"
-    fi
+if [ "$(docker ps --format '{{.Names}}' | grep "^$INSTANCE_NAME$")" ]; then
+    echo [ERROR] "$INSTANCE_NAME" is already used by another service instance.
+    exit 128
 else
     ################################################################################
     ### THIS PART IS IMAGE SPECIFIC. IF YOU NEED TO MODIFY SOMETHING, DO IT HERE ###
@@ -202,6 +194,11 @@ echo "$containerID" > $INSTANCE_NAME"_containerID"
           <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Post_Start_Service/raw" language="groovy"></file>
         </script>
       </post>
+      <cleaning>
+        <script>
+          <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Clean_Start_Service/raw" language="groovy"></file>
+        </script>
+      </cleaning>
       <metadata>
         <positionTop>
             149

--- a/Storm/resources/catalog/Storm.xml
+++ b/Storm/resources/catalog/Storm.xml
@@ -175,7 +175,8 @@ done
         </positionLeft>
       </metadata>
     </task>
-    <task name="start_ui" 
+    <task name="start_ui"
+    onTaskError="cancelJob"
     fork="true">
       <description>
         <![CDATA[ start Storm UI ]]>
@@ -196,9 +197,9 @@ done
 NIMBUS=$variables_INSTANCE_NAME"-nimbus"
 CONTAINER=$variables_INSTANCE_NAME
 
-if [ "$(docker container ls | grep '$CONTAINER$')" ]; then
+if [ "$(docker ps --format '{{.Names}}' | grep "^$INSTANCE_NAME$")" ]; then
          echo [ERROR] "$INSTANCE_NAME" is already used by another service instance.
-         exit 128    
+         exit 128
 else 
  echo "Running $CONTAINER"
  docker create -h ui -p 8080 --name $CONTAINER --link $NIMBUS:$NIMBUS storm:1.2.2 storm ui
@@ -236,6 +237,11 @@ done
           <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Post_Start_Service/raw" language="groovy"></file>
         </script>
       </post>
+      <cleaning>
+        <script>
+          <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Clean_Start_Service/raw" language="groovy"></file>
+        </script>
+      </cleaning>
       <metadata>
         <positionTop>
             610.0710296630859

--- a/Zookeeper/resources/catalog/Zookeeper.xml
+++ b/Zookeeper/resources/catalog/Zookeeper.xml
@@ -67,9 +67,9 @@ if [ -z "$INSTANCE_NAME" ]; then
     exit 1
 fi
 
-if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then   
-        echo [ERROR] "$INSTANCE_NAME" is already used by another service instance.
-        exit 128
+if [ "$(docker ps --format '{{.Names}}' | grep "^$INSTANCE_NAME$")" ]; then
+    echo [ERROR] "$INSTANCE_NAME" is already used by another service instance.
+    exit 128
 else
     ################################################################################
     ### THIS PART IS IMAGE SPECIFIC. IF YOU NEED TO MODIFY SOMETHING, DO IT HERE ###
@@ -104,6 +104,11 @@ echo END "$variables_PA_TASK_NAME"
           <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Post_Start_Service/raw" language="groovy"></file>
         </script>
       </post>
+      <cleaning>
+        <script>
+          <file url="${PA_CATALOG_REST_URL}/buckets/cloud-automation-scripts/resources/Clean_Start_Service/raw" language="groovy"></file>
+        </script>
+      </cleaning>
       <metadata>
         <positionTop>
             331.7471466064453

--- a/Zookeeper/resources/catalog/Zookeeper.xml
+++ b/Zookeeper/resources/catalog/Zookeeper.xml
@@ -77,7 +77,7 @@ else
     F_PORT=$(GET_RANDOM_PORT)
           docker run --name "$INSTANCE_NAME" -p $F_PORT:"$PORT" -d "$DOCKER_IMAGE"
     ################################################################################
-    if [ "$(docker ps -a | grep $INSTANCE_NAME)" ]; then
+    if [ "$(docker ps --format '{{.Names}}' | grep "^$INSTANCE_NAME$")" ]; then
         RUNNING=$(docker inspect --format="{{ .State.Running }}" $INSTANCE_NAME 2> /dev/null)
         if [ "$RUNNING" == "true" ]; then
             echo $INSTANCE_NAME > $INSTANCE_NAME"_status"


### PR DESCRIPTION
This PR makes sure that a PCA service instance has a unique name. This guarantees us to have a unique token and a unique PCA instance per Docker container. Some PCA workflows (such as Visdom or Tensorflow) have not been modified yet. 