### PR TITLE
fix: update cloud node source examples to add parameter startupScript

### DIFF
--- a/NodeSources/resources/catalog/AwsEC2Cloud.json
+++ b/NodeSources/resources/catalog/AwsEC2Cloud.json
@@ -7,7 +7,7 @@
     "configurableFields": [
       {
         "name": "awsKey",
-        "value": "[please put your AWS access key ID]",
+        "value": "",
         "meta": {
           "type": "NONE",
           "description": "Your AWS access key ID (e.g., AKIAIOSFODNN7EXAMPLE)",
@@ -18,7 +18,7 @@
       },
       {
         "name": "awsSecretKey",
-        "value": "[please put your AWS secret access key]",
+        "value": "",
         "meta": {
           "type": "NONE",
           "description": "Your AWS secret access key (e.g., wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY)",
@@ -54,10 +54,10 @@
         "value": "eu-west-3/ami-03bca18cb3dc173c9",
         "meta": {
           "type": "NONE",
-          "description": "(optional, default value: eu-west-3/ami-03bca18cb3dc173c9) VM image id, format region/imageId",
+          "description": "VM image id, format region/imageId (optional, default value: eu-west-3/ami-03bca18cb3dc173c9)",
           "dynamic": false,
           "sectionSelector": 3,
-          "important": false
+          "important": true
         }
       },
       {
@@ -65,7 +65,7 @@
         "value": "ubuntu",
         "meta": {
           "type": "NONE",
-          "description": "(optional, default value: ubuntu) Default username of your VM image, make sure it's adapted to 'image'",
+          "description": "Default username of your VM image, make sure it's adapted to 'image' (optional, default value: ubuntu)",
           "dynamic": false,
           "sectionSelector": 3,
           "important": false
@@ -76,7 +76,7 @@
         "value": "",
         "meta": {
           "type": "NONE",
-          "description": "(optional) The name of your AWS key pair for accessing VM",
+          "description": "The name of your AWS key pair for accessing VM (optional)",
           "dynamic": false,
           "sectionSelector": 3,
           "important": false
@@ -87,7 +87,7 @@
         "value": "",
         "meta": {
           "type": "FILEBROWSER",
-          "description": "(optional) Your AWS private key file corresponding to 'vmKeyPairName' for accessing VM",
+          "description": "Your AWS private key file corresponding to 'vmKeyPairName' for accessing VM (optional)",
           "dynamic": false,
           "sectionSelector": 3,
           "important": false
@@ -98,10 +98,10 @@
         "value": "4096",
         "meta": {
           "type": "NONE",
-          "description": "(optional) The minimum RAM required (in Mega Bytes) for each VM",
+          "description": "The minimum RAM required (in Mega Bytes) for each VM (optional, default value: 2048)",
           "dynamic": false,
           "sectionSelector": 3,
-          "important": false
+          "important": true
         }
       },
       {
@@ -109,10 +109,10 @@
         "value": "2",
         "meta": {
           "type": "NONE",
-          "description": "(optional) The minimum number of CPU cores required for each VM",
+          "description": "The minimum number of CPU cores required for each VM (optional, default value: 2)",
           "dynamic": false,
           "sectionSelector": 3,
-          "important": false
+          "important": true
         }
       },
       {
@@ -120,7 +120,7 @@
         "value": "",
         "meta": {
           "type": "NONE",
-          "description": "(optional) The ids(s) of the security group(s) for VMs, spearated by comma in case of multiple ids.",
+          "description": "The ids(s) of the security group(s) for VMs, spearated by comma in case of multiple ids. (optional)",
           "dynamic": false,
           "sectionSelector": 3,
           "important": false
@@ -131,7 +131,7 @@
         "value": "",
         "meta": {
           "type": "NONE",
-          "description": "(optional) The subnet ID which is added to a specific Amazon VPC.",
+          "description": "The subnet ID which is added to a specific Amazon VPC. (optional)",
           "dynamic": false,
           "sectionSelector": 3,
           "important": false
@@ -145,7 +145,7 @@
           "description": "Resource Manager hostname or ip address (must be accessible from nodes)",
           "dynamic": false,
           "sectionSelector": 4,
-          "important": true
+          "important": false
         }
       },
       {
@@ -156,18 +156,18 @@
           "description": "Connector-iaas URL",
           "dynamic": false,
           "sectionSelector": 4,
-          "important": true
+          "important": false
         }
       },
       {
         "name": "nodeJarURL",
-        "value": "try.activeeon.com/rest/node.jar",
+        "value": "http://try.activeeon.com/rest/node.jar",
         "meta": {
           "type": "NONE",
           "description": "URL used to download the node jar on the VM",
           "dynamic": false,
           "sectionSelector": 4,
-          "important": true
+          "important": false
         }
       },
       {
@@ -175,7 +175,7 @@
         "value": "",
         "meta": {
           "type": "NONE",
-          "description": "(optional) Additional Java command properties (e.g. \"-Dpropertyname=propertyvalue\")",
+          "description": "Additional Java command properties (e.g. \"-Dpropertyname=propertyvalue\") (optional)",
           "dynamic": false,
           "sectionSelector": 5,
           "important": false
@@ -186,7 +186,18 @@
         "value": "300000",
         "meta": {
           "type": "NONE",
-          "description": "The timeout for nodes to connect to RM (in ms). After this timeout expired, the node is considered to be lost.",
+          "description": "The timeout for nodes to connect to RM (in ms). After this timeout expired, the node is considered to be lost. (optional, default value: 300000)",
+          "dynamic": false,
+          "sectionSelector": 5,
+          "important": false
+        }
+      },
+      {
+        "name": "startupScript",
+        "value": "mkdir -p /tmp/node && cd /tmp/node\r\n if ! type -p jre/bin/java; then wget -nv -N https://s3.amazonaws.com/ci-materials/Latest_jre/jre-8u131-linux-x64.tar.gz; tar -xf jre-8u131-linux-x64.tar.gz; mv jre1.8.0_131/ jre; fi\r\nwget -nv %nodeJarUrl%\r\nnohup jre/bin/java -jar node.jar -Dproactive.communication.protocol=%protocol% -Dpython.path=%jythonPath% -Dproactive.pamr.router.address=%rmHostname% -D%instanceIdNodeProperty%=%instanceId% -r %rmUrl% -s %nodeSourceName% %nodeNamingOption% -v %credentials% -w %numberOfNodesPerInstance% %additionalProperties% &",
+        "meta": {
+          "type": "TEXTAREA",
+          "description": "VM startup script to launch the ProActive nodes (optional). Please refer to the documentation for full description.",
           "dynamic": false,
           "sectionSelector": 5,
           "important": false
@@ -235,6 +246,7 @@
     "defaultValues": {},
     "sectionDescriptions": {
       "1": "Authorizations"
-    }
+    },
+    "meta": {}
   }
 }

--- a/NodeSources/resources/catalog/AwsEC2CloudElastic.json
+++ b/NodeSources/resources/catalog/AwsEC2CloudElastic.json
@@ -7,7 +7,7 @@
     "configurableFields": [
       {
         "name": "awsKey",
-        "value": "[please put your AWS access key ID]",
+        "value": "",
         "meta": {
           "type": "NONE",
           "description": "Your AWS access key ID (e.g., AKIAIOSFODNN7EXAMPLE)",
@@ -18,7 +18,7 @@
       },
       {
         "name": "awsSecretKey",
-        "value": "[please put your AWS secret access key]",
+        "value": "",
         "meta": {
           "type": "NONE",
           "description": "Your AWS secret access key (e.g., wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY)",
@@ -54,10 +54,10 @@
         "value": "eu-west-3/ami-03bca18cb3dc173c9",
         "meta": {
           "type": "NONE",
-          "description": "(optional, default value: eu-west-3/ami-03bca18cb3dc173c9) VM image id, format region/imageId",
+          "description": "VM image id, format region/imageId (optional, default value: eu-west-3/ami-03bca18cb3dc173c9)",
           "dynamic": false,
           "sectionSelector": 3,
-          "important": false
+          "important": true
         }
       },
       {
@@ -65,7 +65,7 @@
         "value": "ubuntu",
         "meta": {
           "type": "NONE",
-          "description": "(optional, default value: ubuntu) Default username of your VM image, make sure it's adapted to 'image'",
+          "description": "Default username of your VM image, make sure it's adapted to 'image' (optional, default value: ubuntu)",
           "dynamic": false,
           "sectionSelector": 3,
           "important": false
@@ -76,7 +76,7 @@
         "value": "",
         "meta": {
           "type": "NONE",
-          "description": "(optional) The name of your AWS key pair for accessing VM",
+          "description": "The name of your AWS key pair for accessing VM (optional)",
           "dynamic": false,
           "sectionSelector": 3,
           "important": false
@@ -87,7 +87,7 @@
         "value": "",
         "meta": {
           "type": "FILEBROWSER",
-          "description": "(optional) Your AWS private key file corresponding to 'vmKeyPairName' for accessing VM",
+          "description": "Your AWS private key file corresponding to 'vmKeyPairName' for accessing VM (optional)",
           "dynamic": false,
           "sectionSelector": 3,
           "important": false
@@ -98,10 +98,10 @@
         "value": "4096",
         "meta": {
           "type": "NONE",
-          "description": "(optional) The minimum RAM required (in Mega Bytes) for each VM",
+          "description": "The minimum RAM required (in Mega Bytes) for each VM (optional, default value: 2048)",
           "dynamic": false,
           "sectionSelector": 3,
-          "important": false
+          "important": true
         }
       },
       {
@@ -109,10 +109,10 @@
         "value": "2",
         "meta": {
           "type": "NONE",
-          "description": "(optional) The minimum number of CPU cores required for each VM",
+          "description": "The minimum number of CPU cores required for each VM (optional, default value: 2)",
           "dynamic": false,
           "sectionSelector": 3,
-          "important": false
+          "important": true
         }
       },
       {
@@ -120,7 +120,7 @@
         "value": "",
         "meta": {
           "type": "NONE",
-          "description": "(optional) The ids(s) of the security group(s) for VMs, spearated by comma in case of multiple ids.",
+          "description": "The ids(s) of the security group(s) for VMs, spearated by comma in case of multiple ids. (optional)",
           "dynamic": false,
           "sectionSelector": 3,
           "important": false
@@ -131,7 +131,7 @@
         "value": "",
         "meta": {
           "type": "NONE",
-          "description": "(optional) The subnet ID which is added to a specific Amazon VPC.",
+          "description": "The subnet ID which is added to a specific Amazon VPC. (optional)",
           "dynamic": false,
           "sectionSelector": 3,
           "important": false
@@ -145,7 +145,7 @@
           "description": "Resource Manager hostname or ip address (must be accessible from nodes)",
           "dynamic": false,
           "sectionSelector": 4,
-          "important": true
+          "important": false
         }
       },
       {
@@ -156,7 +156,7 @@
           "description": "Connector-iaas URL",
           "dynamic": false,
           "sectionSelector": 4,
-          "important": true
+          "important": false
         }
       },
       {
@@ -167,7 +167,7 @@
           "description": "URL used to download the node jar on the VM",
           "dynamic": false,
           "sectionSelector": 4,
-          "important": true
+          "important": false
         }
       },
       {
@@ -175,7 +175,7 @@
         "value": "",
         "meta": {
           "type": "NONE",
-          "description": "(optional) Additional Java command properties (e.g. \"-Dpropertyname=propertyvalue\")",
+          "description": "Additional Java command properties (e.g. \"-Dpropertyname=propertyvalue\") (optional)",
           "dynamic": false,
           "sectionSelector": 5,
           "important": false
@@ -186,7 +186,18 @@
         "value": "300000",
         "meta": {
           "type": "NONE",
-          "description": "The timeout for nodes to connect to RM (in ms). After this timeout expired, the node is considered to be lost.",
+          "description": "The timeout for nodes to connect to RM (in ms). After this timeout expired, the node is considered to be lost. (optional, default value: 300000)",
+          "dynamic": false,
+          "sectionSelector": 5,
+          "important": false
+        }
+      },
+      {
+        "name": "startupScript",
+        "value": "mkdir -p /tmp/node && cd /tmp/node\r\n if ! type -p jre/bin/java; then wget -nv -N https://s3.amazonaws.com/ci-materials/Latest_jre/jre-8u131-linux-x64.tar.gz; tar -xf jre-8u131-linux-x64.tar.gz; mv jre1.8.0_131/ jre; fi\r\nwget -nv %nodeJarUrl%\r\nnohup jre/bin/java -jar node.jar -Dproactive.communication.protocol=%protocol% -Dpython.path=%jythonPath% -Dproactive.pamr.router.address=%rmHostname% -D%instanceIdNodeProperty%=%instanceId% -r %rmUrl% -s %nodeSourceName% %nodeNamingOption% -v %credentials% -w %numberOfNodesPerInstance% %additionalProperties% &",
+        "meta": {
+          "type": "TEXTAREA",
+          "description": "VM startup script to launch the ProActive nodes (optional). Please refer to the documentation for full description.",
           "dynamic": false,
           "sectionSelector": 5,
           "important": false
@@ -266,13 +277,13 @@
       },
       {
         "name": "schedulerCredentialsPath",
-        "value": "[please put your Scheduler credentials or upload your credentials file]",
+        "value": "",
         "meta": {
           "type": "CREDENTIAL",
           "description": "Credentials used when contacting the scheduler.",
           "dynamic": false,
           "sectionSelector": 3,
-          "important": true
+          "important": false
         }
       },
       {
@@ -359,6 +370,7 @@
       "2": "Node Limits",
       "3": "Scheduler Configuration",
       "4": "Dynamic Policy Configuration"
-    }
+    },
+    "meta": {}
   }
 }

--- a/NodeSources/resources/catalog/AzureCloud.json
+++ b/NodeSources/resources/catalog/AzureCloud.json
@@ -56,7 +56,7 @@
           "type": "NONE",
           "description": "Optional authentication endpoint from specific Azure environment",
           "dynamic": false,
-          "sectionSelector": 2,
+          "sectionSelector": 3,
           "important": false
         }
       },
@@ -67,7 +67,7 @@
           "type": "NONE",
           "description": "Optional management endpoint from specific Azure environment",
           "dynamic": false,
-          "sectionSelector": 2,
+          "sectionSelector": 3,
           "important": false
         }
       },
@@ -78,7 +78,7 @@
           "type": "NONE",
           "description": "Optional resource manager endpoint from specific Azure environment",
           "dynamic": false,
-          "sectionSelector": 2,
+          "sectionSelector": 3,
           "important": false
         }
       },
@@ -89,7 +89,7 @@
           "type": "NONE",
           "description": "Optional graph endpoint from specific Azure environment",
           "dynamic": false,
-          "sectionSelector": 2,
+          "sectionSelector": 3,
           "important": false
         }
       },
@@ -100,8 +100,8 @@
           "type": "NONE",
           "description": "Resource manager hostname or ip address (must be accessible from nodes)",
           "dynamic": false,
-          "sectionSelector": 3,
-          "important": true
+          "sectionSelector": 4,
+          "important": false
         }
       },
       {
@@ -111,8 +111,8 @@
           "type": "NONE",
           "description": "Connector-iaas URL",
           "dynamic": false,
-          "sectionSelector": 3,
-          "important": true
+          "sectionSelector": 4,
+          "important": false
         }
       },
       {
@@ -122,7 +122,7 @@
           "type": "NONE",
           "description": "Image (name or key)",
           "dynamic": false,
-          "sectionSelector": 5,
+          "sectionSelector": 6,
           "important": true
         }
       },
