### PR TITLE
[pml] Fixed train model with RAPIDS do not support label as string

### DIFF
--- a/MachineLearning/resources/catalog/Encode_Data_Script.py
+++ b/MachineLearning/resources/catalog/Encode_Data_Script.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Proactive Encode Data for Machine Learning
 
 This module contains the Python script for the Encode Data task.

--- a/MachineLearning/resources/catalog/Encode_Data_Script.py
+++ b/MachineLearning/resources/catalog/Encode_Data_Script.py
@@ -1,5 +1,3 @@
-# Copyright Activeeon 2007-2021. All rights reserved.
-
 # -*- coding: utf-8 -*-
 """Proactive Encode Data for Machine Learning
 

--- a/MachineLearning/resources/catalog/Encode_Data_Script.py
+++ b/MachineLearning/resources/catalog/Encode_Data_Script.py
@@ -1,3 +1,4 @@
+# Copyright Activeeon 2007-2021. All rights reserved.
 
 # -*- coding: utf-8 -*-
 """Proactive Encode Data for Machine Learning
@@ -57,8 +58,7 @@ print("dataframe id (in): ", dataframe_id)
 dataframe = get_and_decompress_dataframe(dataframe_id)
 
 # Encode the desired columns of a Pandas dataframe
-columns = [x.strip() for x in COLUMNS_NAME.split(',')]
-dataframe, encode_map = encode_columns(dataframe, columns)
+dataframe, encode_map = encode_columns(dataframe, COLUMNS_NAME)
 print("Encode map: ", encode_map)
 
 # -------------------------------------------------------------

--- a/MachineLearning/resources/catalog/Predict_Model_Script.py
+++ b/MachineLearning/resources/catalog/Predict_Model_Script.py
@@ -1,3 +1,4 @@
+# Copyright Activeeon 2007-2021. All rights reserved.
 
 # -*- coding: utf-8 -*-
 """Proactive Predict Model for Machine Learning
@@ -44,7 +45,7 @@ else:
     exec(urllib.request.urlopen(PA_PYTHON_UTILS_URL).read(), globals())
 global check_task_is_enabled, preview_dataframe_in_task_result
 global is_nvidia_rapids_enabled, is_not_none_not_empty
-global raiser, get_input_variables, dict_to_obj
+global raiser, get_input_variables, dict_to_obj, apply_encoder
 global get_and_decompress_json_dataframe, compress_and_transfer_dataframe
 
 # -------------------------------------------------------------
@@ -70,7 +71,8 @@ input_variables = {
     'task.dataframe_id_test': None,
     'task.algorithm_json': None,
     'task.label_column': None,
-    'task.model_id': None
+    'task.model_id': None,
+    'task.encode_map_json': None
 }
 get_input_variables(input_variables)
 
@@ -80,6 +82,11 @@ if input_variables['task.dataframe_id'] is not None:
 if input_variables['task.dataframe_id_test'] is not None:
     dataframe_id = input_variables['task.dataframe_id_test']
 print("dataframe id (in): ", dataframe_id)
+
+encode_map_json = input_variables['task.encode_map_json']
+encode_map = None
+if encode_map_json is not None:
+    encode_map = json.loads(encode_map_json)
 
 dataframe_json = get_and_decompress_json_dataframe(dataframe_id)
 dataframe = read_json(dataframe_json, orient='split')
@@ -217,11 +224,18 @@ resultMetadata.put("task.name", __file__)
 resultMetadata.put("task.dataframe_id", dataframe_id)
 resultMetadata.put("task.algorithm_json", algorithm_json)
 resultMetadata.put("task.label_column", LABEL_COLUMN)
+resultMetadata.put("task.encode_map_json", input_variables['task.encode_map_json'])
 
 # -------------------------------------------------------------
 # Preview results
 #
-preview_dataframe_in_task_result(dataframe)
+if encode_map is not None and is_labeled_data:
+    # apply_encoder(dataframe, columns, encode_map, sep=",")
+    encode_map['predictions'] = encode_map[LABEL_COLUMN]
+    dataframe_aux = apply_encoder(dataframe, [LABEL_COLUMN, 'predictions'], encode_map)
+    preview_dataframe_in_task_result(dataframe_aux)
+else:
+    preview_dataframe_in_task_result(dataframe)
 
 # -------------------------------------------------------------
 print("END " + __file__)

--- a/MachineLearning/resources/catalog/Predict_Model_Script.py
+++ b/MachineLearning/resources/catalog/Predict_Model_Script.py
@@ -1,5 +1,3 @@
-# Copyright Activeeon 2007-2021. All rights reserved.
-
 # -*- coding: utf-8 -*-
 """Proactive Predict Model for Machine Learning
 

--- a/MachineLearning/resources/catalog/Predict_Model_Script.py
+++ b/MachineLearning/resources/catalog/Predict_Model_Script.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Proactive Predict Model for Machine Learning
 
 This module contains the Python script for the Predict Model task.

