### PR TITLE
Add ServiceNow workflows to query /table endpoint

### DIFF
--- a/ApplicationConnectors/METADATA.json
+++ b/ApplicationConnectors/METADATA.json
@@ -118,6 +118,51 @@
 					"contentType": "application/xml"
 				},
 				"file" : "resources/catalog/PeopleSoft.xml"
+			},
+			{
+				"name" : "ServiceNow_Create_Record",
+				"metadata" : {
+					"kind": "Workflow/standard",
+					"commitMessage": "first version",
+					"contentType": "application/xml"
+				},
+				"file" : "resources/catalog/ServiceNow_Create_Record.xml"
+			},
+			{
+				"name" : "ServiceNow_Delete_Record",
+				"metadata" : {
+					"kind": "Workflow/standard",
+					"commitMessage": "first version",
+					"contentType": "application/xml"
+				},
+				"file" : "resources/catalog/ServiceNow_Delete_Record.xml"
+			},
+			{
+				"name" : "ServiceNow_Retrieve_A_Record",
+				"metadata" : {
+					"kind": "Workflow/standard",
+					"commitMessage": "first version",
+					"contentType": "application/xml"
+				},
+				"file" : "resources/catalog/ServiceNow_Retrieve_A_Record.xml"
+			},
+			{
+				"name" : "ServiceNow_Retrieve_Records",
+				"metadata" : {
+					"kind": "Workflow/standard",
+					"commitMessage": "first version",
+					"contentType": "application/xml"
+				},
+				"file" : "resources/catalog/ServiceNow_Retrieve_Records.xml"
+			},
+			{
+				"name" : "ServiceNow_Update_Or_Modify_A_Record",
+				"metadata" : {
+					"kind": "Workflow/standard",
+					"commitMessage": "first version",
+					"contentType": "application/xml"
+				},
+				"file" : "resources/catalog/ServiceNow_Update_Or_Modify_A_Record.xml"
 			}
 		]
 	}