@@ -133,7 +133,7 @@
           "type": "NONE",
           "description": "Image OS type (choose between 'linux' and 'windows', default: 'linux')",
           "dynamic": false,
-          "sectionSelector": 5,
+          "sectionSelector": 6,
           "important": true
         }
       },
@@ -144,7 +144,7 @@
           "type": "NONE",
           "description": "Azure virtual machine size type (by default: 'Standard_D1_v2')",
           "dynamic": false,
-          "sectionSelector": 5,
+          "sectionSelector": 6,
           "important": true
         }
       },
@@ -155,7 +155,7 @@
           "type": "NONE",
           "description": "The virtual machine Username",
           "dynamic": false,
-          "sectionSelector": 5,
+          "sectionSelector": 6,
           "important": true
         }
       },
@@ -166,7 +166,7 @@
           "type": "PASSWORD",
           "description": "The virtual machine Password",
           "dynamic": false,
-          "sectionSelector": 5,
+          "sectionSelector": 6,
           "important": true
         }
       },
@@ -177,7 +177,7 @@
           "type": "NONE",
           "description": "A public key to allow SSH connection to the VM",
           "dynamic": false,
-          "sectionSelector": 5,
+          "sectionSelector": 6,
           "important": false
         }
       },
@@ -188,7 +188,7 @@
           "type": "NONE",
           "description": "The Azure resourceGroup to use (if not specified, the one from the image will be used)",
           "dynamic": false,
