### PR TITLE
Improve id set of container object in Post_Start_Service script

### DIFF
--- a/PcaScripts/resources/catalog/Post_Start_Service.groovy
+++ b/PcaScripts/resources/catalog/Post_Start_Service.groovy
@@ -30,8 +30,8 @@ def containerID="";
 if ("docker".equalsIgnoreCase(engine)) {
     containerID = new File(instanceName+"_containerID").text.trim()
     if ("".equals(containerID)) {
-        println("Docker container didn't started, terminating execution")
-        System.exit(1);
+        println("Docker container didn't started, terminating execution.")
+        return;
     }
 }
 

--- a/PcaScripts/resources/catalog/Post_Start_Service.groovy
+++ b/PcaScripts/resources/catalog/Post_Start_Service.groovy
@@ -26,11 +26,13 @@ def engine = variables.get("ENGINE") // docker, singularity
 def hostname = variables.get("PA_NODE_HOST")
 def port = new File(instanceName+"_port").text.trim()
 
-def containerID = ""
-if (engine != null && "singularity".equalsIgnoreCase(engine)) {
-    containerID = "0"
-} else {
+def containerID="";
+if ("docker".equalsIgnoreCase(engine)) {
     containerID = new File(instanceName+"_containerID").text.trim()
+    if ("".equals(containerID)) {
+        println("Docker container didn't started, terminating execution")
+        System.exit(1);
+    }
 }
 
 def containerUrl = hostname + ":" + port


### PR DESCRIPTION
Remove container id set to 0 when using singularity and terminate execution if docker container startup failed in Post_Start_Service