--- a/MachineLearning/resources/catalog/Preview_Results_Script.py
+++ b/MachineLearning/resources/catalog/Preview_Results_Script.py
@@ -1,3 +1,4 @@
+# Copyright Activeeon 2007-2021. All rights reserved.
 
 # -*- coding: utf-8 -*-
 """Proactive Preview Results for Machine Learning
@@ -6,6 +7,7 @@ This module contains the Python script for the Preview Results task.
 """
 import ssl
 import urllib.request
+import json
 
 global variables, resultMetadata
 
@@ -37,9 +39,24 @@ assert_not_none_not_empty(OUTPUT_TYPE, "OUTPUT_TYPE should be defined!")
 
 input_variables = {
     'task.dataframe_id': None,
-    'task.label_column': None
+    'task.label_column': None,
+    'task.encode_map_json': None
 }
 get_input_variables(input_variables)
+
+is_labeled_data = False
+LABEL_COLUMN = variables.get("LABEL_COLUMN")
+if is_not_none_not_empty(LABEL_COLUMN):
+    is_labeled_data = True
+else:
+    LABEL_COLUMN = input_variables['task.label_column']
+    if is_not_none_not_empty(LABEL_COLUMN):
+        is_labeled_data = True
+
+encode_map_json = input_variables['task.encode_map_json']
+encode_map = None
+if encode_map_json is not None:
+    encode_map = json.loads(encode_map_json)
 
 dataframe_id = input_variables['task.dataframe_id']
 print("dataframe id (in): ", dataframe_id)
@@ -49,7 +66,13 @@ dataframe = get_and_decompress_dataframe(dataframe_id)
 # -------------------------------------------------------------
 # Preview results
 #
-preview_dataframe_in_task_result(dataframe, output_type=OUTPUT_TYPE)
+if encode_map is not None and is_labeled_data:
+    # apply_encoder(dataframe, columns, encode_map, sep=",")
+    encode_map['predictions'] = encode_map[LABEL_COLUMN]
+    dataframe_aux = apply_encoder(dataframe, [LABEL_COLUMN, 'predictions'], encode_map)
+    preview_dataframe_in_task_result(dataframe_aux)
+else:
+    preview_dataframe_in_task_result(dataframe, output_type=OUTPUT_TYPE)
 
 # -------------------------------------------------------------
 print("END " + __file__)

--- a/MachineLearning/resources/catalog/Preview_Results_Script.py
+++ b/MachineLearning/resources/catalog/Preview_Results_Script.py
@@ -1,6 +1,3 @@
-# Copyright Activeeon 2007-2021. All rights reserved.
-
-# -*- coding: utf-8 -*-
 """Proactive Preview Results for Machine Learning
 
 This module contains the Python script for the Preview Results task.

--- a/MachineLearning/resources/catalog/Split_Data_Script.py
+++ b/MachineLearning/resources/catalog/Split_Data_Script.py
@@ -1,3 +1,4 @@
+# Copyright Activeeon 2007-2021. All rights reserved.
 
 # -*- coding: utf-8 -*-
 """Proactive Split Data for Machine Learning
@@ -44,7 +45,8 @@ test_size = 1 - TRAIN_SIZE
 input_variables = {
     'task.dataframe_id': None,
     'task.label_column': None,
-    'task.feature_names': None
+    'task.feature_names': None,
+    'task.encode_map_json': None
 }
 get_input_variables(input_variables)
 
@@ -70,6 +72,7 @@ resultMetadata.put("task.dataframe_id_train", dataframe_id1)
 resultMetadata.put("task.dataframe_id_test", dataframe_id2)
 resultMetadata.put("task.label_column", input_variables['task.label_column'])
 resultMetadata.put("task.feature_names", input_variables['task.feature_names'])
+resultMetadata.put("task.encode_map_json", input_variables['task.encode_map_json'])
 
 # -------------------------------------------------------------
 # Preview results

--- a/MachineLearning/resources/catalog/Split_Data_Script.py
+++ b/MachineLearning/resources/catalog/Split_Data_Script.py
@@ -1,6 +1,3 @@
-# Copyright Activeeon 2007-2021. All rights reserved.
-
-# -*- coding: utf-8 -*-
 """Proactive Split Data for Machine Learning
 
 This module contains the Python script for the Split Data task.

--- a/MachineLearning/resources/catalog/Train_Model_Script.py
+++ b/MachineLearning/resources/catalog/Train_Model_Script.py
@@ -1,6 +1,3 @@
-# Copyright Activeeon 2007-2021. All rights reserved.
-
-# -*- coding: utf-8 -*-
 """Proactive Train Model for Machine Learning
 
 This module contains the Python script for the Train Model task.