-          "sectionSelector": 5,
+          "sectionSelector": 6,
           "important": true
         }
       },
@@ -199,7 +199,7 @@
           "type": "NONE",
           "description": "The Azure Region to use (if not specified, the one from the image will be used)",
           "dynamic": false,
-          "sectionSelector": 5,
+          "sectionSelector": 6,
           "important": false
         }
       },
@@ -210,7 +210,7 @@
           "type": "NONE",
           "description": "Total instance to create",
           "dynamic": false,
-          "sectionSelector": 4,
+          "sectionSelector": 5,
           "important": true
         }
       },
@@ -221,19 +221,19 @@
           "type": "NONE",
           "description": "Total nodes to create per instance",
           "dynamic": false,
-          "sectionSelector": 4,
+          "sectionSelector": 5,
           "important": true
         }
       },
       {
         "name": "nodeJarURL",
-        "value": "try.activeeon.com/rest/node.jar",
+        "value": "http://try.activeeon.com/rest/node.jar",
         "meta": {
           "type": "NONE",
           "description": "URL used to download the node jar on the VM",
           "dynamic": false,
-          "sectionSelector": 7,
-          "important": true
+          "sectionSelector": 8,
+          "important": false
         }
       },
       {
@@ -243,7 +243,7 @@
           "type": "NONE",
           "description": "Optional network CIDR to attach with new VM(s) (by default: '10.0.0.0/24')",
           "dynamic": false,
-          "sectionSelector": 6,
+          "sectionSelector": 7,
           "important": false
         }
       },
@@ -254,7 +254,7 @@
           "type": "CHECKBOX",
           "description": "Optional flag to specify if the public IP(s) of the new VM(s) must be static ('true' by default)",
           "dynamic": false,
-          "sectionSelector": 6,
+          "sectionSelector": 7,
           "important": false
         }
       },
@@ -265,7 +265,106 @@
           "type": "NONE",
           "description": "Additional Java command properties (e.g. \"-Dpropertyname=propertyvalue\")",
           "dynamic": false,
