### PR TITLE
Bug fix: Remove single quotes from datetime descriptions

### DIFF
--- a/Cron/resources/catalog/start_at.xml
+++ b/Cron/resources/catalog/start_at.xml
@@ -3,7 +3,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns="urn:proactive:jobdescriptor:3.13" xsi:schemaLocation="urn:proactive:jobdescriptor:3.13 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.13/schedulerjob.xsd"  name="Start_At" projectName="1. Basic Workflows" priority="normal" onTaskError="continueJobExecution"  maxNumberOfExecution="2"  >
   <variables>
-    <variable name="DATETIME" value="2019-01-01T12:30:00+02:00" model="PA:DATETIME(yyyy-MM-dd&#39;T&#39;HH:mm:ssXXX)" description="Date and time given in format &lt;b&gt;yyyy-MM-dd&#39;T&#39;HH:mm:ssXXX&lt;/b&gt;&lt;br/&gt; Example:&lt;br/&gt; 2021-10-24T12:54:00+02:00"   />
+    <variable name="DATETIME" value="2019-01-01T12:30:00+02:00" model="PA:DATETIME(yyyy-MM-dd&#39;T&#39;HH:mm:ssXXX)" description="Date and time given in format &lt;b&gt;yyyy-MM-ddTHH:mm:ssXXX&lt;/b&gt;&lt;br/&gt; Example:&lt;br/&gt; 2021-10-24T12:54:00+02:00"   />
   </variables>
   <description>
     <![CDATA[ A workflow which executes a PI computation at a later date. The date and time are given by the DATETIME parameter. ]]>

--- a/Triggers/resources/catalog/Datetime_Trigger.xml
+++ b/Triggers/resources/catalog/Datetime_Trigger.xml
@@ -3,7 +3,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="urn:proactive:jobdescriptor:3.13" xsi:schemaLocation="urn:proactive:jobdescriptor:3.13 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.13/schedulerjob.xsd"  name="Datetime_Trigger"  priority="normal" onTaskError="continueJobExecution"  maxNumberOfExecution="2"  >
   <variables>
-    <variable name="DATETIME" value="2020-12-01T00:00:00+01:00" model="PA:DATETIME(yyyy-MM-dd&#39;T&#39;HH:mm:ssXXX)" description="Date and time given in format &lt;b&gt;yyyy-MM-dd&#39;T&#39;HH:mm:ssXXX&lt;/b&gt;&lt;br/&gt; Example:&lt;br/&gt; 2021-10-24T12:54:00+02:00"/>
+    <variable name="DATETIME" value="2020-12-01T00:00:00+01:00" model="PA:DATETIME(yyyy-MM-dd&#39;T&#39;HH:mm:ssXXX)" description="Date and time given in format &lt;b&gt;yyyy-MM-ddTHH:mm:ssXXX&lt;/b&gt;&lt;br/&gt; Example:&lt;br/&gt; 2021-10-24T12:54:00+02:00"/>
   </variables>
   <description>
     <![CDATA[ Workflow containing a datetime trigger ]]>
@@ -22,7 +22,7 @@
         <![CDATA[ Task starting at the specified date time ]]>
       </description>
       <variables>
-        <variable name="DATETIME" value="2020-12-01T00:00:00+01:00" inherited="true" model="PA:DATETIME(yyyy-MM-dd&#39;T&#39;HH:mm:ssXXX)" description="Date and time given in format &lt;b&gt;yyyy-MM-dd&#39;T&#39;HH:mm:ssXXX&lt;/b&gt;&lt;br/&gt; Example:&lt;br/&gt; 2021-10-24T12:54:00+02:00"/>
+        <variable name="DATETIME" value="2020-12-01T00:00:00+01:00" inherited="true" model="PA:DATETIME(yyyy-MM-dd&#39;T&#39;HH:mm:ssXXX)" description="Date and time given in format &lt;b&gt;yyyy-MM-ddTHH:mm:ssXXX&lt;/b&gt;&lt;br/&gt; Example:&lt;br/&gt; 2021-10-24T12:54:00+02:00"/>
       </variables>
       <genericInformation>
         <info name="START_AT" value="${DATETIME}"/>


### PR DESCRIPTION
single quotes seem to cause issues when added to the description of variables. encoding it as html: & # 3 9 ; does not help either. We should not use single quotes in variable descriptions anymore