--- a/ApplicationConnectors/resources/catalog/ServiceNow_Create_Record.xml
+++ b/ApplicationConnectors/resources/catalog/ServiceNow_Create_Record.xml
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<job xmlns="urn:proactive:jobdescriptor:3.13" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" maxNumberOfExecution="2" name="ServiceNow_Create_Record" onTaskError="continueJobExecution" priority="normal" projectName="ServiceNow" xsi:schemaLocation="urn:proactive:jobdescriptor:3.13 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.13/schedulerjob.xsd">
+  <variables>
+    <variable advanced="false" description="Base URL of the ServiceNow server." group="Http Connection" hidden="false" model="PA:URL" name="SERVICENOW_BASE_URL" value="https://SN_SERVER.com"/>
+    <variable advanced="false" description="Username for basic http authentication." group="Http Connection" hidden="false" name="SERVICENOW_USER" value=""/>
+    <variable advanced="false" description="Password for basic http authentication." group="Http Connection" hidden="false" model="PA:HIDDEN" name="SERVICENOW_PASSWORD" value=""/>
+  </variables>
+  <description>
+    <![CDATA[ A workflow that creates a record in a ServiceNow table ]]>
+  </description>
+  <genericInformation>
+<info name="bucketName" value="application-connectors"/>
+<info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ServiceNow.png"/>
+<info name="group" value="public-objects"/>
+</genericInformation>
+  <taskFlow>
+    <task fork="true" name="Create_Record">
+      <description>
+        <![CDATA[ A task performing a rest POST request using a json request body to create a record ]]>
+      </description>
+      <variables>
+        <variable advanced="false" description="Endpoint that will be queried." group="Http Connection" hidden="false" inherited="false" model="PA:URL" name="ENDPOINT" value="${SERVICENOW_BASE_URL}/api/now/table/${TABLE_NAME}"/>
+        <variable advanced="false" description="Name of the table to insert a record." group="Http Request" hidden="false" inherited="false" name="TABLE_NAME" value=""/>
+        <variable advanced="false" description="Simple JSON structure describing column and their values to be inserted. {&quot;column&quot;:&quot;value&quot;, &quot;column2&quot;:&quot;value&quot;,...}" group="Http Request" hidden="false" inherited="false" model="PA:JSON" name="REQUEST_BODY" value=""/>
+        <variable advanced="false" description="Which data to extract in the response if json, xml or html format is selected. It uses the &lt;a href=&quot;https://groovy-lang.org/processing-xml.html&quot; target=&quot;_blank&quot;&gt;GPath notation&lt;/a&gt;." group="Http Response" hidden="false" inherited="false" name="RESPONSE_PATH" value="."/>
+        <variable advanced="true" description="If true, disable SSL certificate verification." group="Http Connection" hidden="false" inherited="false" model="PA:BOOLEAN" name="SSL_DISABLE_CHECK" value="true"/>
+        <variable advanced="true" description="If true, print the full request and response content in the task output." group="Http Connection" hidden="false" inherited="false" model="PA:BOOLEAN" name="DEBUG" value="false"/>
+        <variable advanced="true" description="Format of the HTTP response body." group="Http Response" hidden="false" inherited="false" model="PA:LIST(application/json,application/xml,text/xml)" name="RESPONSE_FORMAT" value="application/json"/>
+        <variable advanced="true" description="Format of the HTTP request body." group="Http Request" hidden="false" inherited="false" model="PA:LIST(application/json,application/xml,text/xml)" name="REQUEST_FORMAT" value="application/json"/>
+        <variable advanced="true" description="Return field display values (true), actual values (false), or both (all)." group="Action Parameters" hidden="false" inherited="false" model="PA:BOOLEAN" name="SYSPARM_DISPLAY_VALUE" value="true"/>
+        <variable advanced="true" description="True to exclude Table API links for reference fields." group="Action Parameters" hidden="false" inherited="false" model="PA:BOOLEAN" name="SYSPARM_EXCLUDE_REFERENCE_LINK" value="false"/>
+        <variable advanced="true" description="A comma-separated list of fields to return in the response. Defaults to all fields." group="Action Parameters" hidden="false" inherited="false" name="SYSPARM_FIELDS" value=""/>
+        <variable advanced="true" description="Set field values using their display value (true) or actual value (false)." group="Action Parameters" hidden="false" inherited="false" model="PA:BOOLEAN" name="SYSPARM_INPUT_DISPLAY_VALUE" value="false"/>
+        <variable advanced="true" description="True to suppress auto generation of system fields." group="Action Parameters" hidden="false" inherited="false" model="PA:BOOLEAN" name="SYSPARM_SUPPRESS_AUTO_SYS_FIELD" value="false"/>
+      </variables>
+      <genericInformation>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ServiceNow.png"/>
+      </genericInformation>
+      <inputFiles>
+        <files accessMode="cacheFromGlobalSpace" includes="rest-assured-fat-3.3.0.jar"/>
+      </inputFiles>
+      <forkEnvironment>
+        <envScript>
+          <script>
+            <code language="groovy">
+              <![CDATA[
+def jarFile = new File(cachespace, "rest-assured-fat-3.3.0.jar")
+
+forkEnvironment.addAdditionalClasspath(jarFile.getAbsolutePath())
+]]>
+            </code>
+          </script>
+        </envScript>
+      </forkEnvironment>
+      <scriptExecutable>
+        <script>
+          <code language="groovy">
+            <![CDATA[
+import static io.restassured.RestAssured.*;
+import static io.restassured.matcher.RestAssuredMatchers.*;
+import static io.restassured.config.EncoderConfig.*;
+import static org.hamcrest.Matchers.*;
+import org.apache.commons.httpclient.HttpStatus;
+import io.restassured.http.ContentType;
+import io.restassured.RestAssured;
+import com.google.common.base.Strings;
+
+debug = Boolean.parseBoolean(variables.get("DEBUG"))
+
+restCall = given().contentType(variables.get("REQUEST_FORMAT"))
+                  .urlEncodingEnabled(false)
+
+if (Boolean.parseBoolean(variables.get("SSL_DISABLE_CHECK"))) {
+    restCall = restCall.relaxedHTTPSValidation()
+}
+
+if (!Strings.isNullOrEmpty(variables.get("SERVICENOW_USER")) && !Strings.isNullOrEmpty(variables.get("SERVICENOW_PASSWORD"))) {
+    restCall = restCall.auth().preemptive().basic(variables.get("SERVICENOW_USER"), variables.get("SERVICENOW_PASSWORD"))
+}
+
+if (Strings.isNullOrEmpty(variables.get("TABLE_NAME"))) {
+     throw new IllegalArgumentException("Table to query cannot be empty")
+}
+
+if (Strings.isNullOrEmpty(variables.get("REQUEST_BODY"))) {
+     throw new IllegalArgumentException("Request body cannot be empty")
+}
+
+// Add body
+restCall = restCall.body(variables.get("REQUEST_BODY"));
+
+// Add others if they have been added in task variables
+variables.entrySet().stream().filter({entry -> entry.getKey().startsWith("SYSPARM_") && !Strings.isNullOrEmpty(entry.getValue())})
+	.forEach({ entry -> 
+        restCall = restCall.queryParam(entry.getKey().toLowerCase(), entry.getValue().replaceAll(",","%2C")) 
+    });
+
+if (debug) {
+    println "-------------- REQUEST -----------------"
+	restCall = restCall.log().all()
+}
+response = restCall.post(variables.get("ENDPOINT"))
+
+if (debug) {
+    println "-------------- RESPONSE -----------------"
+	println response.statusLine()
+    println response.prettyPrint()
+} else {
+	println response.statusLine()
+}
+
+response = response.then().assertThat()
+  .statusCode(allOf(greaterThanOrEqualTo(HttpStatus.SC_OK),lessThan(HttpStatus.SC_MULTIPLE_CHOICES)))
+  .extract();
+
+if (debug) {
+    println "-------------- RESULT -------------------"
+}
+
+if (response.statusCode() == HttpStatus.SC_NO_CONTENT && !variables.get("RESPONSE_PATH").isEmpty()) {
+    throw new IllegalStateException("A RESPONSE_PATH was requested but http response has no content.")
+} else if (response.statusCode() == HttpStatus.SC_NO_CONTENT) {
+    result = true;
+    // response has no content
+    return;
+}
+
+switch (variables.get("RESPONSE_FORMAT")) {
+    case "application/json":
+    if (variables.get("RESPONSE_PATH").isEmpty()) {
+        throw new IllegalArgumentException("Invalid RESPONSE_PATH for json format")
+    }
+    result = response.jsonPath().get(variables.get("RESPONSE_PATH"));
+    println result
+    break;
+
+    case "application/xml":
+    if (variables.get("RESPONSE_PATH").isEmpty()) {
+        throw new IllegalArgumentException("Invalid RESPONSE_PATH for xml format")
+    }
+    // html parsing results are not serializable and thus can be returned only in string format
+    result = response.xmlPath().getString(variables.get("RESPONSE_PATH"));
+    println result
+    break;
+
+    case "text/xml":
+    result = response.prettyPrint()
+    break;
+}
+]]>
+          </code>
+        </script>
+      </scriptExecutable>
+      <metadata>
+        <positionTop>
+            323.6833190917969
+        </positionTop>
+        <positionLeft>
+            504.10003662109375
+        </positionLeft>
+      </metadata>
+    </task>
+  </taskFlow>
+  <metadata>
+    <visualization>
+      <![CDATA[ <html>
+    <head>
+    <link rel="stylesheet" href="/studio/styles/studio-standalone.css">
+        <style>
+        #workflow-designer {
+            left:0 !important;
+            top:0 !important;
+            width:2257px;
+            height:2302px;
+            }
+        </style>
+    </head>
+    <body>
+    <div id="workflow-visualization-view"><div id="workflow-visualization" style="position:relative;top:-318.6833190917969px;left:-499.10003662109375px"><div class="task _jsPlumb_endpoint_anchor_ ui-draggable" style="top: 323.683px; left: 504.1px;" id="jsPlumb_1_31"><a class="task-name" data-toggle="tooltip" data-placement="right" title="A task performing a rest POST request using a json request body.
+
+This template supports only basic authentication, for more advanced authentication settings, please modify the template according to the rest-assured documentation:
+https://github.com/rest-assured/rest-assured/wiki/Usage#authentication"><img src="/automation-dashboard/styles/patterns/img/wf-icons/api-rest.png" width="20px">&nbsp;<span class="name">Create_Record</span></a></div><div style="position: absolute; height: 20px; width: 20px; left: 545px; top: 354px;" class="_jsPlumb_endpoint source-endpoint dependency-source-endpoint connected _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1" xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1" xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div></div></div>
+    </body>
+</html>
+ ]]>
+    </visualization>
+  </metadata>
+</job>