-          "sectionSelector": 7,
+          "sectionSelector": 8,
+          "important": false
+        }
+      },
+      {
+        "name": "resourceUsageRefreshFreqInMin",
+        "value": "30",
+        "meta": {
+          "type": "NONE",
+          "description": "Periodical resource usage retrieving delay in min.",
+          "dynamic": false,
+          "sectionSelector": 2,
+          "important": false
+        }
+      },
+      {
+        "name": "rateCardRefreshFreqInMin",
+        "value": "30",
+        "meta": {
+          "type": "NONE",
+          "description": "Periodical rate card retrieving delay in min.",
+          "dynamic": false,
+          "sectionSelector": 2,
+          "important": false
+        }
+      },
+      {
+        "name": "offerId",
+        "value": "MS-AZR-0003p",
+        "meta": {
+          "type": "NONE",
+          "description": "The Offer ID parameter consists of the 'MS-AZR-' prefix, plus the Offer ID number.",
+          "dynamic": false,
+          "sectionSelector": 2,
+          "important": false
+        }
+      },
+      {
+        "name": "currency",
+        "value": "USD",
+        "meta": {
+          "type": "NONE",
+          "description": "The currency in which the resource rates need to be provided.",
+          "dynamic": false,
+          "sectionSelector": 2,
+          "important": false
+        }
+      },
+      {
+        "name": "locale",
+        "value": "en-US",
+        "meta": {
+          "type": "NONE",
+          "description": "The culture in which the resource metadata needs to be localized.",
+          "dynamic": false,
+          "sectionSelector": 2,
+          "important": false
+        }
+      },
+      {
+        "name": "regionInfo",
+        "value": "US",
+        "meta": {
+          "type": "NONE",
+          "description": "The 2 letter ISO code where the offer was purchased.",
+          "dynamic": false,
+          "sectionSelector": 2,
+          "important": false
+        }
+      },
+      {
+        "name": "maxBudget",
+        "value": "50.0",
+        "meta": {
+          "type": "NONE",
+          "description": "Your budget for this node source related Azure resources. Will be used to compute your global cost in % budget.",
+          "dynamic": false,
+          "sectionSelector": 2,
+          "important": false
+        }
+      },
+      {
+        "name": "linuxStartupScript",
+        "value": "mkdir -p /tmp/node && cd /tmp/node\r\n if ! type -p jre/bin/java; then wget -nv -N https://s3.amazonaws.com/ci-materials/Latest_jre/jre-8u131-linux-x64.tar.gz; tar -xf jre-8u131-linux-x64.tar.gz; mv jre1.8.0_131/ jre; fi\r\nwget -nv %nodeJarUrl%\r\nnohup jre/bin/java -jar node.jar -Dproactive.communication.protocol=%protocol% -Dpython.path=%jythonPath% -Dproactive.pamr.router.address=%rmHostname% -D%instanceIdNodeProperty%=%instanceId% -r %rmUrl% -s %nodeSourceName% %nodeNamingOption% -v %credentials% -w %numberOfNodesPerInstance% %additionalProperties% &",
+        "meta": {
+          "type": "TEXTAREA",
+          "description": "Linux VM startup script to launch the ProActive nodes (optional). Please refer to the documentation for full description. (optional)",
+          "dynamic": false,
+          "sectionSelector": 8,
+          "important": false
+        }
+      },
+      {
+        "name": "windowsStartupScript",
+        "value": "$download=New-Object System.Net.WebClient;\r\n$download.DownloadFile('http://javadl.oracle.com/webapps/download/AutoDL?BundleId=238729_478a62b7d4e34b78b671c754eaaf38ab', 'c:\\jreInstall.exe');\r\n$procInstall=Start-Process -FilePath 'c:\\jreInstall.exe' -ArgumentList '/s REBOOT=ReallySuppress INSTALLDIR=c:\\jre' -Wait -PassThru;\r\n$procInstall.waitForExit();\r\n$download.DownloadFile('%nodeJarUrl%', 'c:\\node.jar');\r\nStart-Process -NoNewWindow 'c:\\jre\\bin\\java' -ArgumentList '-jar', 'c:\\node.jar', '-Dproactive.communication.protocol=%protocol%', '-Dproactive.pamr.router.address=%rmHostname%', '-D%instanceIdNodeProperty%=%instanceId%', '-r', '%rmUrl%', '-s', '%nodeSourceName%', '-v', '%credentials%', '-w', '%numberOfNodesPerInstance%', '%additionalProperties%'",
+        "meta": {
+          "type": "TEXTAREA",
+          "description": "Powershell script to be run during Windows VM startup for launching the ProActive nodes (optional). Please refer to the documentation for full description. (optional)",
+          "dynamic": false,
+          "sectionSelector": 8,
           "important": false
         }
       }
@@ -273,12 +372,16 @@
     "defaultValues": {},
     "sectionDescriptions": {
       "1": "Azure Configuration",
-      "2": "Endpoints",
-      "3": "PA Server Configuration",
-      "4": "Deployment Configuration",
-      "5": "VM Configuration",
-      "6": "Network Configuration",
-      "7": "Node Configuration"
+      "2": "Azure Billing Configuration",
+      "3": "Endpoints",
+      "4": "PA Server Configuration",
+      "5": "Deployment Configuration",
+      "6": "VM Configuration",
+      "7": "Network Configuration",
+      "8": "Node Configuration"
+    },
+    "meta": {
+      "elastic": "false"
     }
   },
   "policyPluginDescriptor": {
@@ -311,6 +414,7 @@
     "defaultValues": {},
     "sectionDescriptions": {
       "1": "Authorizations"
-    }
+    },
+    "meta": {}
   }
 }

--- a/NodeSources/resources/catalog/GoogleComputeEngine.json
+++ b/NodeSources/resources/catalog/GoogleComputeEngine.json
@@ -7,7 +7,7 @@
     "configurableFields": [
       {
         "name": "gceCredential",
-        "value": "[please upload the credential file of your Google Cloud Platform service account]",
+        "value": "",
         "meta": {
           "type": "FILEBROWSER",
           "description": "The JSON key file path of your Google Cloud Platform service account",
@@ -43,9 +43,10 @@
         "value": "",
         "meta": {
           "type": "NONE",
-          "description": "(optional) The virtual machine username",
+          "description": "The virtual machine username (optional)",
           "dynamic": false,
-          "sectionSelector": 3
+          "sectionSelector": 3,
+          "important": false
         }
       },
       {
@@ -53,9 +54,10 @@
         "value": "",
         "meta": {
           "type": "FILEBROWSER",
-          "description": "(optional) The public key for accessing the virtual machine",
+          "description": "The public key for accessing the virtual machine (optional)",
           "dynamic": false,
-          "sectionSelector": 3
+          "sectionSelector": 3,
+          "important": false
         }
       },
       {
@@ -63,9 +65,10 @@
         "value": "",
         "meta": {
           "type": "FILEBROWSER",
-          "description": "(optional) The private key for accessing the virtual machine",
+          "description": "The private key for accessing the virtual machine (optional)",
           "dynamic": false,
-          "sectionSelector": 3
+          "sectionSelector": 3,
+          "important": false
         }
       },
       {
@@ -73,19 +76,21 @@
         "value": "debian-9-stretch-v20190326",
         "meta": {
           "type": "NONE",
-          "description": "(optional) The image of the virtual machine",
+          "description": "The image of the virtual machine (optional, default value: debian-9-stretch-v20190326)",
           "dynamic": false,
-          "sectionSelector": 3
+          "sectionSelector": 3,
+          "important": true
         }
       },
       {
         "name": "region",
-        "value": "us-central1-a",
+        "value": "europe-west2-c",
         "meta": {
           "type": "NONE",
-          "description": "(optional) The region of the virtual machine",
+          "description": "The region of the virtual machine (optional, default value: europe-west2-c)",
           "dynamic": false,
-          "sectionSelector": 3
+          "sectionSelector": 3,
+          "important": true
         }
       },
       {
@@ -93,9 +98,10 @@
         "value": "1740",
         "meta": {
           "type": "NONE",
-          "description": "(optional) The minimum RAM required (in Mega Bytes) for each virtual machine",
+          "description": "The minimum RAM required (in Mega Bytes) for each virtual machine (optional, default value: 1740)",
           "dynamic": false,
-          "sectionSelector": 3
+          "sectionSelector": 3,
+          "important": true
         }
       },
       {
@@ -103,9 +109,10 @@
         "value": "1",
         "meta": {
           "type": "NONE",
-          "description": "(optional) The minimum number of CPU cores required for each virtual machine",
+          "description": "The minimum number of CPU cores required for each virtual machine (optional, default value: 1)",
           "dynamic": false,
-          "sectionSelector": 3
+          "sectionSelector": 3,
+          "important": true
         }
       },
       {
@@ -116,7 +123,7 @@
           "description": "Resource manager hostname or ip address (must be accessible from nodes)",
           "dynamic": false,
           "sectionSelector": 4,
-          "important": true
+          "important": false
         }
       },
       {
@@ -127,18 +134,18 @@
           "description": "Connector-iaas URL",
           "dynamic": false,
           "sectionSelector": 4,
-          "important": true
+          "important": false
         }
       },
       {
         "name": "nodeJarURL",
-        "value": "try.activeeon.com/rest/node.jar",
+        "value": "http://try.activeeon.com/rest/node.jar",
         "meta": {
           "type": "NONE",
           "description": "URL used to download the node jar on the virtual machine",
           "dynamic": false,
           "sectionSelector": 4,
-          "important": true
+          "important": false
         }
       },
       {
@@ -146,19 +153,32 @@
         "value": "-Dproactive.useIPaddress=true",
         "meta": {
           "type": "NONE",
-          "description": "(optional) Additional Java command properties (e.g. \"-Dpropertyname=propertyvalue\")",
+          "description": "Additional Java command properties (e.g. \"-Dpropertyname=propertyvalue\") (optional)",
           "dynamic": false,
-          "sectionSelector": 5
+          "sectionSelector": 5,
+          "important": false
         }
       },
       {
         "name": "nodeTimeout",
-        "value": "240000",
+        "value": "300000",
         "meta": {
           "type": "NONE",
-          "description": "Node timeout in ms. After this timeout expired, the node is considered to be lost",
+          "description": "Node timeout in ms. After this timeout expired, the node is considered to be lost (optional, default value: 300000)",
           "dynamic": false,
-          "sectionSelector": 5
+          "sectionSelector": 5,
+          "important": false
+        }
+      },
+      {
+        "name": "startupScript",
+        "value": "mkdir -p /tmp/node && cd /tmp/node\r\n if ! type -p jre/bin/java; then wget -nv -N https://s3.amazonaws.com/ci-materials/Latest_jre/jre-8u131-linux-x64.tar.gz; tar -xf jre-8u131-linux-x64.tar.gz; mv jre1.8.0_131/ jre; fi\r\nwget -nv %nodeJarUrl%\r\nnohup jre/bin/java -jar node.jar -Dproactive.communication.protocol=%protocol% -Dpython.path=%jythonPath% -Dproactive.pamr.router.address=%rmHostname% -D%instanceIdNodeProperty%=%instanceId% -r %rmUrl% -s %nodeSourceName% %nodeNamingOption% -v %credentials% -w %numberOfNodesPerInstance% %additionalProperties% &",
+        "meta": {
+          "type": "TEXTAREA",
+          "description": "VM startup script to launch the ProActive nodes (optional). Please refer to the documentation for full description.",
+          "dynamic": false,
+          "sectionSelector": 5,
+          "important": false
         }
       }
     ],