--- a/MachineLearning/resources/catalog/Train_Model_Script.py
+++ b/MachineLearning/resources/catalog/Train_Model_Script.py
@@ -1,3 +1,4 @@
+# Copyright Activeeon 2007-2021. All rights reserved.
 
 # -*- coding: utf-8 -*-
 """Proactive Train Model for Machine Learning
@@ -31,7 +32,7 @@ else:
 global check_task_is_enabled, is_nvidia_rapids_enabled
 global raiser, get_input_variables, dict_to_obj, is_not_none_not_empty
 global get_and_decompress_json_dataframe, preview_dataframe_in_task_result
-global compress_and_transfer_dataframe, compress_and_transfer_data
+global compress_and_transfer_dataframe, compress_and_transfer_data, apply_encoder
 
 # -------------------------------------------------------------
 # Check if the Python task is enabled or not
@@ -90,7 +91,8 @@ input_variables = {
     'task.dataframe_id_train': None,
     'task.algorithm_json': None,
     'task.label_column': None,
-    'task.feature_names': None
+    'task.feature_names': None,
+    'task.encode_map_json': None
 }
 get_input_variables(input_variables)
 
@@ -100,6 +102,11 @@ if input_variables['task.dataframe_id'] is not None:
 if input_variables['task.dataframe_id_train'] is not None:
     dataframe_id = input_variables['task.dataframe_id_train']
 print("dataframe id (in): ", dataframe_id)
+
+encode_map_json = input_variables['task.encode_map_json']
+encode_map = None
+if encode_map_json is not None:
+    encode_map = json.loads(encode_map_json)
 
 dataframe_json = get_and_decompress_json_dataframe(dataframe_id)
 
@@ -423,6 +430,7 @@ resultMetadata.put("task.algorithm_json", algorithm_json)
 resultMetadata.put("task.dataframe_id", dataframe_id)
 resultMetadata.put("task.label_column", LABEL_COLUMN)
 resultMetadata.put("task.feature_names", input_variables['task.feature_names'])
+resultMetadata.put("task.encode_map_json", input_variables['task.encode_map_json'])
 
 # -----------------------------------------------------------------
 # Model Explainer
@@ -447,7 +455,12 @@ print('result_map: ', result_map)
 # -------------------------------------------------------------
 # Preview results
 #
-preview_dataframe_in_task_result(dataframe)
+if encode_map is not None and is_labeled_data:
+    # apply_encoder(dataframe, columns, encode_map, sep=",")
+    dataframe_aux = apply_encoder(dataframe, LABEL_COLUMN, encode_map)
+    preview_dataframe_in_task_result(dataframe_aux)
+else:
+    preview_dataframe_in_task_result(dataframe)
 
 # -------------------------------------------------------------
 print("END " + __file__)

--- a/MachineLearning/resources/catalog/Utils_Script.py
+++ b/MachineLearning/resources/catalog/Utils_Script.py
@@ -1,6 +1,3 @@
-# Copyright Activeeon 2007-2021. All rights reserved.
-
-# -*- coding: utf-8 -*-
 """Proactive Python Utils for Machine Learning
 
 Provide a collection of common utility Python functions and classes

--- a/MachineLearning/resources/catalog/Utils_Script.py
+++ b/MachineLearning/resources/catalog/Utils_Script.py
@@ -1,3 +1,4 @@
+# Copyright Activeeon 2007-2021. All rights reserved.
 
 # -*- coding: utf-8 -*-
 """Proactive Python Utils for Machine Learning
@@ -52,8 +53,9 @@ def assert_not_empty(s, msg=None):
     :param msg: Default error message.
     :return: None.
     """
-    if not s.strip():
-        raiser(msg)
+    if type(s) == str:
+        if not s.strip():
+            raiser(msg)
 
 
 def assert_not_none(expr, msg=None):
@@ -1011,11 +1013,11 @@ def encode_columns(dataframe, columns, sep=","):
     :return: Pandas dataframe and the encode map dictionary.
     """
     from sklearn.preprocessing import LabelEncoder
-    if isinstance(columns, str):
+    assert_not_none_not_empty(columns, "The columns to be encoded should be defined!")
+    if type(columns) == str:
         columns2encode = [x.strip() for x in columns.split(sep)]
     else:
         columns2encode = columns
-    assert_not_none_not_empty(columns2encode, "The columns to be encoded should be defined!")
     encode_map = {}
     dataframe_aux = dataframe.copy()
     for col in columns2encode:
@@ -1039,15 +1041,16 @@ def apply_encoder(dataframe, columns, encode_map, sep=","):
     :param sep: Column separator. Default is comma ','.
     :return: Pandas dataframe.
     """
-    if isinstance(columns, str):
+    assert_not_none_not_empty(columns, "The columns to be encoded should be defined!")
+    if type(columns) == str:
         columns2encode = [x.strip() for x in columns.split(sep)]
     else:
         columns2encode = columns
-    assert_not_none_not_empty(columns2encode, "The columns to be encoded should be defined!")
     dataframe_aux = dataframe.copy()
     for col in columns2encode:
         col_mapper = encode_map[col]
-        dataframe_aux[col] = dataframe[col].map(col_mapper)
+        inv_col_mapper = {v: k for k, v in col_mapper.items()}
+        dataframe_aux[col] = dataframe_aux[col].map(inv_col_mapper)
     return dataframe_aux
 
 


### PR DESCRIPTION
Fixed some ML tasks with RAPIDS that did not support label as a string.  The tasks were:

* Encode_Data_Script.py
* Predict_Model_Script.py
* Preview_Results_Script.py
* Split_Data_Script.py
* Train_Model_Script.py
* Utils_Script.py