### PR TITLE
Redirecting Maas_ML endpoint to the MaaS_ML analytics dash app

### DIFF
--- a/ModelAsService/resources/catalog/MaaS_Post_Script.groovy
+++ b/ModelAsService/resources/catalog/MaaS_Post_Script.groovy
@@ -64,14 +64,14 @@ if (proxyfied.toLowerCase()=="true"){
         containerUrl = "http://"+containerUrl
     }
     containerUrl = URLDecoder.decode(containerUrl, "UTF-8");
-    proxyfiedURL = pcaUrl+"/services/"+instanceId+"/endpoints/"+endpointID+"/api/trace_preview?key="+userKey
+    proxyfiedURL = pcaUrl+"/services/"+instanceId+"/endpoints/"+endpointID+"/api/dashapp?key="+userKey
     endpoint.setProxyfied(true);
     endpoint.setProxyfiedUrl(proxyfiedURL)
 }else{
     endpoint.setProxyfied(false)
     ENDPOINT_PATH = "/api/ui"
     if (traceEnabled.toLowerCase()=="true"){
-        ENDPOINT_PATH = "/api/trace_preview?key="+userKey
+        ENDPOINT_PATH = "/api/dashapp?key="+userKey
     }
     if (httpsEnabled.toLowerCase()=="true"){
         containerUrl = "https://"+containerUrl+ENDPOINT_PATH

--- a/ModelAsService/resources/catalog/ml_service-api.yaml
+++ b/ModelAsService/resources/catalog/ml_service-api.yaml
@@ -264,28 +264,28 @@ paths:
 #          description: text-like predictions information
 #          schema:
 #            type: string
-  /trace_preview:
-    get:
-      summary: Returns the stored traceability information.
-      operationId: ml_service.trace_preview_api
-      produces:
-        - "text/html"
-      parameters:
-        - in: query
-          name: key
-          type: string
-          required: true
-          default: ""
-          description: The key generated during the service deployment.
-      responses:
-        200:
-          description: text-like traceability information
-          schema:
-            type: string
-  /maas_analytics:
+#  /trace_preview:
+#    get:
+#      summary: Returns the stored traceability information.
+#      operationId: ml_service.trace_preview_api
+#      produces:
+#        - "text/html"
+#      parameters:
+#        - in: query
+#          name: key
+#          type: string
+#          required: true
+#          default: ""
+#          description: The key generated during the service deployment.
+#      responses:
+#        200:
+#          description: text-like traceability information
+#          schema:
+#            type: string
+  /dashapp:
     get:
       summary: Return Dash app page for MaaS_ML data analytics.
-      operationId: ml_service.maas_analytics_api
+      operationId: ml_service.dashapp_api
       produces:
         - "text/html"
       parameters:
@@ -299,4 +299,4 @@ paths:
         200:
           description: text-like information redirecting to a Dash app
           schema:
-            type: string    
+            type: string

--- a/ModelAsService/resources/catalog/ml_service.py
+++ b/ModelAsService/resources/catalog/ml_service.py
@@ -511,62 +511,65 @@ def get_predictions_api(api_token,model_name,model_version):
         return log("[ERROR] Invalid token", api_token)
 
 
-def trace_preview_api(key) -> str:
-    if USER_KEY == key.encode():
-        if exists(TRACE_FILE) and isfile(TRACE_FILE):
-            header = ["Date Time", "Token", "Traceability information"]
-            result = ""
-            with open(TRACE_FILE) as f, TemporaryFile("w+") as t:
-                for line in f:
-                    ln = len(line.strip().split("|"))
-                    if ln < 3:
-                        line = "||" + line
-                    t.write(line)
-                t.seek(0)
-                trace_dataframe = pd.read_csv(t, sep='|', names=header, engine='python')
-                trace_dataframe.fillna('', inplace=True)
-            # Add config information
-            with open(CONFIG_FILE) as f:
-                config = json.load(f)
-            dataframe_config = pd.DataFrame.from_records([config])
-            config_result = dataframe_config.to_html(escape=False, classes='table table-bordered', justify='center',index=False)
-            trace_result = trace_dataframe.to_html(escape=False, classes='table table-bordered table-striped', justify='center', index=False)
-            css_style = """
-            div {
-            weight: 100%;
-            }
-            """
-            result = """
-            <!DOCTYPE html>
-            <html>
-              <head>
-                <meta charset="UTF-8">
-                  <title>Audit & Traceability</title>
-                  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
-              </head>
-                <body>
-                  <p><a href='ui/#/default' target='_blank'>Click here to access Swagger UI</a></p>
-                  <h2 class="text-center my-4" style="color:#003050;">Audit & Traceability</h2>
-                  <div style="text-align:center;">{0}
-                  <br/>
-                  <br/>
-                  <br/>
-                  {1}
-                  </div>
-                </body></html>""".format(config_result, trace_result)
-            if (os.path.isdir(os.environ['MODELS_PATH'])):
-                directory_contents = os.listdir(os.environ['MODELS_PATH'])
-                if (len(directory_contents) > 0):
-                    result = "<p><a href='maas_analytics?key=" + quote(key) + "' target='_blank'>Click here for MaaS_ML data analytics</a></p>" + result
-            return result
-        else:
-            return log("[WARN] Trace file is empty", key)
-    else:
-        return log("[ERROR] Invalid key", key)
+# def trace_preview_api(key) -> str:
+#     if USER_KEY == key.encode():
+#         if exists(TRACE_FILE) and isfile(TRACE_FILE):
+#             header = ["Date Time", "Token", "Traceability information"]
+#             result = ""
+#             with open(TRACE_FILE) as f, TemporaryFile("w+") as t:
+#                 for line in f:
+#                     ln = len(line.strip().split("|"))
+#                     if ln < 3:
+#                         line = "||" + line
+#                     t.write(line)
+#                 t.seek(0)
+#                 trace_dataframe = pd.read_csv(t, sep='|', names=header, engine='python')
+#                 trace_dataframe.fillna('', inplace=True)
+#             # Add config information
+#             with open(CONFIG_FILE) as f:
+#                 config = json.load(f)
+#             dataframe_config = pd.DataFrame.from_records([config])
+#             config_result = dataframe_config.to_html(escape=False, classes='table table-bordered', justify='center',index=False)
+#             trace_result = trace_dataframe.to_html(escape=False, classes='table table-bordered table-striped', justify='center', index=False)
+#             css_style = """
+#             div {
+#             weight: 100%;
+#             }
+#             """
+#             result = """
+#             <!DOCTYPE html>
+#             <html>
+#               <head>
+#                 <meta charset="UTF-8">
+#                   <title>Audit & Traceability</title>
+#                   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+#               </head>
+#                 <body>
+#                   <p><a href='ui/#/default' target='_blank'>Click here to access Swagger UI</a></p>
+#                   <h2 class="text-center my-4" style="color:#003050;">Audit & Traceability</h2>
+#                   <div style="text-align:center;">{0}
+#                   <br/>
+#                   <br/>
+#                   <br/>
+#                   {1}
+#                   </div>
+#                 </body></html>""".format(config_result, trace_result)
+#             if (os.path.isdir(os.environ['MODELS_PATH'])):
+#                 directory_contents = os.listdir(os.environ['MODELS_PATH'])
+#                 if (len(directory_contents) > 0):
+#                     result = "<p><a href='maas_analytics?key=" + quote(key) + "' target='_blank'>Click here for MaaS_ML data analytics</a></p>" + result
+#             return result
+#         else:
+#             return log("[WARN] Trace file is empty", key)
+#     else:
+#         return log("[ERROR] Invalid key", key)
 
 
-def maas_analytics_api(key) -> str:
+def dashapp_api(key) -> str:
     if USER_KEY == key.encode():
+
+        if not exists(TRACE_FILE):
+            log("[WARN] Trace file is empty", key)
         return render_template(
             'index.jinja2',
             title='Plotly Dash Flask Tutorial',


### PR DESCRIPTION
In this PR:
The MaaS_ML endpoint is redirected to the Dash application page containing the Audit and Traceability tab and a button that leads to the Swagger api