@@ -168,7 +188,8 @@
       "2": "Deployment Configuration",
       "3": "VM Configuration",
       "4": "PA Server Configuration",
-      "5": "Node Configuration"
+      "5": "Node Configuration",
+      "6": "Startup Scripts"
     },
     "meta": {
       "elastic": "true"
@@ -184,7 +205,9 @@
         "meta": {
           "type": "NONE",
           "description": "ME|users=name1,name2;groups=group1,group2;tokens=t1,t2|ALL",
-          "dynamic": false
+          "dynamic": false,
+          "sectionSelector": 1,
+          "important": false
         }
       },
       {
@@ -193,10 +216,16 @@
         "meta": {
           "type": "NONE",
           "description": "ME|users=name1,name2;groups=group1,group2|ALL",
-          "dynamic": false
+          "dynamic": false,
+          "sectionSelector": 1,
+          "important": false
         }
       }
     ],
-    "defaultValues": {}
+    "defaultValues": {},
+    "sectionDescriptions": {
+      "1": "Authorizations"
+    },
+    "meta": {}
   }
 }

--- a/NodeSources/resources/catalog/GoogleComputeEngineElastic.json
+++ b/NodeSources/resources/catalog/GoogleComputeEngineElastic.json
@@ -7,7 +7,7 @@
     "configurableFields": [
       {
         "name": "gceCredential",
-        "value": "[please upload the credential file of your Google Cloud Platform service account]",
+        "value": "",
         "meta": {
           "type": "FILEBROWSER",
           "description": "The JSON key file path of your Google Cloud Platform service account",
@@ -43,9 +43,10 @@
         "value": "",
         "meta": {
           "type": "NONE",
-          "description": "(optional) The virtual machine username",
+          "description": "The virtual machine username (optional)",
           "dynamic": false,
-          "sectionSelector": 3
+          "sectionSelector": 3,
+          "important": false
         }
       },
       {
@@ -53,9 +54,10 @@
         "value": "",
         "meta": {
           "type": "FILEBROWSER",
-          "description": "(optional) The public key for accessing the virtual machine",
+          "description": "The public key for accessing the virtual machine (optional)",
           "dynamic": false,
-          "sectionSelector": 3
+          "sectionSelector": 3,
+          "important": false
         }
       },
       {
@@ -63,9 +65,10 @@
         "value": "",
         "meta": {
           "type": "FILEBROWSER",
-          "description": "(optional) The private key for accessing the virtual machine",
+          "description": "The private key for accessing the virtual machine (optional)",
           "dynamic": false,
-          "sectionSelector": 3
+          "sectionSelector": 3,
+          "important": false
         }
       },
       {
@@ -73,19 +76,21 @@
         "value": "debian-9-stretch-v20190326",
         "meta": {
           "type": "NONE",
-          "description": "(optional) The image of the virtual machine",
+          "description": "The image of the virtual machine (optional, default value: debian-9-stretch-v20190326)",
           "dynamic": false,
-          "sectionSelector": 3
+          "sectionSelector": 3,
+          "important": true
         }
       },
       {
         "name": "region",
-        "value": "us-central1-a",
+        "value": "europe-west2-c",
         "meta": {
           "type": "NONE",
-          "description": "(optional) The region of the virtual machine",
+          "description": "The region of the virtual machine (optional, default value: europe-west2-c)",
           "dynamic": false,
-          "sectionSelector": 3
+          "sectionSelector": 3,
+          "important": true
         }
       },
       {
@@ -93,9 +98,10 @@
         "value": "1740",
         "meta": {
           "type": "NONE",
-          "description": "(optional) The minimum RAM required (in Mega Bytes) for each virtual machine",
+          "description": "The minimum RAM required (in Mega Bytes) for each virtual machine (optional, default value: 1740)",
           "dynamic": false,
-          "sectionSelector": 3
+          "sectionSelector": 3,
+          "important": true
         }
       },
       {
@@ -103,9 +109,10 @@
         "value": "1",
         "meta": {
           "type": "NONE",
-          "description": "(optional) The minimum number of CPU cores required for each virtual machine",
+          "description": "The minimum number of CPU cores required for each virtual machine (optional, default value: 1)",
           "dynamic": false,
-          "sectionSelector": 3
+          "sectionSelector": 3,
+          "important": true
         }
       },
       {
@@ -116,7 +123,7 @@
           "description": "Resource manager hostname or ip address (must be accessible from nodes)",
           "dynamic": false,
           "sectionSelector": 4,
-          "important": true
+          "important": false
         }
       },
       {
@@ -127,18 +134,18 @@
           "description": "Connector-iaas URL",
           "dynamic": false,
           "sectionSelector": 4,
-          "important": true
+          "important": false
         }
       },
       {
         "name": "nodeJarURL",
-        "value": "try.activeeon.com/rest/node.jar",
+        "value": "http://try.activeeon.com/rest/node.jar",
         "meta": {
           "type": "NONE",
           "description": "URL used to download the node jar on the virtual machine",
           "dynamic": false,
           "sectionSelector": 4,
-          "important": true
+          "important": false
         }
       },
       {
@@ -146,19 +153,32 @@
         "value": "-Dproactive.useIPaddress=true",
         "meta": {
           "type": "NONE",
-          "description": "(optional) Additional Java command properties (e.g. \"-Dpropertyname=propertyvalue\")",
+          "description": "Additional Java command properties (e.g. \"-Dpropertyname=propertyvalue\") (optional)",
           "dynamic": false,
-          "sectionSelector": 5
+          "sectionSelector": 5,
+          "important": false
         }
       },
       {
         "name": "nodeTimeout",
-        "value": "240000",
+        "value": "300000",
         "meta": {
           "type": "NONE",
-          "description": "Node timeout in ms. After this timeout expired, the node is considered to be lost",
+          "description": "Node timeout in ms. After this timeout expired, the node is considered to be lost (optional, default value: 300000)",
           "dynamic": false,
-          "sectionSelector": 5
+          "sectionSelector": 5,
+          "important": false
+        }
+      },
+      {
+        "name": "startupScript",
+        "value": "mkdir -p /tmp/node && cd /tmp/node\r\n if ! type -p jre/bin/java; then wget -nv -N https://s3.amazonaws.com/ci-materials/Latest_jre/jre-8u131-linux-x64.tar.gz; tar -xf jre-8u131-linux-x64.tar.gz; mv jre1.8.0_131/ jre; fi\r\nwget -nv %nodeJarUrl%\r\nnohup jre/bin/java -jar node.jar -Dproactive.communication.protocol=%protocol% -Dpython.path=%jythonPath% -Dproactive.pamr.router.address=%rmHostname% -D%instanceIdNodeProperty%=%instanceId% -r %rmUrl% -s %nodeSourceName% %nodeNamingOption% -v %credentials% -w %numberOfNodesPerInstance% %additionalProperties% &",
+        "meta": {
+          "type": "TEXTAREA",
+          "description": "VM startup script to launch the ProActive nodes (optional). Please refer to the documentation for full description.",
+          "dynamic": false,
+          "sectionSelector": 5,
+          "important": false
         }
       }
     ],
