### PR TITLE
Revert "Fix token use instead of password due to websocket issue (#752)"

### DIFF
--- a/JupyterLab/resources/catalog/JupyterLab.xml
+++ b/JupyterLab/resources/catalog/JupyterLab.xml
@@ -10,7 +10,7 @@
     <variable name="PROXYFIED" value="False" model="PA:Boolean"/>
     <variable name="HTTPS_ENABLED" value="False" model="PA:Boolean"/>
     <variable name="SERVICE_PORT" value="-1" model="PA:Integer"/>
-    <variable name="JUPYTERLAB_TOKEN" value="" model="PA:HIDDEN"/>
+    <variable name="JUPYTERLAB_PASSWORD" value="" model="PA:HIDDEN"/>
     <variable name="SINGULARITY_IMAGE_PATH" value="/tmp/jupyterlab.sif"/>
     <variable name="BUILD_IMAGE_IF_NOT_EXISTS" value="True" model="PA:Boolean"/>
     <variable name="ENGINE" value="docker" model="PA:List(docker,singularity)"/>
@@ -68,13 +68,13 @@ else
 fi
 
 #ENV_VARS=$variables_ENV_VARS
-JUPYTERLAB_TOKEN=$variables_JUPYTERLAB_TOKEN
+JUPYTERLAB_PASSWORD=$variables_JUPYTERLAB_PASSWORD
 SIF_IMAGE_PATH=$variables_SINGULARITY_IMAGE_PATH
 INSTANCE_NAME=$variables_INSTANCE_NAME
 JUPYTER_HOST_PORT=$variables_SERVICE_PORT
 BUILD_IMAGE=$variables_BUILD_IMAGE_IF_NOT_EXISTS
 ################################################################################
-#echo "JUPYTERLAB_TOKEN: $JUPYTERLAB_TOKEN"
+#echo "JUPYTERLAB_PASSWORD: $JUPYTERLAB_PASSWORD"
 
 PATH=$PATH:/usr/sbin
 
@@ -142,6 +142,8 @@ else
         singularity instance start $SIF_IMAGE_PATH $INSTANCE_NAME
     fi
 