--- a/ApplicationConnectors/resources/catalog/ServiceNow_Delete_Record.xml
+++ b/ApplicationConnectors/resources/catalog/ServiceNow_Delete_Record.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<job xmlns="urn:proactive:jobdescriptor:3.13" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" maxNumberOfExecution="2" name="ServiceNow_Delete_Record" onTaskError="continueJobExecution" priority="normal" projectName="ServiceNow" xsi:schemaLocation="urn:proactive:jobdescriptor:3.13 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.13/schedulerjob.xsd">
+  <variables>
+    <variable advanced="false" description="Base URL of the ServiceNow server." group="Http Connection" hidden="false" model="PA:URL" name="SERVICENOW_BASE_URL" value="https://SN_SERVER.com"/>
+    <variable advanced="false" description="Username for basic http authentication." group="Http Connection" hidden="false" name="SERVICENOW_USER" value=""/>
+    <variable advanced="false" description="Password for basic http authentication." group="Http Connection" hidden="false" model="PA:HIDDEN" name="SERVICENOW_PASSWORD" value=""/>
+  </variables>
+  <description>
+    <![CDATA[ A workflow that runs a REST DELETE request to delete a record from a ServiceNow table ]]>
+  </description>
+  <genericInformation>
+<info name="bucketName" value="application-connectors"/>
+<info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ServiceNow.png"/>
+<info name="group" value="public-objects"/>
+</genericInformation>
+  <taskFlow>
+    <task fork="true" name="Delete_Record">
+      <description>
+        <![CDATA[ Executes a DELETE request to delete a record from a ServiceNow table ]]>
+      </description>
+      <variables>
+        <variable advanced="false" description="Endpoint that will be queried." group="Http Connection" hidden="false" inherited="false" model="PA:URL" name="ENDPOINT" value="${SERVICENOW_BASE_URL}/api/now/table/${TABLE_NAME}/${SYS_ID}"/>
+        <variable advanced="false" description="Name of the table that contains the record." group="Http Request" hidden="false" inherited="false" name="TABLE_NAME" value=""/>
+        <variable advanced="false" description="Unique ID (column SYS_ID) of the record to delete." group="Http Request" hidden="false" inherited="false" name="SYS_ID" value=""/>
+        <variable advanced="true" description="If true, disable SSL certificate verification." group="Http Connection" hidden="false" inherited="false" model="PA:BOOLEAN" name="SSL_DISABLE_CHECK" value="true"/>
+        <variable advanced="true" description="If true, print the full request and response content in the task output." group="Http Connection" hidden="false" inherited="false" model="PA:BOOLEAN" name="DEBUG" value="true"/>
+        <variable advanced="true" description="True to access data across domains if authorized." group="Action Parameters" hidden="false" inherited="false" model="PA:BOOLEAN" name="SYSPARM_QUERY_NO_DOMAIN" value="false"/>
+      </variables>
+      <genericInformation>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ServiceNow.png"/>
+      </genericInformation>
+      <inputFiles>
+        <files accessMode="cacheFromGlobalSpace" includes="rest-assured-fat-3.3.0.jar"/>
+      </inputFiles>
+      <forkEnvironment>
+        <envScript>
+          <script>
+            <code language="groovy">
+              <![CDATA[
+def jarFile = new File(cachespace, "rest-assured-fat-3.3.0.jar")
+
+forkEnvironment.addAdditionalClasspath(jarFile.getAbsolutePath())
+]]>
+            </code>
+          </script>
+        </envScript>
+      </forkEnvironment>
+      <scriptExecutable>
+        <script>
+          <code language="groovy">
+            <![CDATA[
+import static io.restassured.RestAssured.*;
+import static io.restassured.matcher.RestAssuredMatchers.*;
+import static io.restassured.config.EncoderConfig.*;
+import static org.hamcrest.Matchers.*;
+import org.apache.commons.httpclient.HttpStatus;
+import io.restassured.http.ContentType;
+import io.restassured.RestAssured;
+import com.google.common.base.Strings;
+
+debug = Boolean.parseBoolean(variables.get("DEBUG"))
+
+restCall = given().urlEncodingEnabled(false)
+
+if (Boolean.parseBoolean(variables.get("SSL_DISABLE_CHECK"))) {
+    restCall = restCall.relaxedHTTPSValidation()
+}
+
+if (!Strings.isNullOrEmpty(variables.get("SERVICENOW_USER")) && !Strings.isNullOrEmpty(variables.get("SERVICENOW_PASSWORD"))) {
+    restCall = restCall.auth().preemptive().basic(variables.get("SERVICENOW_USER"), variables.get("SERVICENOW_PASSWORD"))
+} else {
+    throw new IllegalArgumentException("Provide a username and password in order to query ServiceNow")
+}
+
+if (Strings.isNullOrEmpty(variables.get("TABLE_NAME"))) {
+     throw new IllegalArgumentException("Table to query cannot be empty")
+}
+
+// Add query parameters
+variables.entrySet().stream().filter({entry -> entry.getKey().startsWith("SYSPARM_") && !Strings.isNullOrEmpty(entry.getValue())})
+	.forEach({ entry -> 
+        restCall = restCall.queryParam(entry.getKey().toLowerCase(), entry.getValue().replaceAll(",","%2C")) 
+    });
+
+if (debug) {
+    println "-------------- REQUEST -----------------"
+	restCall = restCall.log().all()
+}
+response = restCall.delete(variables.get("ENDPOINT"))
+
+if (debug) {
+    println "-------------- RESPONSE -----------------"
+	println response.statusLine()
+    println response.prettyPrint()
+} else {
+	println response.statusLine()
+}
+
+response = response.then().assertThat()
+  .statusCode(HttpStatus.SC_NO_CONTENT)
+  .extract();
+
+result = true;
+return;
+]]>
+          </code>
+        </script>
+      </scriptExecutable>
+      <metadata>
+        <positionTop>
+            322.2833251953125
+        </positionTop>
+        <positionLeft>
+            470.54998779296875
+        </positionLeft>
+      </metadata>
+    </task>
+  </taskFlow>
+  <metadata>
+    <visualization>
+      <![CDATA[ <html>
+    <head>
+    <link rel="stylesheet" href="/studio/styles/studio-standalone.css">
+        <style>
+        #workflow-designer {
+            left:0 !important;
+            top:0 !important;
+            width:2257px;
+            height:2302px;
+            }
+        </style>
+    </head>
+    <body>
+    <div id="workflow-visualization-view"><div id="workflow-visualization" style="position:relative;top:-317.2833251953125px;left:-465.54998779296875px"><div class="task _jsPlumb_endpoint_anchor_ ui-draggable" style="top: 322.283px; left: 470.55px; z-index: 24;" id="jsPlumb_1_10"><a class="task-name" data-toggle="tooltip" data-placement="right" title="A task performing a rest GET request.
+This template supports only basic authentication, for more advanced authentication settings, please modify the template according to the rest-assured documentation:
+https://github.com/rest-assured/rest-assured/wiki/Usage#authentication"><img src="/automation-dashboard/styles/patterns/img/wf-icons/api-rest.png" width="20px">&nbsp;<span class="name">Delete_A_Record</span></a></div><div style="position: absolute; height: 20px; width: 20px; left: 518.55px; top: 352.283px;" class="_jsPlumb_endpoint source-endpoint dependency-source-endpoint connected _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1" xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1" xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div></div></div>
+    </body>
+</html>
+ ]]>
+    </visualization>
+  </metadata>
+</job>