@@ -168,7 +188,8 @@
       "2": "Deployment Configuration",
       "3": "VM Configuration",
       "4": "PA Server Configuration",
-      "5": "Node Configuration"
+      "5": "Node Configuration",
+      "6": "Startup Scripts"
     },
     "meta": {
       "elastic": "true"
@@ -184,7 +205,9 @@
         "meta": {
           "type": "NONE",
           "description": "ME|users=name1,name2;groups=group1,group2;tokens=t1,t2|ALL",
-          "dynamic": false
+          "dynamic": false,
+          "sectionSelector": 1,
+          "important": false
         }
       },
       {
@@ -193,7 +216,9 @@
         "meta": {
           "type": "NONE",
           "description": "ME|users=name1,name2;groups=group1,group2|ALL",
-          "dynamic": false
+          "dynamic": false,
+          "sectionSelector": 1,
+          "important": false
         }
       },
       {
@@ -202,7 +227,9 @@
         "meta": {
           "type": "NONE",
           "description": "Minimum number of nodes deployed.",
-          "dynamic": true
+          "dynamic": true,
+          "sectionSelector": 2,
+          "important": true
         }
       },
       {
@@ -211,7 +238,9 @@
         "meta": {
           "type": "NONE",
           "description": "Maximum number of nodes deployed.",
-          "dynamic": true
+          "dynamic": true,
+          "sectionSelector": 2,
+          "important": true
         }
       },
       {
@@ -220,16 +249,20 @@
         "meta": {
           "type": "NONE",
           "description": "URL used to contact the scheduler (e.g. pnp://SCHEDULER_IP:PORT).",
-          "dynamic": false
+          "dynamic": false,
+          "sectionSelector": 3,
+          "important": true
         }
       },
       {
         "name": "schedulerCredentialsPath",
-        "value": "[please put your Scheduler credentials or upload your credentials file]",
+        "value": "",
         "meta": {
           "type": "CREDENTIAL",
           "description": "Credentials used when contacting the scheduler.",
-          "dynamic": false
+          "dynamic": false,
+          "sectionSelector": 3,
+          "important": false
         }
       },
       {
@@ -238,7 +271,9 @@
         "meta": {
           "type": "NONE",
           "description": "Timeout in ms to establish connection with the scheduler.",
-          "dynamic": false
+          "dynamic": false,
+          "sectionSelector": 3,
+          "important": false
         }
       },
       {
@@ -247,7 +282,9 @@
         "meta": {
           "type": "NONE",
           "description": "Number of attempts to connect with the scheduler.",
-          "dynamic": false
+          "dynamic": false,
+          "sectionSelector": 3,
+          "important": false
         }
       },
       {
@@ -256,7 +293,9 @@
         "meta": {
           "type": "NONE",
           "description": "Refresh frequency (ms).",
-          "dynamic": false
+          "dynamic": false,
+          "sectionSelector": 3,
+          "important": false
         }
       },
       {
@@ -265,7 +304,9 @@
         "meta": {
           "type": "NONE",
           "description": "Desired number of tasks per node.",
-          "dynamic": false
+          "dynamic": false,
+          "sectionSelector": 4,
+          "important": false
         }
       },
       {
@@ -274,7 +315,9 @@
         "meta": {
           "type": "NONE",
           "description": "Delay to initialize the infrastructure (eg. in a scaleSet this must cover the creation of Azure's resources).",
-          "dynamic": false
+          "dynamic": false,
+          "sectionSelector": 4,
+          "important": false
         }
       },
       {
@@ -283,19 +326,30 @@
         "meta": {
           "type": "NONE",
           "description": "Minimal uptime of a new free node to be candidate for deletion (ms).",
-          "dynamic": false
+          "dynamic": false,
+          "sectionSelector": 4,
+          "important": false
         }
       },
       {
         "name": "globalScope",
         "value": "false",
         "meta": {
-          "type": "NONE",
+          "type": "CHECKBOX",
           "description": "Specify the scope of the policy: consider specific tasks ('false': target generic information NODESOURCENAME) or all tasks ('true': use only if a single DynamicPolicy is activated).",
-          "dynamic": true
+          "dynamic": true,
+          "sectionSelector": 4,
+          "important": true
         }
       }
     ],