+    JUPYTERLAB_PASSWORD_HASH=$(singularity exec instance://$INSTANCE_NAME python -c "from IPython.lib.security import passwd; print(passwd(passphrase='$JUPYTERLAB_PASSWORD', algorithm='sha1'))")
+
     if [ "${variables_HTTPS_ENABLED,,}" = "true" ]; then
         echo "[INFO] Running $INSTANCE_NAME container in a secured HTTPS"
         CERTFILE="$HOME/.cert.pem"
@@ -153,12 +155,12 @@ else
             openssl req -x509 -newkey rsa:4096 -sha256 -nodes -days 365 -subj "/CN=$HOSTNAME" -keyout $KEYFILE -out $CERTFILE
             echo "[INFO] Auto-signed certificate created."
         fi
-        echo "singularity exec instance://$INSTANCE_NAME bash -c nohup jupyter lab --port=$JUPYTER_HOST_PORT --ip=0.0.0.0 --no-browser --NotebookApp.token=\"'$JUPYTERLAB_TOKEN'\" --NotebookApp.notebook_dir=$HOME --NotebookApp.certfile=$CERTFILE --NotebookApp.keyfile=$KEYFILE $ADDITIONAL_OPTIONS &> $HOME/$INSTANCE_NAME.txt & &> $HOME/$INSTANCE_NAME.log"
-        singularity exec instance://$INSTANCE_NAME bash -c "nohup jupyter lab --port=$JUPYTER_HOST_PORT --ip=0.0.0.0 --no-browser --NotebookApp.token=\"'$JUPYTERLAB_TOKEN'\" --NotebookApp.notebook_dir=$HOME --NotebookApp.certfile=$CERTFILE --NotebookApp.keyfile=$KEYFILE $ADDITIONAL_OPTIONS &> $HOME/$INSTANCE_NAME.txt &" &> $HOME/$INSTANCE_NAME.log
+        echo "singularity exec instance://$INSTANCE_NAME bash -c nohup jupyter lab --port=$JUPYTER_HOST_PORT --ip=0.0.0.0 --no-browser --NotebookApp.token='' --NotebookApp.password='$JUPYTERLAB_PASSWORD_HASH' --NotebookApp.notebook_dir=$HOME --NotebookApp.certfile=$CERTFILE --NotebookApp.keyfile=$KEYFILE $ADDITIONAL_OPTIONS &> $HOME/$INSTANCE_NAME.txt & &> $HOME/$INSTANCE_NAME.log"
+        singularity exec instance://$INSTANCE_NAME bash -c "nohup jupyter lab --port=$JUPYTER_HOST_PORT --ip=0.0.0.0 --no-browser --NotebookApp.token='' --NotebookApp.password='$JUPYTERLAB_PASSWORD_HASH' --NotebookApp.notebook_dir=$HOME --NotebookApp.certfile=$CERTFILE --NotebookApp.keyfile=$KEYFILE $ADDITIONAL_OPTIONS &> $HOME/$INSTANCE_NAME.txt &" &> $HOME/$INSTANCE_NAME.log
     else
         echo "[INFO] Running $INSTANCE_NAME container in HTTP"
-        echo "singularity exec instance://$INSTANCE_NAME bash -c nohup jupyter lab --port=$JUPYTER_HOST_PORT --ip=0.0.0.0 --no-browser --NotebookApp.token=\"'$JUPYTERLAB_TOKEN'\" --NotebookApp.notebook_dir=$HOME $ADDITIONAL_OPTIONS &> $HOME/$INSTANCE_NAME.txt & &> $HOME/$INSTANCE_NAME.log"
-        singularity exec instance://$INSTANCE_NAME bash -c "nohup jupyter lab --port=$JUPYTER_HOST_PORT --ip=0.0.0.0 --no-browser --NotebookApp.token=\"'$JUPYTERLAB_TOKEN'\" --NotebookApp.notebook_dir=$HOME $ADDITIONAL_OPTIONS &> $HOME/$INSTANCE_NAME.txt &" &> $HOME/$INSTANCE_NAME.log
+        echo "singularity exec instance://$INSTANCE_NAME bash -c nohup jupyter lab --port=$JUPYTER_HOST_PORT --ip=0.0.0.0 --no-browser --NotebookApp.token='' --NotebookApp.password='$JUPYTERLAB_PASSWORD_HASH' --NotebookApp.notebook_dir=$HOME $ADDITIONAL_OPTIONS &> $HOME/$INSTANCE_NAME.txt & &> $HOME/$INSTANCE_NAME.log"
+        singularity exec instance://$INSTANCE_NAME bash -c "nohup jupyter lab --port=$JUPYTER_HOST_PORT --ip=0.0.0.0 --no-browser --NotebookApp.token='' --NotebookApp.password='$JUPYTERLAB_PASSWORD_HASH' --NotebookApp.notebook_dir=$HOME $ADDITIONAL_OPTIONS &> $HOME/$INSTANCE_NAME.txt &" &> $HOME/$INSTANCE_NAME.log
     fi
 
     #if [[ -d $HOME/proactive-jupyter-notebooks ]]; then
@@ -319,10 +321,10 @@ else
     JUPYTER_INTERNAL_PORT=8888
 fi
 #ENV_VARS=$variables_ENV_VARS
-JUPYTERLAB_TOKEN=$variables_JUPYTERLAB_TOKEN
+JUPYTERLAB_PASSWORD=$variables_JUPYTERLAB_PASSWORD
 JUPYTER_HOST_PORT=$variables_SERVICE_PORT
 ################################################################################
-#echo "JUPYTERLAB_TOKEN: $JUPYTERLAB_TOKEN"
+#echo "JUPYTERLAB_PASSWORD: $JUPYTERLAB_PASSWORD"
 
 PATH=$PATH:/usr/sbin
 
@@ -371,10 +373,10 @@ else
         echo "Running $INSTANCE_NAME container in a secured HTTPS"
         CERTFILE="/opt/conda/etc/jupyter/fullchain.pem"
         KEYFILE="/opt/conda/etc/jupyter/privkey.pem"
-        if [ -z "$JUPYTERLAB_TOKEN" ]; then
+        if [ -z "$JUPYTERLAB_PASSWORD" ]; then
             INSTANCE_STATUS=$( eval "docker create --name $INSTANCE_NAME -p $JUPYTER_HOST_PORT:$JUPYTER_INTERNAL_PORT -e CERTFILE=$CERTFILE -e KEYFILE=$KEYFILE $ADDITIONAL_OPTIONS_STRING $DOCKER_IMAGE" 2>&1)
         else
-            INSTANCE_STATUS=$( eval "docker create --name $INSTANCE_NAME -p $JUPYTER_HOST_PORT:$JUPYTER_INTERNAL_PORT -e CERTFILE=$CERTFILE -e KEYFILE=$KEYFILE -e JUPYTERLAB_TOKEN='$JUPYTERLAB_TOKEN' $ADDITIONAL_OPTIONS_STRING $DOCKER_IMAGE" 2>&1)
+            INSTANCE_STATUS=$( eval "docker create --name $INSTANCE_NAME -p $JUPYTER_HOST_PORT:$JUPYTER_INTERNAL_PORT -e CERTFILE=$CERTFILE -e KEYFILE=$KEYFILE -e JUPYTERLAB_TOKEN='$JUPYTERLAB_PASSWORD' $ADDITIONAL_OPTIONS_STRING $DOCKER_IMAGE" 2>&1)
         fi
         if [[ -f fullchain.pem && -f privkey.pem ]]; then
             docker cp fullchain.pem $INSTANCE_NAME:$CERTFILE
@@ -388,10 +390,10 @@ else
         docker start $INSTANCE_NAME
     else
         echo "Running $INSTANCE_NAME container in HTTP"
-        if [ -z "$JUPYTERLAB_TOKEN" ]; then
+        if [ -z "$JUPYTERLAB_PASSWORD" ]; then
             INSTANCE_STATUS=$( eval "docker run --name $INSTANCE_NAME -p $JUPYTER_HOST_PORT:$JUPYTER_INTERNAL_PORT $ADDITIONAL_OPTIONS_STRING -d $DOCKER_IMAGE" 2>&1)
         else
-            INSTANCE_STATUS=$( eval "docker run --name $INSTANCE_NAME -p $JUPYTER_HOST_PORT:$JUPYTER_INTERNAL_PORT -e JUPYTERLAB_TOKEN='$JUPYTERLAB_TOKEN' $ADDITIONAL_OPTIONS_STRING -d $DOCKER_IMAGE" 2>&1)
+            INSTANCE_STATUS=$( eval "docker run --name $INSTANCE_NAME -p $JUPYTER_HOST_PORT:$JUPYTER_INTERNAL_PORT -e JUPYTERLAB_TOKEN='$JUPYTERLAB_PASSWORD' $ADDITIONAL_OPTIONS_STRING -d $DOCKER_IMAGE" 2>&1)
         fi
     fi
     


### PR DESCRIPTION
After the fix of the ProActive proxy Jupyterlab can be accessed with a password. 
For this reason, this fix is reverted.
This reverts commit 1c1def3b4ada381fc7fca477b9be416f276be98d.