--- a/ApplicationConnectors/resources/catalog/ServiceNow_Retrieve_A_Record.xml
+++ b/ApplicationConnectors/resources/catalog/ServiceNow_Retrieve_A_Record.xml
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<job xmlns="urn:proactive:jobdescriptor:3.13" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" maxNumberOfExecution="2" name="ServiceNow_Retrieve_A_Record" onTaskError="continueJobExecution" priority="normal" projectName="ServiceNow" xsi:schemaLocation="urn:proactive:jobdescriptor:3.13 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.13/schedulerjob.xsd">
+  <variables>
+    <variable advanced="false" description="Base URL of the ServiceNow server." group="Http Connection" hidden="false" model="PA:URL" name="SERVICENOW_BASE_URL" value="https://SN_SERVER.com"/>
+    <variable advanced="false" description="Username for basic http authentication." group="Http Connection" hidden="false" model="" name="SERVICENOW_USER" value=""/>
+    <variable advanced="false" description="Password for basic http authentication." group="Http Connection" hidden="false" model="PA:HIDDEN" name="SERVICENOW_PASSWORD" value=""/>
+  </variables>
+  <description>
+    <![CDATA[ A workflow that runs a REST GET request to retrieve a single record from a ServiceNow table ]]>
+  </description>
+  <genericInformation>
+<info name="bucketName" value="application-connectors"/>
+<info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ServiceNow.png"/>
+<info name="group" value="public-objects"/>
+</genericInformation>
+  <taskFlow>
+    <task fork="true" name="Retrieve_A_Record">
+      <description>
+        <![CDATA[ Executes a GET to retrieve a single record from a ServiceNow table ]]>
+      </description>
+      <variables>
+        <variable advanced="false" description="Endpoint that will be queried." group="Http Connection" hidden="false" inherited="false" model="PA:URL" name="ENDPOINT" value="${SERVICENOW_BASE_URL}/api/now/table/${TABLE_NAME}/${SYS_ID}"/>
+        <variable advanced="false" description="Name of table to retrieve records from." group="Http Request" hidden="false" inherited="false" name="TABLE_NAME" value=""/>
+        <variable advanced="false" description="Unique ID (SYS_ID column) of the record to delete." group="Http Request" hidden="false" inherited="false" name="SYS_ID" value=""/>
+        <variable advanced="true" description="If true, disable SSL certificate verification." group="Http Connection" hidden="false" inherited="false" model="PA:BOOLEAN" name="SSL_DISABLE_CHECK" value="true"/>
+        <variable advanced="true" description="If true, print the full request and response content in the task output." group="Http Connection" hidden="false" inherited="false" model="PA:BOOLEAN" name="DEBUG" value="true"/>
+        <variable advanced="true" description="Which data to extract in the response if json, xml or html format is selected. It uses the &lt;a href=&quot;https://groovy-lang.org/processing-xml.html&quot; target=&quot;_blank&quot;&gt;GPath notation&lt;/a&gt;." group="Http Response" hidden="false" inherited="false" name="RESPONSE_PATH" value="."/>
+        <variable advanced="true" description="Format of REST response body." group="Http Response Parameters" hidden="false" inherited="false" model="PA:LIST(application/json,application/xml,text/xml)" name="RESPONSE_FORMAT" value="application/json"/>
+        <variable advanced="true" description="Return field display values (true), actual values (false), or both (all)." group="Action Parameters" hidden="false" inherited="false" model="PA:BOOLEAN" name="SYSPARM_DISPLAY_VALUE" value="true"/>
+        <variable advanced="true" description="A comma-separated list of fields to return in the response (default to all fields)." group="Action Parameters" hidden="false" inherited="false" name="SYSPARM_FIELDS" value=""/>
+        <variable advanced="true" description="True to access data across domains if authorized." group="Action Parameters" hidden="false" inherited="false" model="PA:BOOLEAN" name="SYSPARM_QUERY_NO_DOMAIN" value="false"/>
+        <variable advanced="true" description="True to exclude Table API links for reference fields." group="Action Parameters" hidden="false" inherited="false" model="PA:BOOLEAN" name="SYSPARM_EXCLUDE_REFERENCE_LINK" value="false"/>
+      </variables>
+      <genericInformation>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ServiceNow.png"/>
+      </genericInformation>
+      <inputFiles>
+        <files accessMode="cacheFromGlobalSpace" includes="rest-assured-fat-3.3.0.jar"/>
+      </inputFiles>
+      <forkEnvironment>
+        <envScript>
+          <script>
+            <code language="groovy">
+              <![CDATA[
+def jarFile = new File(cachespace, "rest-assured-fat-3.3.0.jar")
+
+forkEnvironment.addAdditionalClasspath(jarFile.getAbsolutePath())
+]]>
+            </code>
+          </script>
+        </envScript>
+      </forkEnvironment>
+      <scriptExecutable>
+        <script>
+          <code language="groovy">
+            <![CDATA[
+import static io.restassured.RestAssured.*;
+import static io.restassured.matcher.RestAssuredMatchers.*;
+import static io.restassured.config.EncoderConfig.*;
+import static org.hamcrest.Matchers.*;
+import org.apache.commons.httpclient.HttpStatus;
+import io.restassured.http.ContentType;
+import io.restassured.RestAssured;
+import com.google.common.base.Strings;
+
+debug = Boolean.parseBoolean(variables.get("DEBUG"))
+
+restCall = given().urlEncodingEnabled(false)
+
+if (Boolean.parseBoolean(variables.get("SSL_DISABLE_CHECK"))) {
+    restCall = restCall.relaxedHTTPSValidation()
+}
+
+if (!Strings.isNullOrEmpty(variables.get("SERVICENOW_USER")) && !Strings.isNullOrEmpty(variables.get("SERVICENOW_PASSWORD"))) {
+    restCall = restCall.auth().preemptive().basic(variables.get("SERVICENOW_USER"), variables.get("SERVICENOW_PASSWORD"))
+} else {
+    throw new IllegalArgumentException("Provide a username and password in order to query ServiceNow")
+}
+
+if (Strings.isNullOrEmpty(variables.get("TABLE_NAME"))) {
+     throw new IllegalArgumentException("Table to query cannot be empty")
+}
+
+// Add query parameters
+variables.entrySet().stream().filter({entry -> entry.getKey().startsWith("SYSPARM_") && !Strings.isNullOrEmpty(entry.getValue())})
+	.forEach({ entry -> 
+        restCall = restCall.queryParam(entry.getKey().toLowerCase(), entry.getValue().replaceAll(",","%2C")) 
+    });
+
+if (debug) {
+    println "-------------- REQUEST -----------------"
+	restCall = restCall.log().all()
+}
+response = restCall.get(variables.get("ENDPOINT"))
+
+if (debug) {
+    println "-------------- RESPONSE -----------------"
+	println response.statusLine()
+    println response.prettyPrint()
+} else {
+	println response.statusLine()
+}
+
+response = response.then().assertThat()
+  .statusCode(allOf(greaterThanOrEqualTo(HttpStatus.SC_OK),lessThan(HttpStatus.SC_MULTIPLE_CHOICES)))
+  .extract();
+
+if (debug) {
+    println "-------------- RESULT -------------------"
+}
+
+if (response.statusCode() == HttpStatus.SC_NO_CONTENT && !variables.get("RESPONSE_PATH").isEmpty()) {
+    throw new IllegalStateException("A RESPONSE_PATH was requested but http response has no content.")
+} else if (response.statusCode() == HttpStatus.SC_NO_CONTENT) {
+    result = true;
+    // response has no content
+    return;
+}
+
+switch (variables.get("RESPONSE_FORMAT")) {
+    case "application/json":
+    if (variables.get("RESPONSE_PATH").isEmpty()) {
+        throw new IllegalArgumentException("Invalid RESPONSE_PATH for json format")
+    }
+    result = response.jsonPath().get(variables.get("RESPONSE_PATH"));
+    println result
+    break;
+
+    case "application/xml":
+    if (variables.get("RESPONSE_PATH").isEmpty()) {
+        throw new IllegalArgumentException("Invalid RESPONSE_PATH for xml format")
+    }
+    // html parsing results are not serializable and thus can be returned only in string format
+    result = response.xmlPath().getString(variables.get("RESPONSE_PATH"));
+    println result
+    break;
+
+    case "text/xml":
+    result = response.prettyPrint()
+    break;
+}
+]]>
+          </code>
+        </script>
+      </scriptExecutable>
+      <metadata>
+        <positionTop>
+            323.2833251953125
+        </positionTop>
+        <positionLeft>
+            470.54998779296875
+        </positionLeft>
+      </metadata>
+    </task>
+  </taskFlow>
+  <metadata>
+    <visualization>
+      <![CDATA[ <html>
+    <head>
+    <link rel="stylesheet" href="/studio/styles/studio-standalone.css">
+        <style>
+        #workflow-designer {
+            left:0 !important;
+            top:0 !important;
+            width:2163px;
+            height:2302px;
+            }
+        </style>
+    </head>
+    <body>
+    <div id="workflow-visualization-view"><div id="workflow-visualization" style="position:relative;top:-318.2833251953125px;left:-465.54998779296875px"><div class="task _jsPlumb_endpoint_anchor_ ui-draggable active-task" style="top: 323.283px; left: 470.55px;" id="jsPlumb_1_10"><a class="task-name" data-toggle="tooltip" data-placement="right" title="A task performing a rest GET request.
+This template supports only basic authentication, for more advanced authentication settings, please modify the template according to the rest-assured documentation:
+https://github.com/rest-assured/rest-assured/wiki/Usage#authentication"><img src="/automation-dashboard/styles/patterns/img/wf-icons/api-rest.png" width="20px">&nbsp;<span class="name">Retrieve_A_Record</span></a></div><div style="position: absolute; height: 20px; width: 20px; left: 519px; top: 353px;" class="_jsPlumb_endpoint source-endpoint dependency-source-endpoint connected _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1" xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1" xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div></div></div>
+    </body>
+</html>
+ ]]>
+    </visualization>
+  </metadata>
+</job>