-    "defaultValues": {}
+    "defaultValues": {},
+    "sectionDescriptions": {
+      "1": "Authorizations",
+      "2": "Node Limits",
+      "3": "Scheduler Configuration",
+      "4": "Dynamic Policy Configuration"
+    },
+    "meta": {}
   }
 }

--- a/NodeSources/resources/catalog/OVH.json
+++ b/NodeSources/resources/catalog/OVH.json
@@ -90,7 +90,7 @@
           "description": "Openstack identity version",
           "dynamic": false,
           "sectionSelector": 1,
-          "important": false
+          "important": true
         }
       },
       {
@@ -120,7 +120,7 @@
         "value": "ProActiveServer",
         "meta": {
           "type": "NONE",
-          "description": "Public key name for Openstack instance",
+          "description": "(optional) Public key name for Openstack instance",
           "dynamic": false,
           "sectionSelector": 3,
           "important": false
@@ -156,7 +156,7 @@
           "description": "Connector-iaas URL",
           "dynamic": false,
           "sectionSelector": 4,
-          "important": true
+          "important": false
         }
       },
       {
@@ -167,7 +167,7 @@
           "description": "Resource Manager hostname or ip address",
           "dynamic": false,
           "sectionSelector": 4,
-          "important": true
+          "important": false
         }
       },
       {
@@ -178,7 +178,7 @@
           "description": "URL used to download the node jar on the instance",
           "dynamic": false,
           "sectionSelector": 5,
-          "important": true
+          "important": false
         }
       },
       {
@@ -186,7 +186,7 @@
         "value": "-Dproactive.useIPaddress=true",
         "meta": {
           "type": "NONE",
-          "description": "Additional Java command properties (e.g. \"-Dpropertyname=propertyvalue\")",
+          "description": "(optional) Additional Java command properties (e.g. \"-Dpropertyname=propertyvalue\")",
           "dynamic": false,
           "sectionSelector": 5,
           "important": false
@@ -197,7 +197,18 @@
         "value": "240000",
         "meta": {
           "type": "NONE",
-          "description": "Estimated startup time of the nodes (including the startup time of VMs)",
+          "description": "(optional, default value: 240000) Estimated startup time of the nodes (including the startup time of VMs)",
+          "dynamic": false,
+          "sectionSelector": 5,
+          "important": false
+        }
+      },
+      {
+        "name": "startupScript",
+        "value": "mkdir -p /tmp/node && cd /tmp/node\r\n if ! type -p jre/bin/java; then wget -nv -N https://s3.amazonaws.com/ci-materials/Latest_jre/jre-8u131-linux-x64.tar.gz; tar -xf jre-8u131-linux-x64.tar.gz; mv jre1.8.0_131/ jre; fi\r\nwget -nv %nodeJarUrl%\r\nnohup jre/bin/java -jar node.jar -Dproactive.communication.protocol=%protocol% -Dpython.path=%jythonPath% -Dproactive.pamr.router.address=%rmHostname% -D%instanceIdNodeProperty%=%instanceId% -r %rmUrl% -s %nodeSourceName% %nodeNamingOption% -v %credentials% -w %numberOfNodesPerInstance% %additionalProperties% &",
+        "meta": {
+          "type": "TEXTAREA",
+          "description": "VM startup script to launch the ProActive nodes (optional). Please refer to the documentation for full description.",
           "dynamic": false,
           "sectionSelector": 5,
           "important": false
@@ -246,6 +257,7 @@
     "defaultValues": {},
     "sectionDescriptions": {
       "1": "Authorizations"
-    }
+    },
+    "meta": {}
   }
 }

--- a/NodeSources/resources/catalog/OVHElastic.json
+++ b/NodeSources/resources/catalog/OVHElastic.json
@@ -90,7 +90,7 @@
           "description": "Openstack identity version",
           "dynamic": false,
           "sectionSelector": 1,
-          "important": false
+          "important": true
         }
       },
       {
@@ -120,7 +120,7 @@
         "value": "AEKeyPair",
         "meta": {
           "type": "NONE",
-          "description": "Public key name for Openstack instance",
+          "description": "(optional) Public key name for Openstack instance",
           "dynamic": false,
           "sectionSelector": 3,
           "important": false
@@ -156,7 +156,7 @@
           "description": "Connector-iaas URL",
           "dynamic": false,
           "sectionSelector": 4,
-          "important": true
+          "important": false
         }
       },
       {
@@ -167,7 +167,7 @@
           "description": "Resource Manager hostname or ip address",
           "dynamic": false,
           "sectionSelector": 4,
-          "important": true
+          "important": false
         }
       },
       {
@@ -178,7 +178,7 @@
           "description": "URL used to download the node jar on the instance",
           "dynamic": false,
           "sectionSelector": 5,
-          "important": true
+          "important": false
         }
       },
       {
@@ -186,7 +186,7 @@
         "value": "-Dproactive.useIPaddress=true",
         "meta": {
           "type": "NONE",
-          "description": "Additional Java command properties (e.g. \"-Dpropertyname=propertyvalue\")",
+          "description": "(optional) Additional Java command properties (e.g. \"-Dpropertyname=propertyvalue\")",
           "dynamic": false,
           "sectionSelector": 5,
           "important": false
@@ -197,7 +197,18 @@
         "value": "240000",
         "meta": {
           "type": "NONE",
-          "description": "Estimated startup time of the nodes (including the startup time of VMs)",
+          "description": "(optional, default value: 240000) Estimated startup time of the nodes (including the startup time of VMs)",
+          "dynamic": false,
+          "sectionSelector": 5,
+          "important": false
+        }
+      },
+      {
+        "name": "startupScript",
+        "value": "mkdir -p /tmp/node && cd /tmp/node\r\n if ! type -p jre/bin/java; then wget -nv -N https://s3.amazonaws.com/ci-materials/Latest_jre/jre-8u131-linux-x64.tar.gz; tar -xf jre-8u131-linux-x64.tar.gz; mv jre1.8.0_131/ jre; fi\r\nwget -nv %nodeJarUrl%\r\nnohup jre/bin/java -jar node.jar -Dproactive.communication.protocol=%protocol% -Dpython.path=%jythonPath% -Dproactive.pamr.router.address=%rmHostname% -D%instanceIdNodeProperty%=%instanceId% -r %rmUrl% -s %nodeSourceName% %nodeNamingOption% -v %credentials% -w %numberOfNodesPerInstance% %additionalProperties% &",
+        "meta": {
+          "type": "TEXTAREA",
+          "description": "VM startup script to launch the ProActive nodes (optional). Please refer to the documentation for full description.",
           "dynamic": false,
           "sectionSelector": 5,
           "important": false
@@ -283,7 +294,7 @@
           "description": "Credentials used when contacting the scheduler.",
           "dynamic": false,
           "sectionSelector": 3,
-          "important": true
+          "important": false
         }
       },
       {
@@ -370,6 +381,7 @@
       "2": "Node Limits",
       "3": "Scheduler Configuration",
       "4": "Dynamic Policy Configuration"
-    }
+    },
+    "meta": {}
   }
 }

--- a/NodeSources/resources/catalog/Openstack_Liberty.json
+++ b/NodeSources/resources/catalog/Openstack_Liberty.json
@@ -84,13 +84,13 @@
       },
       {
         "name": "identityVersion",
-        "value": "",
+        "value": "3",
         "meta": {
           "type": "NONE",
           "description": "Openstack identity version",
           "dynamic": false,
           "sectionSelector": 1,
-          "important": false
+          "important": true
         }
       },
       {
@@ -120,7 +120,7 @@
         "value": "",
         "meta": {
           "type": "NONE",
-          "description": "Public key name for Openstack instance",
+          "description": "(optional) Public key name for Openstack instance",
           "dynamic": false,
           "sectionSelector": 3,
           "important": false
@@ -156,7 +156,7 @@
           "description": "Connector-iaas URL",
           "dynamic": false,
           "sectionSelector": 4,
-          "important": true
+          "important": false
         }
       },
       {
@@ -167,7 +167,7 @@
           "description": "Resource Manager hostname or ip address",
           "dynamic": false,
           "sectionSelector": 4,
-          "important": true
+          "important": false
         }
       },
       {
@@ -178,7 +178,7 @@
           "description": "URL used to download the node jar on the instance",
           "dynamic": false,
           "sectionSelector": 5,
-          "important": true
+          "important": false
         }
       },
       {
@@ -186,7 +186,7 @@
         "value": "-Dproactive.useIPaddress=true",
         "meta": {
           "type": "NONE",
-          "description": "Additional Java command properties (e.g. \"-Dpropertyname=propertyvalue\")",
+          "description": "(optional) Additional Java command properties (e.g. \"-Dpropertyname=propertyvalue\")",
           "dynamic": false,
           "sectionSelector": 5,
           "important": false
@@ -197,7 +197,18 @@
         "value": "240000",
         "meta": {
           "type": "NONE",
-          "description": "Estimated startup time of the nodes (including the startup time of VMs)",
+          "description": "(optional, default value: 240000) Estimated startup time of the nodes (including the startup time of VMs)",
+          "dynamic": false,
+          "sectionSelector": 5,
+          "important": false
+        }
+      },
+      {
+        "name": "startupScript",
+        "value": "mkdir -p /tmp/node && cd /tmp/node\r\n if ! type -p jre/bin/java; then wget -nv -N https://s3.amazonaws.com/ci-materials/Latest_jre/jre-8u131-linux-x64.tar.gz; tar -xf jre-8u131-linux-x64.tar.gz; mv jre1.8.0_131/ jre; fi\r\nwget -nv %nodeJarUrl%\r\nnohup jre/bin/java -jar node.jar -Dproactive.communication.protocol=%protocol% -Dpython.path=%jythonPath% -Dproactive.pamr.router.address=%rmHostname% -D%instanceIdNodeProperty%=%instanceId% -r %rmUrl% -s %nodeSourceName% %nodeNamingOption% -v %credentials% -w %numberOfNodesPerInstance% %additionalProperties% &",
+        "meta": {
+          "type": "TEXTAREA",
+          "description": "VM startup script to launch the ProActive nodes (optional). Please refer to the documentation for full description.",
           "dynamic": false,
           "sectionSelector": 5,
           "important": false
@@ -246,6 +257,7 @@
     "defaultValues": {},
     "sectionDescriptions": {
       "1": "Authorizations"
-    }
+    },
+    "meta": {}
   }
 }

--- a/NodeSources/resources/catalog/Openstack_Rocky.json
+++ b/NodeSources/resources/catalog/Openstack_Rocky.json
@@ -90,7 +90,7 @@
           "description": "Openstack identity version",
           "dynamic": false,
           "sectionSelector": 1,
-          "important": false
+          "important": true
         }
       },
       {
@@ -120,7 +120,7 @@
         "value": "",
         "meta": {
           "type": "NONE",
-          "description": "Public key name for Openstack instance",
+          "description": "(optional) Public key name for Openstack instance",
           "dynamic": false,
           "sectionSelector": 3,
           "important": false
@@ -156,7 +156,7 @@
           "description": "Connector-iaas URL",
           "dynamic": false,
           "sectionSelector": 4,
-          "important": true
+          "important": false
         }
       },
       {
@@ -167,7 +167,7 @@
           "description": "Resource Manager hostname or ip address",
           "dynamic": false,
           "sectionSelector": 4,
-          "important": true
+          "important": false
         }
       },
       {
@@ -178,7 +178,7 @@
           "description": "URL used to download the node jar on the instance",
           "dynamic": false,
           "sectionSelector": 5,
-          "important": true
+          "important": false
         }
       },
       {
@@ -186,7 +186,7 @@
         "value": "-Dproactive.useIPaddress=true",
         "meta": {
           "type": "NONE",
-          "description": "Additional Java command properties (e.g. \"-Dpropertyname=propertyvalue\")",
+          "description": "(optional) Additional Java command properties (e.g. \"-Dpropertyname=propertyvalue\")",
           "dynamic": false,
           "sectionSelector": 5,
           "important": false
@@ -197,7 +197,18 @@
         "value": "240000",
         "meta": {
           "type": "NONE",
-          "description": "Estimated startup time of the nodes (including the startup time of VMs)",
+          "description": "(optional, default value: 240000) Estimated startup time of the nodes (including the startup time of VMs)",
+          "dynamic": false,
+          "sectionSelector": 5,
+          "important": false
+        }
+      },
+      {
+        "name": "startupScript",
+        "value": "mkdir -p /tmp/node && cd /tmp/node\r\n if ! type -p jre/bin/java; then wget -nv -N https://s3.amazonaws.com/ci-materials/Latest_jre/jre-8u131-linux-x64.tar.gz; tar -xf jre-8u131-linux-x64.tar.gz; mv jre1.8.0_131/ jre; fi\r\nwget -nv %nodeJarUrl%\r\nnohup jre/bin/java -jar node.jar -Dproactive.communication.protocol=%protocol% -Dpython.path=%jythonPath% -Dproactive.pamr.router.address=%rmHostname% -D%instanceIdNodeProperty%=%instanceId% -r %rmUrl% -s %nodeSourceName% %nodeNamingOption% -v %credentials% -w %numberOfNodesPerInstance% %additionalProperties% &",
+        "meta": {
+          "type": "TEXTAREA",
+          "description": "VM startup script to launch the ProActive nodes (optional). Please refer to the documentation for full description.",
           "dynamic": false,
           "sectionSelector": 5,
           "important": false
@@ -246,6 +257,7 @@
     "defaultValues": {},
     "sectionDescriptions": {
       "1": "Authorizations"
-    }
+    },
+    "meta": {}
   }
 }


### PR DESCRIPTION
Add parameter startupScript and update some fields description and default value, to make the node source examples to match their updated infrastructure fields definition.