--- a/ApplicationConnectors/resources/catalog/ServiceNow_Retrieve_Records.xml
+++ b/ApplicationConnectors/resources/catalog/ServiceNow_Retrieve_Records.xml
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<job xmlns="urn:proactive:jobdescriptor:3.13" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" maxNumberOfExecution="2" name="ServiceNow_Retrieve_Records" onTaskError="continueJobExecution" priority="normal" projectName="ServiceNow" xsi:schemaLocation="urn:proactive:jobdescriptor:3.13 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.13/schedulerjob.xsd">
+  <variables>
+    <variable advanced="false" description="Base URL of the ServiceNow server." group="Http Connection" hidden="false" model="PA:URL" name="SERVICENOW_BASE_URL" value="https://SN_SERVER.com"/>
+    <variable advanced="false" description="Username for basic http authentication." group="Http Connection" hidden="false" name="SERVICENOW_USER" value=""/>
+    <variable advanced="false" description="Password for basic http authentication." group="Http Connection" hidden="false" model="PA:HIDDEN" name="SERVICENOW_PASSWORD" value=""/>
+  </variables>
+  <description>
+    <![CDATA[ A workflow that runs a REST GET request to retrieve multiple records from a ServiceNow table ]]>
+  </description>
+  <genericInformation>
+<info name="bucketName" value="application-connectors"/>
+<info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ServiceNow.png"/>
+<info name="group" value="public-objects"/>
+</genericInformation>
+  <taskFlow>
+    <task fork="true" name="Retrieve_Records">
+      <description>
+        <![CDATA[ Executes a GET to retrieve multiple record from a ServiceNow table ]]>
+      </description>
+      <variables>
+        <variable advanced="false" description="Endpoint that will be queried." group="Http Connection" hidden="false" inherited="false" name="ENDPOINT" value="${SERVICENOW_BASE_URL}/api/now/table/${TABLE_NAME}"/>
+        <variable advanced="false" description="Name of table to retrieve records from." group="Http Request" hidden="false" inherited="false" name="TABLE_NAME" value=""/>
+        <variable advanced="false" description="A comma-separated list of fields to return in the response (default to all fields)." group="Action Parameters" hidden="false" inherited="false" name="SYSPARM_FIELDS" value=""/>
+        <variable advanced="false" description="The maximum number of results returned per page." group="Query parameters" hidden="false" inherited="false" model="PA:INTEGER" name="SYSPARM_LIMIT" value="10000"/>
+        <variable advanced="true" description="If true, disable SSL certificate verification." group="Http Connection" hidden="false" inherited="false" model="PA:BOOLEAN" name="SSL_DISABLE_CHECK" value="true"/>
+        <variable advanced="true" description="If true, print the full request and response content in the task output." group="Http Connection" hidden="false" inherited="false" model="PA:BOOLEAN" name="DEBUG" value="true"/>
+        <variable advanced="true" description="Which data to extract in the response if json, xml or html format is selected. It uses the &lt;a href=&quot;https://groovy-lang.org/processing-xml.html&quot; target=&quot;_blank&quot;&gt;GPath notation&lt;/a&gt;." group="Http Response" hidden="false" inherited="false" name="RESPONSE_PATH" value="."/>
+        <variable advanced="true" description="Format of REST response body." group="Http Response" hidden="false" inherited="false" model="PA:LIST(application/json,application/xml,text/xml)" name="RESPONSE_FORMAT" value="application/json"/>
+        <variable advanced="true" description="An encoded query string used to filter the results." group="Action Parameters" hidden="false" inherited="false" name="SYSPARM_QUERY" value=""/>
+        <variable advanced="true" description="Return field display values (true), actual values (false), or both (all)." group="Action Parameters" hidden="false" inherited="false" model="PA:BOOLEAN" name="SYSPARM_DISPLAY_VALUE" value="true"/>
+        <variable advanced="true" description="Do not execute a select count(*) on table." group="Action Parameters" hidden="false" inherited="false" model="PA:BOOLEAN" name="SYSPARM_NO_COUNT" value="false"/>
+        <variable advanced="true" description="True to access data across domains if authorized." group="Action Parameters" hidden="false" inherited="false" model="PA:BOOLEAN" name="SYSPARM_QUERY_NO_DOMAIN" value="false"/>
+        <variable advanced="true" description="True to exclude Table API links for reference fields." group="Action Parameters" hidden="false" inherited="false" model="PA:BOOLEAN" name="SYSPARM_EXCLUDE_REFERENCE_LINK" value="false"/>
+      </variables>
+      <genericInformation>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ServiceNow.png"/>
+      </genericInformation>
+      <inputFiles>
+        <files accessMode="cacheFromGlobalSpace" includes="rest-assured-fat-3.3.0.jar"/>
+      </inputFiles>
+      <forkEnvironment>
+        <envScript>
+          <script>
+            <code language="groovy">
+              <![CDATA[
+def jarFile = new File(cachespace, "rest-assured-fat-3.3.0.jar")
+
+forkEnvironment.addAdditionalClasspath(jarFile.getAbsolutePath())
+]]>
+            </code>
+          </script>
+        </envScript>
+      </forkEnvironment>
+      <scriptExecutable>
+        <script>
+          <code language="groovy">
+            <![CDATA[
+import static io.restassured.RestAssured.*;
+import static io.restassured.matcher.RestAssuredMatchers.*;
+import static io.restassured.config.EncoderConfig.*;
+import static org.hamcrest.Matchers.*;
+import org.apache.commons.httpclient.HttpStatus;
+import io.restassured.http.ContentType;
+import io.restassured.RestAssured;
+import com.google.common.base.Strings;
+
+debug = Boolean.parseBoolean(variables.get("DEBUG"))
+
+restCall = given().urlEncodingEnabled(false)
+
+if (Boolean.parseBoolean(variables.get("SSL_DISABLE_CHECK"))) {
+    restCall = restCall.relaxedHTTPSValidation()
+}
+
+if (!Strings.isNullOrEmpty(variables.get("SERVICENOW_USER")) && !Strings.isNullOrEmpty(variables.get("SERVICENOW_PASSWORD"))) {
+    restCall = restCall.auth().preemptive().basic(variables.get("SERVICENOW_USER"), variables.get("SERVICENOW_PASSWORD"))
+} else {
+    throw new IllegalArgumentException("Provide a username and password in order to query ServiceNow")
+}
+
+if (Strings.isNullOrEmpty(variables.get("TABLE_NAME"))) {
+     throw new IllegalArgumentException("Table to query cannot be empty")
+}
+
+// Add query parameters
+variables.entrySet().stream().filter({entry -> entry.getKey().startsWith("SYSPARM_") && !Strings.isNullOrEmpty(entry.getValue())})
+	.forEach({ entry -> 
+        restCall = restCall.queryParam(entry.getKey().toLowerCase(), entry.getValue().replaceAll(",","%2C")) 
+    });
+
+if (debug) {
+    println "-------------- REQUEST -----------------"
+	restCall = restCall.log().all()
+}
+response = restCall.get(variables.get("ENDPOINT"))
+
+if (debug) {
+    println "-------------- RESPONSE -----------------"
+	println response.statusLine()
+    println response.prettyPrint()
+} else {
+	println response.statusLine()
+}
+
+response = response.then().assertThat()
+  .statusCode(allOf(greaterThanOrEqualTo(HttpStatus.SC_OK),lessThan(HttpStatus.SC_MULTIPLE_CHOICES)))
+  .extract();
+
+if (debug) {
+    println "-------------- RESULT -------------------"
+}
+
+if (response.statusCode() == HttpStatus.SC_NO_CONTENT && !variables.get("RESPONSE_PATH").isEmpty()) {
+    throw new IllegalStateException("A RESPONSE_PATH was requested but http response has no content.")
+} else if (response.statusCode() == HttpStatus.SC_NO_CONTENT) {
+    result = true;
+    // response has no content
+    return;
+}
+
+switch (variables.get("RESPONSE_FORMAT")) {
+    case "application/json":
+    if (variables.get("RESPONSE_PATH").isEmpty()) {
+        throw new IllegalArgumentException("Invalid RESPONSE_PATH for json format")
+    }
+    result = response.jsonPath().get(variables.get("RESPONSE_PATH"));
+    println result
+    break;
+
+    case "application/xml":
+    if (variables.get("RESPONSE_PATH").isEmpty()) {
+        throw new IllegalArgumentException("Invalid RESPONSE_PATH for xml format")
+    }
+    // html parsing results are not serializable and thus can be returned only in string format
+    result = response.xmlPath().getString(variables.get("RESPONSE_PATH"));
+    println result
+    break;
+
+    case "text/xml":
+    result = response.prettyPrint()
+    break;
+}
+]]>
+          </code>
+        </script>
+      </scriptExecutable>
+      <metadata>
+        <positionTop>
+            323.2833251953125
+        </positionTop>
+        <positionLeft>
+            495.04998779296875
+        </positionLeft>
+      </metadata>
+    </task>
+  </taskFlow>
+  <metadata>
+    <visualization>
+      <![CDATA[ <html>
+    <head>
+    <link rel="stylesheet" href="/studio/styles/studio-standalone.css">
+        <style>
+        #workflow-designer {
+            left:0 !important;
+            top:0 !important;
+            width:2257px;
+            height:2302px;
+            }
+        </style>
+    </head>
+    <body>
+    <div id="workflow-visualization-view"><div id="workflow-visualization" style="position:relative;top:-318.2833251953125px;left:-490.04998779296875px"><div class="task _jsPlumb_endpoint_anchor_ ui-draggable" style="top: 323.283px; left: 495.05px;" id="jsPlumb_1_10"><a class="task-name" data-toggle="tooltip" data-placement="right" title="A task performing a rest GET request.
+This template supports only basic authentication, for more advanced authentication settings, please modify the template according to the rest-assured documentation:
+https://github.com/rest-assured/rest-assured/wiki/Usage#authentication"><img src="/automation-dashboard/styles/patterns/img/wf-icons/api-rest.png" width="20px">&nbsp;<span class="name">Retrieve_Records</span></a></div><div style="position: absolute; height: 20px; width: 20px; left: 543px; top: 353px;" class="_jsPlumb_endpoint source-endpoint dependency-source-endpoint connected _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1" xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1" xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div></div></div>
+    </body>
+</html>
+ ]]>
+    </visualization>
+  </metadata>
+</job>

--- a/ApplicationConnectors/resources/catalog/ServiceNow_Update_Or_Modify_A_Record.xml
+++ b/ApplicationConnectors/resources/catalog/ServiceNow_Update_Or_Modify_A_Record.xml
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<job xmlns="urn:proactive:jobdescriptor:3.13" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" maxNumberOfExecution="2" name="ServiceNow_Update_Or_Modify_A_Record" onTaskError="continueJobExecution" priority="normal" projectName="ServiceNow" xsi:schemaLocation="urn:proactive:jobdescriptor:3.13 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.13/schedulerjob.xsd">
+  <variables>
+    <variable advanced="false" description="Base URL of the ServiceNow server." group="Http Connection" hidden="false" model="PA:URL" name="SERVICENOW_BASE_URL" value="https://SN_SERVER.com"/>
+    <variable advanced="false" description="Username for basic http authentication." group="Http Connection" hidden="false" name="SERVICENOW_USER" value=""/>
+    <variable advanced="false" description="Password for basic http authentication." group="Http Connection" hidden="false" model="PA:HIDDEN" name="SERVICENOW_PASSWORD" value=""/>
+  </variables>
+  <description>
+    <![CDATA[ A workflow that modifies a record in a ServiceNow table ]]>
+  </description>
+  <genericInformation>
+<info name="bucketName" value="application-connectors"/>
+<info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ServiceNow.png"/>
+<info name="group" value="public-objects"/>
+</genericInformation>
+  <taskFlow>
+    <task fork="true" name="Update_Or_Modify_Record">
+      <description>
+        <![CDATA[ A task performing a rest POST request using a json request body.
+
+This template supports only basic authentication, for more advanced authentication settings, please modify the template according to the rest-assured documentation:
+https://github.com/rest-assured/rest-assured/wiki/Usage#authentication ]]>
+      </description>
+      <variables>
+        <variable advanced="false" description="Endpoint that will be queried." group="Http Connection" hidden="false" inherited="false" model="PA:URL" name="ENDPOINT" value="${SERVICENOW_BASE_URL}/api/now/table/${TABLE_NAME}/${SYS_ID}"/>
+        <variable advanced="false" description="Simple JSON structure describing column and their values to be updated. Note that in case of a PUT, all non modified fields with values must be present as well in the json body." group="Http Request" hidden="false" inherited="false" model="PA:JSON" name="REQUEST_BODY" value=""/>
+        <variable advanced="false" description="Name of the table which contains the record that will be updated or modified." group="Http Request" hidden="false" inherited="false" name="TABLE_NAME" value=""/>
+        <variable advanced="false" description="Unique ID (SYS_ID column) of the record to update or modify." group="Http Request" hidden="false" inherited="false" name="SYS_ID" value=""/>
+        <variable advanced="false" description="The HTTP method to execute." group="Http Request" hidden="false" inherited="false" model="PA:LIST(PUT,PATCH)" name="HTTP_METHOD" value="PUT"/>
+        <variable advanced="true" description="If true, disable SSL certificate verification." group="Http Connection" hidden="false" inherited="false" model="PA:BOOLEAN" name="SSL_DISABLE_CHECK" value="true"/>
+        <variable advanced="true" description="If true, print the full request and response content in the task output." group="Http Connection" hidden="false" inherited="false" model="PA:BOOLEAN" name="DEBUG" value="false"/>
+        <variable advanced="true" description="Format of the HTTP response body." group="Http Response" hidden="false" inherited="false" model="PA:LIST(application/json,application/xml,text/xml)" name="RESPONSE_FORMAT" value="application/json"/>
+        <variable advanced="true" description="Format of the HTTP request body." group="Http Request" hidden="false" inherited="false" model="PA:LIST(application/json,application/xml,text/xml)" name="REQUEST_FORMAT" value="application/json"/>
+        <variable advanced="true" description="Which data to extract in the response if json, xml or html format is selected. It uses the &lt;a href=&quot;https://groovy-lang.org/processing-xml.html&quot; target=&quot;_blank&quot;&gt;GPath notation&lt;/a&gt;." group="Http Response" hidden="false" inherited="false" name="RESPONSE_PATH" value="."/>
+        <variable advanced="true" description="Return field display values (true), actual values (false), or both (all)." group="Action Parameters" hidden="false" inherited="false" model="PA:BOOLEAN" name="SYSPARM_DISPLAY_VALUE" value="true"/>
+        <variable advanced="true" description="True to exclude Table API links for reference fields." group="Action Parameters" hidden="false" inherited="false" model="PA:BOOLEAN" name="SYSPARM_EXCLUDE_REFERENCE_LINK" value="false"/>
+        <variable advanced="true" description="A comma-separated list of fields to return in the response. Defaults to all fields." group="Action Parameters" hidden="false" inherited="false" name="SYSPARM_FIELDS" value=""/>
+        <variable advanced="true" description="Set field values using their display value (true) or actual value (false)." group="Action Parameters" hidden="false" inherited="false" model="PA:BOOLEAN" name="SYSPARM_INPUT_DISPLAY_VALUE" value="false"/>
+        <variable advanced="true" description="True to suppress auto generation of system fields." group="Action Parameters" hidden="false" inherited="false" model="PA:BOOLEAN" name="SYSPARM_SUPPRESS_AUTO_SYS_FIELD" value="false"/>
+        <variable advanced="true" description="True to access data across domains if authorized." group="Action Parameters" hidden="false" inherited="false" model="PA:BOOLEAN" name="SYSPARM_QUERY_NO_DOMAIN" value="false"/>
+      </variables>
+      <genericInformation>
+        <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ServiceNow.png"/>
+      </genericInformation>
+      <inputFiles>
+        <files accessMode="cacheFromGlobalSpace" includes="rest-assured-fat-3.3.0.jar"/>
+      </inputFiles>
+      <forkEnvironment>
+        <envScript>
+          <script>
+            <code language="groovy">
+              <![CDATA[
+def jarFile = new File(cachespace, "rest-assured-fat-3.3.0.jar")
+
+forkEnvironment.addAdditionalClasspath(jarFile.getAbsolutePath())
+]]>
+            </code>
+          </script>
+        </envScript>
+      </forkEnvironment>
+      <scriptExecutable>
+        <script>
+          <code language="groovy">
+            <![CDATA[
+import static io.restassured.RestAssured.*;
+import static io.restassured.matcher.RestAssuredMatchers.*;
+import static io.restassured.config.EncoderConfig.*;
+import static org.hamcrest.Matchers.*;
+import org.apache.commons.httpclient.HttpStatus;
+import io.restassured.http.ContentType;
+import io.restassured.RestAssured;
+import com.google.common.base.Strings;
+
+debug = Boolean.parseBoolean(variables.get("DEBUG"))
+
+restCall = given().contentType(variables.get("REQUEST_FORMAT"))
+                  .urlEncodingEnabled(false)
+
+if (Boolean.parseBoolean(variables.get("SSL_DISABLE_CHECK"))) {
+    restCall = restCall.relaxedHTTPSValidation()
+}
+
+if (!Strings.isNullOrEmpty(variables.get("SERVICENOW_USER")) && !Strings.isNullOrEmpty(variables.get("SERVICENOW_PASSWORD"))) {
+    restCall = restCall.auth().preemptive().basic(variables.get("SERVICENOW_USER"), variables.get("SERVICENOW_PASSWORD"))
+}
+
+if (Strings.isNullOrEmpty(variables.get("TABLE_NAME"))) {
+     throw new IllegalArgumentException("Table to query cannot be empty")
+}
+
+if (Strings.isNullOrEmpty(variables.get("REQUEST_BODY"))) {
+     throw new IllegalArgumentException("Request body cannot be empty")
+}
+
+// Add body
+restCall = restCall.body(variables.get("REQUEST_BODY"));
+
+// Add others if they have been added in task variables
+variables.entrySet().stream().filter({entry -> entry.getKey().startsWith("SYSPARM_") && !Strings.isNullOrEmpty(entry.getValue())})
+	.forEach({ entry -> 
+        restCall = restCall.queryParam(entry.getKey().toLowerCase(), entry.getValue().replaceAll(",","%2C")) 
+    });
+
+if (debug) {
+    println "-------------- REQUEST -----------------"
+	restCall = restCall.log().all()
+}
+
+if (variables.get("HTTP_METHOD").equals("PATCH")) {
+	response = restCall.patch(variables.get("ENDPOINT"));
+} else if (variables.get("HTTP_METHOD").equals("PUT")) {
+    response = restCall.put(variables.get("ENDPOINT"));
+} else {
+    throw new IllegalArgumentException("Wrong HTTP_METHOD provided. Can be PUT or PATCH")
+}
+
+if (debug) {
+    println "-------------- RESPONSE -----------------"
+	println response.statusLine()
+    println response.prettyPrint()
+} else {
+	println response.statusLine()
+}
+
+response = response.then().assertThat()
+  .statusCode(allOf(greaterThanOrEqualTo(HttpStatus.SC_OK),lessThan(HttpStatus.SC_MULTIPLE_CHOICES)))
+  .extract();
+
+if (debug) {
+    println "-------------- RESULT -------------------"
+}
+
+if (response.statusCode() == HttpStatus.SC_NO_CONTENT && !variables.get("RESPONSE_PATH").isEmpty()) {
+    throw new IllegalStateException("A RESPONSE_PATH was requested but http response has no content.")
+} else if (response.statusCode() == HttpStatus.SC_NO_CONTENT) {
+    result = true;
+    // response has no content
+    return;
+}
+
+switch (variables.get("RESPONSE_FORMAT")) {
+    case "application/json":
+    if (variables.get("RESPONSE_PATH").isEmpty()) {
+        throw new IllegalArgumentException("Invalid RESPONSE_PATH for json format")
+    }
+    result = response.jsonPath().get(variables.get("RESPONSE_PATH"));
+    println result
+    break;
+    
+    case "application/xml":
+    if (variables.get("RESPONSE_PATH").isEmpty()) {
+        throw new IllegalArgumentException("Invalid RESPONSE_PATH for xml format")
+    }
+    // html parsing results are not serializable and thus can be returned only in string format
+    result = response.xmlPath().getString(variables.get("RESPONSE_PATH"));
+    println result
+    break;
+    
+    case "text/xml":
+    result = response.prettyPrint()
+    break;
+}
+]]>
+          </code>
+        </script>
+      </scriptExecutable>
+      <metadata>
+        <positionTop>
+            323.6833190917969
+        </positionTop>
+        <positionLeft>
+            479.10003662109375
+        </positionLeft>
+      </metadata>
+    </task>
+  </taskFlow>
+  <metadata>
+    <visualization>
+      <![CDATA[ <html>
+    <head>
+    <link rel="stylesheet" href="/studio/styles/studio-standalone.css">
+        <style>
+        #workflow-designer {
+            left:0 !important;
+            top:0 !important;
+            width:2257px;
+            height:2302px;
+            }
+        </style>
+    </head>
+    <body>
+    <div id="workflow-visualization-view"><div id="workflow-visualization" style="position:relative;top:-318.6833190917969px;left:-474.10003662109375px"><div class="task _jsPlumb_endpoint_anchor_ ui-draggable" style="top: 323.683px; left: 479.1px;" id="jsPlumb_1_4"><a class="task-name" data-toggle="tooltip" data-placement="right" title="A task performing a rest POST request using a json request body.
+
+This template supports only basic authentication, for more advanced authentication settings, please modify the template according to the rest-assured documentation:
+https://github.com/rest-assured/rest-assured/wiki/Usage#authentication"><img src="/automation-dashboard/styles/patterns/img/wf-icons/api-rest.png" width="20px">&nbsp;<span class="name">Update_Or_Modify_Record</span></a></div><div style="position: absolute; height: 20px; width: 20px; left: 548.5px; top: 354px;" class="_jsPlumb_endpoint source-endpoint dependency-source-endpoint connected _jsPlumb_endpoint_anchor_ ui-draggable ui-droppable"><svg style="position:absolute;left:0px;top:0px" width="20" height="20" pointer-events="all" position="absolute" version="1.1" xmlns="http://www.w3.org/1999/xhtml"><circle cx="10" cy="10" r="10" version="1.1" xmlns="http://www.w3.org/1999/xhtml" fill="#666" stroke="none" style=""></circle></svg></div></div></div>
+    </body>
+</html>
+ ]]>
+    </visualization>
+  </metadata>
+</job>


### PR DESCRIPTION
Add ServiceNow workflows in application-connector bucket to query the Table API on SN in order to perform CRUD on tables.

- Retrieve 1 or more records
- Update records using PUT or PATCH
- Create records
- Delete records