### PR TITLE
Remove usage of check_node_source_name script in AI workflows

### DIFF
--- a/AutoML/resources/catalog/CIFAR_100_Image_Classification.xml
+++ b/AutoML/resources/catalog/CIFAR_100_Image_Classification.xml
@@ -27,11 +27,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/keras.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_hyperparameter_optimization"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/AutoML/resources/catalog/CIFAR_10_Image_Classification.xml
+++ b/AutoML/resources/catalog/CIFAR_10_Image_Classification.xml
@@ -31,11 +31,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/keras.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_hyperparameter_optimization"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/AutoML/resources/catalog/Digits_Classification.xml
+++ b/AutoML/resources/catalog/Digits_Classification.xml
@@ -30,11 +30,6 @@
       <depends>
         <task ref="get_automl_variables"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -204,11 +199,6 @@ print("END " + __file__)
       <description>
         <![CDATA[ The simplest task, ran by a Groovy engine. ]]>
       </description>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <scriptExecutable>
         <script>
           <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/ai-auto-ml-optimization/resources/get_automl_variables/raw"/>

--- a/AutoML/resources/catalog/Himmelblau_Function.xml
+++ b/AutoML/resources/catalog/Himmelblau_Function.xml
@@ -26,11 +26,6 @@
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_objective_functions"/>
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/himmelblau_function.png"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/AutoML/resources/catalog/Image_Object_Detection.xml
+++ b/AutoML/resources/catalog/Image_Object_Detection.xml
@@ -38,11 +38,6 @@ https://github.com/eriklindernoren/PyTorch-YOLOv3 ]]>
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/deep_detection.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_hyperparameter_optimization"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -714,11 +709,6 @@ print("END YOLO")
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/import_image.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_import_image_dataset"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -765,11 +755,6 @@ print("END YOLO")
         <files accessMode="transferFromGlobalSpace" includes="$DATASET_PATH/**"/>
         <files accessMode="transferFromGlobalSpace" includes="$LABEL_PATH/**"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/AutoML/resources/catalog/Kursawe_Multiobjective_Function.xml
+++ b/AutoML/resources/catalog/Kursawe_Multiobjective_Function.xml
@@ -26,11 +26,6 @@
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_objective_functions"/>
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/kursawe.png"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/AutoML/resources/catalog/Multiple_Objective_Handwritten_Digit_Classification.xml
+++ b/AutoML/resources/catalog/Multiple_Objective_Handwritten_Digit_Classification.xml
@@ -34,11 +34,6 @@
       <depends>
         <task ref="get_automl_variables"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/AutoML/resources/catalog/Python_Task.xml
+++ b/AutoML/resources/catalog/Python_Task.xml
@@ -25,11 +25,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/python.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_templates"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/AutoML/resources/catalog/Single_Objective_Handwritten_Digit_Classification.xml
+++ b/AutoML/resources/catalog/Single_Objective_Handwritten_Digit_Classification.xml
@@ -34,11 +34,6 @@
       <depends>
         <task ref="get_automl_variables"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/DataVisualization/resources/catalog/Tensorboard_Realtime_CIFAR10_Training.xml
+++ b/DataVisualization/resources/catalog/Tensorboard_Realtime_CIFAR10_Training.xml
@@ -74,11 +74,6 @@
       <depends>
         <task ref="Start_Tensorboard"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/DataVisualization/resources/catalog/Visdom_Visualize_Results.xml
+++ b/DataVisualization/resources/catalog/Visdom_Visualize_Results.xml
@@ -28,11 +28,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/visdom.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_visdom_visualize_results"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/DeepLearning/resources/catalog/AlexNet.xml
+++ b/DeepLearning/resources/catalog/AlexNet.xml
@@ -27,11 +27,6 @@ You can see more details in: http://pytorch.org/docs/master/torchvision/models.h
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/deep_learning.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_alexnet"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/DeepLearning/resources/catalog/DenseNet_161.xml
+++ b/DeepLearning/resources/catalog/DenseNet_161.xml
@@ -29,11 +29,6 @@ You can see more details in: http://pytorch.org/docs/master/torchvision/models.h
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/deep_learning.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_densenet_161"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/DeepLearning/resources/catalog/Download_Model.xml
+++ b/DeepLearning/resources/catalog/Download_Model.xml
@@ -29,11 +29,6 @@
       <inputFiles>
         <files accessMode="transferFromGlobalSpace" includes="$MODEL_FOLDER/**"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/DeepLearning/resources/catalog/Export_Images.xml
+++ b/DeepLearning/resources/catalog/Export_Images.xml
@@ -27,11 +27,6 @@
         <files accessMode="transferFromGlobalSpace" includes="$DATASET_PATH/**"/>
         <files accessMode="transferFromGlobalSpace" includes="$OUTPUT_FOLDER/**"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/DeepLearning/resources/catalog/FCN.xml
+++ b/DeepLearning/resources/catalog/FCN.xml
@@ -28,11 +28,6 @@ You can see more details in: ]]>
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/deep_segmentation.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_fcn"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/DeepLearning/resources/catalog/GRU.xml
+++ b/DeepLearning/resources/catalog/GRU.xml
@@ -28,11 +28,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/deep_text_classification.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_gru"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/DeepLearning/resources/catalog/Import_Image_Dataset.xml
+++ b/DeepLearning/resources/catalog/Import_Image_Dataset.xml
@@ -33,11 +33,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/import_image.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_import_image_dataset"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/DeepLearning/resources/catalog/Import_Model.xml
+++ b/DeepLearning/resources/catalog/Import_Model.xml
@@ -26,11 +26,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/import_deep_model.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_import_model_2"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/DeepLearning/resources/catalog/Import_Text_Dataset.xml
+++ b/DeepLearning/resources/catalog/Import_Text_Dataset.xml
@@ -34,11 +34,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/import_text.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_import_text_dataset"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/DeepLearning/resources/catalog/LSTM.xml
+++ b/DeepLearning/resources/catalog/LSTM.xml
@@ -28,11 +28,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/deep_text_classification.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_lstm"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/DeepLearning/resources/catalog/Model_Explainability.xml
+++ b/DeepLearning/resources/catalog/Model_Explainability.xml
@@ -33,11 +33,6 @@
         <files accessMode="transferFromGlobalSpace" includes="$DATASET_PATH/**"/>
         <files accessMode="transferFromGlobalSpace" includes="$MODEL_FOLDER/**"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/DeepLearning/resources/catalog/Predict_Image_Classification_Model.xml
+++ b/DeepLearning/resources/catalog/Predict_Image_Classification_Model.xml
@@ -32,11 +32,6 @@
         <files accessMode="transferFromGlobalSpace" includes="$DATASET_PATH/**"/>
         <files accessMode="transferFromGlobalSpace" includes="$MODEL_FOLDER/**"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/DeepLearning/resources/catalog/Predict_Image_Object_Detection_Model.xml
+++ b/DeepLearning/resources/catalog/Predict_Image_Object_Detection_Model.xml
@@ -31,11 +31,6 @@
         <files accessMode="transferFromGlobalSpace" includes="$DATASET_PATH/**"/>
         <files accessMode="transferFromGlobalSpace" includes="$MODEL_FOLDER/**"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/DeepLearning/resources/catalog/Predict_Image_Segmentation_Model.xml
+++ b/DeepLearning/resources/catalog/Predict_Image_Segmentation_Model.xml
@@ -32,11 +32,6 @@
         <files accessMode="transferFromGlobalSpace" includes="$DATASET_PATH/**"/>
         <files accessMode="transferFromGlobalSpace" includes="$MODEL_FOLDER/**"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/DeepLearning/resources/catalog/Predict_Text_Classification_Model.xml
+++ b/DeepLearning/resources/catalog/Predict_Text_Classification_Model.xml
@@ -30,11 +30,6 @@
         <files accessMode="transferFromGlobalSpace" includes="$DATASET_PATH/**"/>
         <files accessMode="transferFromGlobalSpace" includes="$MODEL_FOLDER/**"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/DeepLearning/resources/catalog/Preview_Results.xml
+++ b/DeepLearning/resources/catalog/Preview_Results.xml
@@ -30,11 +30,6 @@
         <files accessMode="transferFromGlobalSpace" includes="$DATASET_PATH/**"/>
         <files accessMode="transferFromGlobalSpace" includes="$OUTPUT_FOLDER/**"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/DeepLearning/resources/catalog/RNN.xml
+++ b/DeepLearning/resources/catalog/RNN.xml
@@ -28,11 +28,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/deep_text_classification.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_rnn"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/DeepLearning/resources/catalog/ResNet_18.xml
+++ b/DeepLearning/resources/catalog/ResNet_18.xml
@@ -27,11 +27,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/deep_learning.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_resnet_18"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/DeepLearning/resources/catalog/SSD.xml
+++ b/DeepLearning/resources/catalog/SSD.xml
@@ -40,11 +40,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/deep_detection.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_ssd"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/DeepLearning/resources/catalog/Search_Image_Dataset.xml
+++ b/DeepLearning/resources/catalog/Search_Image_Dataset.xml
@@ -33,11 +33,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/search_image_dataset.png"/>
          <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_search_image_dataset"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/DeepLearning/resources/catalog/SegNet.xml
+++ b/DeepLearning/resources/catalog/SegNet.xml
@@ -28,11 +28,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/deep_segmentation.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_segnet"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/DeepLearning/resources/catalog/Train_Image_Classification_Model.xml
+++ b/DeepLearning/resources/catalog/Train_Image_Classification_Model.xml
@@ -32,11 +32,6 @@
       <inputFiles>
         <files accessMode="transferFromGlobalSpace" includes="$DATASET_PATH/**"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/DeepLearning/resources/catalog/Train_Image_Object_Detection_Model.xml
+++ b/DeepLearning/resources/catalog/Train_Image_Object_Detection_Model.xml
@@ -32,11 +32,6 @@
         <files accessMode="transferFromGlobalSpace" includes="$DATASET_PATH/**"/>
         <files accessMode="transferFromGlobalSpace" includes="$LABEL_PATH/**"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/DeepLearning/resources/catalog/Train_Image_Segmentation_Model.xml
+++ b/DeepLearning/resources/catalog/Train_Image_Segmentation_Model.xml
@@ -32,11 +32,6 @@
       <inputFiles>
         <files accessMode="transferFromGlobalSpace" includes="$DATASET_PATH/**"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/DeepLearning/resources/catalog/Train_Text_Classification_Model.xml
+++ b/DeepLearning/resources/catalog/Train_Text_Classification_Model.xml
@@ -36,11 +36,6 @@
         <files accessMode="transferFromGlobalSpace" includes="$DATASET_PATH/**"/>
         <files accessMode="transferFromGlobalSpace" includes=".vector_cache/**"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/DeepLearning/resources/catalog/UNet.xml
+++ b/DeepLearning/resources/catalog/UNet.xml
@@ -28,11 +28,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/deep_segmentation.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_unet"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/DeepLearning/resources/catalog/VGG_16.xml
+++ b/DeepLearning/resources/catalog/VGG_16.xml
@@ -26,11 +26,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/deep_learning.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_vgg_16"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/DeepLearning/resources/catalog/YOLO.xml
+++ b/DeepLearning/resources/catalog/YOLO.xml
@@ -34,11 +34,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/deep_detection.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_yolo"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/DeepLearningWorkflows/resources/catalog/Custom_Sentiment_Analysis_In_Bing_News.xml
+++ b/DeepLearningWorkflows/resources/catalog/Custom_Sentiment_Analysis_In_Bing_News.xml
@@ -128,11 +128,6 @@ variables.put("IS_LABELED_DATA","False")
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/import_deep_model.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_import_model_2"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw" language="groovy"></file>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr" >
         <envScript>
           <script>
@@ -183,11 +178,6 @@ variables.put("IS_LABELED_DATA","False")
         <files  includes="$DATASET_PATH/**" accessMode="transferFromGlobalSpace"/>
         <files  includes="$MODEL_FOLDER/**" accessMode="transferFromGlobalSpace"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw" language="groovy"></file>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr" >
         <envScript>
           <script>
@@ -233,11 +223,6 @@ variables.put("IS_LABELED_DATA","False")
         <files  includes="$DATASET_PATH/**" accessMode="transferFromGlobalSpace"/>
         <files  includes="$OUTPUT_FOLDER/**" accessMode="transferFromGlobalSpace"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw" language="groovy"></file>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr" >
         <envScript>
           <script>
@@ -467,11 +452,6 @@ else:
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/deep_text_classification.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_rnn"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw" language="groovy"></file>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr" >
         <envScript>
           <script>

--- a/DeepLearningWorkflows/resources/catalog/Deep_Model_Explainability.xml
+++ b/DeepLearningWorkflows/resources/catalog/Deep_Model_Explainability.xml
@@ -26,11 +26,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/deep_learning.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_resnet_18"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -71,11 +66,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/import_image.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_import_image_dataset"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -122,11 +112,6 @@
       <inputFiles>
         <files accessMode="transferFromGlobalSpace" includes="$DATASET_PATH/**"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -183,11 +168,6 @@
         <files accessMode="transferFromGlobalSpace" includes="$DATASET_PATH/**"/>
         <files accessMode="transferFromGlobalSpace" includes="$MODEL_FOLDER/**"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/DeepLearningWorkflows/resources/catalog/IMDB_Sentiment_Analysis.xml
+++ b/DeepLearningWorkflows/resources/catalog/IMDB_Sentiment_Analysis.xml
@@ -41,11 +41,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/import_text.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_import_text_dataset"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw" language="groovy"></file>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr" >
         <envScript>
           <script>
@@ -89,11 +84,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/deep_text_classification.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_rnn"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw" language="groovy"></file>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr" >
         <envScript>
           <script>
@@ -146,11 +136,6 @@
         <files  includes="$DATASET_PATH/**" accessMode="transferFromGlobalSpace"/>
         <files  includes=".vector_cache/**" accessMode="transferFromGlobalSpace"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw" language="groovy"></file>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr" >
         <envScript>
           <script>
@@ -200,11 +185,6 @@
         <files  includes="$DATASET_PATH/**" accessMode="transferFromGlobalSpace"/>
         <files  includes="$MODEL_FOLDER/**" accessMode="transferFromGlobalSpace"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw" language="groovy"></file>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr" >
         <envScript>
           <script>
@@ -249,11 +229,6 @@
       <inputFiles>
         <files  includes="$MODEL_FOLDER/**" accessMode="transferFromGlobalSpace"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw" language="groovy"></file>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr" >
         <envScript>
           <script>
@@ -299,11 +274,6 @@
         <files  includes="$DATASET_PATH/**" accessMode="transferFromGlobalSpace"/>
         <files  includes="$OUTPUT_FOLDER/**" accessMode="transferFromGlobalSpace"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw" language="groovy"></file>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr" >
         <envScript>
           <script>

--- a/DeepLearningWorkflows/resources/catalog/Image_Classification.xml
+++ b/DeepLearningWorkflows/resources/catalog/Image_Classification.xml
@@ -33,11 +33,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/import_image.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_import_image_dataset"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -74,11 +69,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/deep_learning.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_resnet_18"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -112,11 +102,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/import_deep_model.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_import_model_2"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -164,11 +149,6 @@
         <files accessMode="transferFromGlobalSpace" includes="$DATASET_PATH/**"/>
         <files accessMode="transferFromGlobalSpace" includes="$MODEL_FOLDER/**"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -209,11 +189,6 @@
         <files accessMode="transferFromGlobalSpace" includes="$DATASET_PATH/**"/>
         <files accessMode="transferFromGlobalSpace" includes="$OUTPUT_FOLDER/**"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/DeepLearningWorkflows/resources/catalog/Image_Object_Detection.xml
+++ b/DeepLearningWorkflows/resources/catalog/Image_Object_Detection.xml
@@ -33,11 +33,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/import_image.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_import_image_dataset"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -74,11 +69,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/import_deep_model.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_import_model_2"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -123,11 +113,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/deep_detection.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_yolo"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -171,11 +156,6 @@
         <files accessMode="transferFromGlobalSpace" includes="$DATASET_PATH/**"/>
         <files accessMode="transferFromGlobalSpace" includes="$MODEL_FOLDER/**"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -219,11 +199,6 @@
         <files accessMode="transferFromGlobalSpace" includes="$DATASET_PATH/**"/>
         <files accessMode="transferFromGlobalSpace" includes="$OUTPUT_FOLDER/**"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/DeepLearningWorkflows/resources/catalog/Image_Segmentation.xml
+++ b/DeepLearningWorkflows/resources/catalog/Image_Segmentation.xml
@@ -33,11 +33,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/import_image.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_import_image_dataset"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -75,11 +70,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/deep_segmentation.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_segnet"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -113,11 +103,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/import_deep_model.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_import_model_2"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -165,11 +150,6 @@
         <files accessMode="transferFromGlobalSpace" includes="$DATASET_PATH/**"/>
         <files accessMode="transferFromGlobalSpace" includes="$MODEL_FOLDER/**"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -213,11 +193,6 @@
         <files accessMode="transferFromGlobalSpace" includes="$DATASET_PATH/**"/>
         <files accessMode="transferFromGlobalSpace" includes="$OUTPUT_FOLDER/**"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/DeepLearningWorkflows/resources/catalog/Keras_Task.xml
+++ b/DeepLearningWorkflows/resources/catalog/Keras_Task.xml
@@ -30,11 +30,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/keras.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_templates_2"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw" language="groovy"></file>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr" >
         <envScript>
           <script>

--- a/DeepLearningWorkflows/resources/catalog/Language_Detection.xml
+++ b/DeepLearningWorkflows/resources/catalog/Language_Detection.xml
@@ -35,11 +35,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/deep_text_classification.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_lstm"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw" language="groovy"></file>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr" >
         <envScript>
           <script>
@@ -86,11 +81,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/import_text.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_import_text_dataset"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw" language="groovy"></file>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr" >
         <envScript>
           <script>
@@ -146,11 +136,6 @@
         <files  includes="$DATASET_PATH/**" accessMode="transferFromGlobalSpace"/>
         <files  includes=".vector_cache/**" accessMode="transferFromGlobalSpace"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw" language="groovy"></file>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr" >
         <envScript>
           <script>
@@ -199,11 +184,6 @@
       <inputFiles>
         <files  includes="$MODEL_FOLDER/**" accessMode="transferFromGlobalSpace"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw" language="groovy"></file>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr" >
         <envScript>
           <script>
@@ -249,11 +229,6 @@
         <files  includes="$DATASET_PATH/**" accessMode="transferFromGlobalSpace"/>
         <files  includes="$MODEL_FOLDER/**" accessMode="transferFromGlobalSpace"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw" language="groovy"></file>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr" >
         <envScript>
           <script>
@@ -299,11 +274,6 @@
         <files  includes="$DATASET_PATH/**" accessMode="transferFromGlobalSpace"/>
         <files  includes="$OUTPUT_FOLDER/**" accessMode="transferFromGlobalSpace"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw" language="groovy"></file>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr" >
         <envScript>
           <script>

--- a/DeepLearningWorkflows/resources/catalog/PyTorch_Task.xml
+++ b/DeepLearningWorkflows/resources/catalog/PyTorch_Task.xml
@@ -25,11 +25,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/pytoch.jpg"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_templates_2"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw" language="groovy"></file>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr" >
         <envScript>
           <script>

--- a/DeepLearningWorkflows/resources/catalog/Search_Classify_Images.xml
+++ b/DeepLearningWorkflows/resources/catalog/Search_Classify_Images.xml
@@ -78,11 +78,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/search_image_dataset.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_search_image_dataset"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -121,11 +116,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/search_image_dataset.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_search_image_dataset"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -161,11 +151,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/import_deep_model.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_import_model_2"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -202,11 +187,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/deep_learning.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_resnet_18"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -251,11 +231,6 @@
         <files accessMode="transferFromGlobalSpace" includes="$DATASET_PATH/**"/>
         <files accessMode="transferFromGlobalSpace" includes="$MODEL_FOLDER/**"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -296,11 +271,6 @@
         <files accessMode="transferFromGlobalSpace" includes="$DATASET_PATH/**"/>
         <files accessMode="transferFromGlobalSpace" includes="$OUTPUT_FOLDER/**"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/DeepLearningWorkflows/resources/catalog/Search_Train_Image_Classification.xml
+++ b/DeepLearningWorkflows/resources/catalog/Search_Train_Image_Classification.xml
@@ -78,11 +78,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/search_image_dataset.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_search_image_dataset"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -121,11 +116,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/search_image_dataset.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_search_image_dataset"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -161,11 +151,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/deep_learning.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_resnet_18"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -209,11 +194,6 @@
       <inputFiles>
         <files accessMode="transferFromGlobalSpace" includes="$DATASET_PATH/**"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -268,11 +248,6 @@
         <files accessMode="transferFromGlobalSpace" includes="$DATASET_PATH/**"/>
         <files accessMode="transferFromGlobalSpace" includes="$MODEL_FOLDER/**"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -313,11 +288,6 @@
         <files accessMode="transferFromGlobalSpace" includes="$DATASET_PATH/**"/>
         <files accessMode="transferFromGlobalSpace" includes="$OUTPUT_FOLDER/**"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/DeepLearningWorkflows/resources/catalog/TensorFlow_Task.xml
+++ b/DeepLearningWorkflows/resources/catalog/TensorFlow_Task.xml
@@ -30,11 +30,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/tensorflow.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_templates_2"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw" language="groovy"></file>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr" >
         <envScript>
           <script>

--- a/DeepLearningWorkflows/resources/catalog/Train_Image_Classification.xml
+++ b/DeepLearningWorkflows/resources/catalog/Train_Image_Classification.xml
@@ -26,11 +26,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/deep_learning.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_resnet_18"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -71,11 +66,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/import_image.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_import_image_dataset"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -122,11 +112,6 @@
       <inputFiles>
         <files accessMode="transferFromGlobalSpace" includes="$DATASET_PATH/**"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -181,11 +166,6 @@
         <files accessMode="transferFromGlobalSpace" includes="$DATASET_PATH/**"/>
         <files accessMode="transferFromGlobalSpace" includes="$MODEL_FOLDER/**"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -226,11 +206,6 @@
         <files accessMode="transferFromGlobalSpace" includes="$DATASET_PATH/**"/>
         <files accessMode="transferFromGlobalSpace" includes="$OUTPUT_FOLDER/**"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/DeepLearningWorkflows/resources/catalog/Train_Image_Object_Detection.xml
+++ b/DeepLearningWorkflows/resources/catalog/Train_Image_Object_Detection.xml
@@ -33,11 +33,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/import_image.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_import_image_dataset"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw" language="groovy"></file>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr" >
         <envScript>
           <script>
@@ -89,11 +84,6 @@
         <files  includes="$DATASET_PATH/**" accessMode="transferFromGlobalSpace"/>
         <files  includes="$LABEL_PATH/**" accessMode="transferFromGlobalSpace"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw" language="groovy"></file>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr" >
         <envScript>
           <script>
@@ -152,11 +142,6 @@
         <files  includes="$DATASET_PATH/**" accessMode="transferFromGlobalSpace"/>
         <files  includes="$MODEL_FOLDER/**" accessMode="transferFromGlobalSpace"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw" language="groovy"></file>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr" >
         <envScript>
           <script>
@@ -205,11 +190,6 @@
         <files  includes="$DATASET_PATH/**" accessMode="transferFromGlobalSpace"/>
         <files  includes="$OUTPUT_FOLDER/**" accessMode="transferFromGlobalSpace"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw" language="groovy"></file>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr" >
         <envScript>
           <script>
@@ -256,11 +236,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/deep_detection.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_yolo"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw" language="groovy"></file>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr" >
         <envScript>
           <script>

--- a/DeepLearningWorkflows/resources/catalog/Train_Image_Segmentation.xml
+++ b/DeepLearningWorkflows/resources/catalog/Train_Image_Segmentation.xml
@@ -31,11 +31,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/import_image.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_import_image_dataset"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -73,11 +68,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/deep_segmentation.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_segnet"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -121,11 +111,6 @@
       <inputFiles>
         <files accessMode="transferFromGlobalSpace" includes="$DATASET_PATH/**"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -180,11 +165,6 @@
         <files accessMode="transferFromGlobalSpace" includes="$DATASET_PATH/**"/>
         <files accessMode="transferFromGlobalSpace" includes="$MODEL_FOLDER/**"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -228,11 +208,6 @@
         <files accessMode="transferFromGlobalSpace" includes="$DATASET_PATH/**"/>
         <files accessMode="transferFromGlobalSpace" includes="$OUTPUT_FOLDER/**"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MLOpsDashboard/resources/catalog/MLOps_Dashboard.xml
+++ b/MLOpsDashboard/resources/catalog/MLOps_Dashboard.xml
@@ -41,9 +41,6 @@
             </arguments>
           </file>
         </script>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
       </selection>
       <pre>
         <script>

--- a/MLOpsModelServer/resources/catalog/MLOps_Model_Server.xml
+++ b/MLOpsModelServer/resources/catalog/MLOps_Model_Server.xml
@@ -47,9 +47,6 @@
             </arguments>
           </file>
         </script>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
       </selection>
       <scriptExecutable>
         <script>

--- a/MLOpsModelServer/resources/catalog/MLOps_Model_Server_Application_Inference.xml
+++ b/MLOpsModelServer/resources/catalog/MLOps_Model_Server_Application_Inference.xml
@@ -32,11 +32,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/model_server.png"/>
         <info name="PRE_SCRIPT_AS_FILE" value="$TASK_FILE_PATH"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment>
         <envScript>
           <script>

--- a/MLOpsModelServer/resources/catalog/MLOps_Model_Server_Application_Performance_Analyzer.xml
+++ b/MLOpsModelServer/resources/catalog/MLOps_Model_Server_Application_Performance_Analyzer.xml
@@ -37,11 +37,6 @@ Overhead: The average time spent in the endpoint that cannot be correctly captur
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/model_server.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw" language="groovy"></file>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr" >
         <envScript>
           <script>

--- a/MLOpsModelServer/resources/catalog/MLOps_Model_Server_Inference_Test.xml
+++ b/MLOpsModelServer/resources/catalog/MLOps_Model_Server_Inference_Test.xml
@@ -30,11 +30,6 @@
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html"/>
         <info name="PRE_SCRIPT_AS_FILE" value="$TASK_FILE_PATH"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MLOpsModelServer/resources/catalog/MLOps_Model_Server_Service_Manager.xml
+++ b/MLOpsModelServer/resources/catalog/MLOps_Model_Server_Service_Manager.xml
@@ -37,11 +37,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/model_server.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_start_a_generic_service_instance"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <scriptExecutable>
         <script>
           <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/service-automation/resources/Service_Start/raw">
@@ -89,11 +84,6 @@
       <depends>
         <task ref="wait_for_signals"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <scriptExecutable>
         <script>
           <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/service-automation/resources/Service_Action/raw"/>
@@ -123,11 +113,6 @@
       <depends>
         <task ref="MLOps_Model_Server_Service_Start"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <scriptExecutable>
         <script>
           <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/control-signal/resources/check_and_remove_many_signals/raw">

--- a/MLOpsModelServer/resources/catalog/MLOps_Model_Server_Service_Start.xml
+++ b/MLOpsModelServer/resources/catalog/MLOps_Model_Server_Service_Start.xml
@@ -37,11 +37,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/model_server.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_start_a_generic_service_instance"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <scriptExecutable>
         <script>
           <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/service-automation/resources/Service_Start/raw">

--- a/MLOpsModelServer/resources/catalog/MLOps_Model_Server_Service_Stop.xml
+++ b/MLOpsModelServer/resources/catalog/MLOps_Model_Server_Service_Stop.xml
@@ -26,11 +26,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/model_server.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_delete_finish_the_service"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <scriptExecutable>
         <script>
           <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/service-automation/resources/Service_Action/raw"/>

--- a/MachineLearning/resources/catalog/AdaBoost.xml
+++ b/MachineLearning/resources/catalog/AdaBoost.xml
@@ -28,11 +28,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ml_ensemble.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_adaboost"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/Append_Data.xml
+++ b/MachineLearning/resources/catalog/Append_Data.xml
@@ -28,11 +28,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/data-processing.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_append_data"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/AutoSklearn_Classifier.xml
+++ b/MachineLearning/resources/catalog/AutoSklearn_Classifier.xml
@@ -31,11 +31,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/AutoML.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_autosklearn_classifier"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/AutoSklearn_Regressor.xml
+++ b/MachineLearning/resources/catalog/AutoSklearn_Regressor.xml
@@ -31,11 +31,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/AutoML.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_autosklearn_regressor"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/Bayesian_Ridge_Regression.xml
+++ b/MachineLearning/resources/catalog/Bayesian_Ridge_Regression.xml
@@ -28,11 +28,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ml_regresssion.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_bayesian_ridge_regression"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/CatBoost.xml
+++ b/MachineLearning/resources/catalog/CatBoost.xml
@@ -28,11 +28,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ml_ensemble.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_catboost"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/Download_Model.xml
+++ b/MachineLearning/resources/catalog/Download_Model.xml
@@ -26,11 +26,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/download_model.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_download_model"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/Drop_Columns.xml
+++ b/MachineLearning/resources/catalog/Drop_Columns.xml
@@ -29,11 +29,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/data-processing.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_drop_columns"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/Drop_NaNs.xml
+++ b/MachineLearning/resources/catalog/Drop_NaNs.xml
@@ -28,11 +28,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/data-processing.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_drop_nans"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/Encode_Data.xml
+++ b/MachineLearning/resources/catalog/Encode_Data.xml
@@ -29,11 +29,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/data-processing.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_encode_data"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/Export_Data.xml
+++ b/MachineLearning/resources/catalog/Export_Data.xml
@@ -29,11 +29,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/export_data.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_export_data"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/Feature_Vector_Extractor.xml
+++ b/MachineLearning/resources/catalog/Feature_Vector_Extractor.xml
@@ -34,11 +34,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/filled_filter.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_feature_vector_extractor"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/Fill_NaNs.xml
+++ b/MachineLearning/resources/catalog/Fill_NaNs.xml
@@ -29,11 +29,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/data-processing.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_fill_nans"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/Filter_Columns.xml
+++ b/MachineLearning/resources/catalog/Filter_Columns.xml
@@ -29,11 +29,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/data-processing.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_filter_columns"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/Gaussian_Naive_Bayes.xml
+++ b/MachineLearning/resources/catalog/Gaussian_Naive_Bayes.xml
@@ -28,11 +28,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ml_classification.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_gaussian_naive_bayes"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/Gradient_Boosting.xml
+++ b/MachineLearning/resources/catalog/Gradient_Boosting.xml
@@ -28,11 +28,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ml_ensemble.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_gradient_boosting"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/Import_Data.xml
+++ b/MachineLearning/resources/catalog/Import_Data.xml
@@ -36,11 +36,6 @@
       <inputFiles>
         <files accessMode="transferFromGlobalSpace" includes="data_type_identifier/*"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/Import_Data_And_Automate_Feature_Engineering.xml
+++ b/MachineLearning/resources/catalog/Import_Data_And_Automate_Feature_Engineering.xml
@@ -36,11 +36,6 @@
         <files accessMode="transferFromGlobalSpace" includes="templates/*"/>
         <files accessMode="transferFromGlobalSpace" includes="static/AE-Logo.png"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/Import_Model.xml
+++ b/MachineLearning/resources/catalog/Import_Model.xml
@@ -27,11 +27,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/load_model.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_import_model"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/Isolation_Forest.xml
+++ b/MachineLearning/resources/catalog/Isolation_Forest.xml
@@ -28,11 +28,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ml_anomaly.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_isolation_forest"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/K_Means.xml
+++ b/MachineLearning/resources/catalog/K_Means.xml
@@ -28,11 +28,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ml_clustering.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_kmeans"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/Linear_Regression.xml
+++ b/MachineLearning/resources/catalog/Linear_Regression.xml
@@ -28,11 +28,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ml_regresssion.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_linear_regression"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/Load_Boston_Dataset.xml
+++ b/MachineLearning/resources/catalog/Load_Boston_Dataset.xml
@@ -28,11 +28,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/load_dataset.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_load_boston_dataset"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/Load_Iris_Dataset.xml
+++ b/MachineLearning/resources/catalog/Load_Iris_Dataset.xml
@@ -32,11 +32,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/load_dataset.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_load_iris_dataset"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/Log_Parser.xml
+++ b/MachineLearning/resources/catalog/Log_Parser.xml
@@ -30,11 +30,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/log_parser.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_log_parser"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/Logistic_Regression.xml
+++ b/MachineLearning/resources/catalog/Logistic_Regression.xml
@@ -28,11 +28,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ml_classification.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_logistic_regression"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/Mean_Shift.xml
+++ b/MachineLearning/resources/catalog/Mean_Shift.xml
@@ -28,11 +28,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ml_clustering.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_mean_shift"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/Merge_Data.xml
+++ b/MachineLearning/resources/catalog/Merge_Data.xml
@@ -29,11 +29,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/data-processing.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_merge_data"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/Model_Explainability.xml
+++ b/MachineLearning/resources/catalog/Model_Explainability.xml
@@ -31,11 +31,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/model-explainability.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_ml_explainability"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/One_Class_SVM.xml
+++ b/MachineLearning/resources/catalog/One_Class_SVM.xml
@@ -28,11 +28,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ml_anomaly.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_one_class_svm"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/Predict_Model.xml
+++ b/MachineLearning/resources/catalog/Predict_Model.xml
@@ -29,11 +29,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/predict.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_predict_model"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/Preview_Results.xml
+++ b/MachineLearning/resources/catalog/Preview_Results.xml
@@ -29,11 +29,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/preview_results.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_preview_results"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/Query_Data.xml
+++ b/MachineLearning/resources/catalog/Query_Data.xml
@@ -29,11 +29,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/data-processing.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_query_data"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/Random_Forest.xml
+++ b/MachineLearning/resources/catalog/Random_Forest.xml
@@ -28,11 +28,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ml_ensemble.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_random_forest"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/Rename_Columns.xml
+++ b/MachineLearning/resources/catalog/Rename_Columns.xml
@@ -29,11 +29,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/data-processing.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_rename_columns"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/Scale_Data.xml
+++ b/MachineLearning/resources/catalog/Scale_Data.xml
@@ -31,11 +31,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/data-processing.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_scale_data"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/Split_Data.xml
+++ b/MachineLearning/resources/catalog/Split_Data.xml
@@ -29,11 +29,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/data-processing.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_split_data"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/Summarize_Data.xml
+++ b/MachineLearning/resources/catalog/Summarize_Data.xml
@@ -30,11 +30,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/filled_filter.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_summarize_data"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/Support_Vector_Machines.xml
+++ b/MachineLearning/resources/catalog/Support_Vector_Machines.xml
@@ -27,11 +27,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ml_classification.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_support_vector_machines"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/Support_Vector_Regression.xml
+++ b/MachineLearning/resources/catalog/Support_Vector_Regression.xml
@@ -28,11 +28,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ml_regresssion.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_support_vector_regression"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/TPOT_Classifier.xml
+++ b/MachineLearning/resources/catalog/TPOT_Classifier.xml
@@ -30,11 +30,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/AutoML.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_tpot_classifier"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/TPOT_Regressor.xml
+++ b/MachineLearning/resources/catalog/TPOT_Regressor.xml
@@ -30,11 +30,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/AutoML.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_tpot_regressor"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/Time_Series_Feature_Extraction.xml
+++ b/MachineLearning/resources/catalog/Time_Series_Feature_Extraction.xml
@@ -31,11 +31,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/filled_filter.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_tsfresh_features_extraction"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/Train_Model.xml
+++ b/MachineLearning/resources/catalog/Train_Model.xml
@@ -29,11 +29,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/train.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_train_model"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearning/resources/catalog/XGBoost.xml
+++ b/MachineLearning/resources/catalog/XGBoost.xml
@@ -28,11 +28,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ml_ensemble.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_xgboost"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearningWorkflows/resources/catalog/Breast_Cancer_Detection_Using_AutoSklearn_Classifier.xml
+++ b/MachineLearningWorkflows/resources/catalog/Breast_Cancer_Detection_Using_AutoSklearn_Classifier.xml
@@ -232,11 +232,6 @@ variables.put("PREVIOUS_PA_TASK_NAME", variables.get("PA_TASK_NAME"))
       <depends>
         <task ref="Predict_Model"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearningWorkflows/resources/catalog/California_Housing_Prediction_Using_TPOT_Regressor.xml
+++ b/MachineLearningWorkflows/resources/catalog/California_Housing_Prediction_Using_TPOT_Regressor.xml
@@ -231,11 +231,6 @@ variables.put("PREVIOUS_PA_TASK_NAME", variables.get("PA_TASK_NAME"))
       <depends>
         <task ref="Predict_Model"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearningWorkflows/resources/catalog/Forecasting_Power_Consumption_With_Time_Series.xml
+++ b/MachineLearningWorkflows/resources/catalog/Forecasting_Power_Consumption_With_Time_Series.xml
@@ -48,11 +48,6 @@
       <inputFiles>
         <files accessMode="transferFromGlobalSpace" includes="data_type_identifier/*"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -91,11 +86,6 @@
       <depends>
         <task ref="Import_Train_Data"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -136,11 +126,6 @@
       <depends>
         <task ref="Drop_Columns"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -272,11 +257,6 @@ print("END " + __file__)
         <task ref="Scale_Train_Data"/>
         <task ref="Support_Vector_Regression"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -320,11 +300,6 @@ print("END " + __file__)
       <depends>
         <task ref="Start"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -368,11 +343,6 @@ print("END " + __file__)
       <depends>
         <task ref="Fill_NaNs"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -418,11 +388,6 @@ print("END " + __file__)
       <inputFiles>
         <files accessMode="transferFromGlobalSpace" includes="data_type_identifier/*"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -462,11 +427,6 @@ print("END " + __file__)
         <task ref="Train_Model"/>
         <task ref="Scale_Test_Data"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -507,11 +467,6 @@ print("END " + __file__)
         <task ref="Scale_Train_Data"/>
         <task ref="Drop_Columns2"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -658,11 +613,6 @@ print("END " + __file__)
       <depends>
         <task ref="Import_Test_Data"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -832,11 +782,6 @@ variables.put("ENDPOINT_VISDOM",variables.get("ENDPOINT_" + variables.get("INSTA
       <depends>
         <task ref="Predict_Model"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearningWorkflows/resources/catalog/Train_Classification_Model_On_GPU.xml
+++ b/MachineLearningWorkflows/resources/catalog/Train_Classification_Model_On_GPU.xml
@@ -34,11 +34,6 @@
         <task ref="Split_Data"/>
         <task ref="Random_Forest"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -83,11 +78,6 @@
         <task ref="Train_Model"/>
         <task ref="Split_Data"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -123,11 +113,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ml_ensemble.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_random_forest"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -175,11 +160,6 @@
       <inputFiles>
         <files accessMode="transferFromGlobalSpace" includes="data_type_identifier/*"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -218,11 +198,6 @@
       <depends>
         <task ref="Import_Data"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -261,11 +236,6 @@
       <depends>
         <task ref="Predict_Model"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -301,11 +271,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ml_ensemble.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_xgboost"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -346,11 +311,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ml_classification.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_logistic_regression"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -390,11 +350,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ml_classification.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_support_vector_machines"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearningWorkflows/resources/catalog/Train_Multiple_Classification_Models_On_GPU.xml
+++ b/MachineLearningWorkflows/resources/catalog/Train_Multiple_Classification_Models_On_GPU.xml
@@ -34,11 +34,6 @@
         <task ref="Split_Data"/>
         <task ref="Random_Forest"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -83,11 +78,6 @@
         <task ref="Train_Model"/>
         <task ref="Split_Data"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -123,11 +113,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ml_ensemble.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_random_forest"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -175,11 +160,6 @@
       <inputFiles>
         <files accessMode="transferFromGlobalSpace" includes="data_type_identifier/*"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -218,11 +198,6 @@
       <depends>
         <task ref="Import_Data"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -261,11 +236,6 @@
       <depends>
         <task ref="Predict_Model"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -301,11 +271,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ml_ensemble.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_xgboost"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -346,11 +311,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ml_classification.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_logistic_regression"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -390,11 +350,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ml_classification.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_support_vector_machines"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -439,11 +394,6 @@
         <task ref="Split_Data"/>
         <task ref="XGBoost"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -488,11 +438,6 @@
         <task ref="Train_Model2"/>
         <task ref="Split_Data"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -531,11 +476,6 @@
       <depends>
         <task ref="Predict_Model2"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -575,11 +515,6 @@
         <task ref="Logistic_Regression"/>
         <task ref="Split_Data"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -624,11 +559,6 @@
         <task ref="Train_Model3"/>
         <task ref="Split_Data"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -667,11 +597,6 @@
       <depends>
         <task ref="Predict_Model3"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -711,11 +636,6 @@
         <task ref="Support_Vector_Machines"/>
         <task ref="Split_Data"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -760,11 +680,6 @@
         <task ref="Train_Model4"/>
         <task ref="Split_Data"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -803,11 +718,6 @@
       <depends>
         <task ref="Predict_Model4"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearningWorkflows/resources/catalog/Train_Multiple_Regression_Models_On_GPU.xml
+++ b/MachineLearningWorkflows/resources/catalog/Train_Multiple_Regression_Models_On_GPU.xml
@@ -34,11 +34,6 @@
         <task ref="Split_Data"/>
         <task ref="Linear_Regression"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -83,11 +78,6 @@
         <task ref="Train_Model"/>
         <task ref="Split_Data"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -130,11 +120,6 @@
       <inputFiles>
         <files accessMode="transferFromGlobalSpace" includes="data_type_identifier/*"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -173,11 +158,6 @@
       <depends>
         <task ref="Import_Data"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -216,11 +196,6 @@
       <depends>
         <task ref="Predict_Model"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -256,11 +231,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ml_regresssion.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_linear_regression"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -301,11 +271,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ml_regresssion.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_support_vector_regression"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -350,11 +315,6 @@
         <task ref="Support_Vector_Regression"/>
         <task ref="Split_Data"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -398,11 +358,6 @@
       <depends>
         <task ref="Train_Model2"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -441,11 +396,6 @@
       <depends>
         <task ref="Predict_Model2"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearningWorkflows/resources/catalog/Train_Regression_Model_On_GPU.xml
+++ b/MachineLearningWorkflows/resources/catalog/Train_Regression_Model_On_GPU.xml
@@ -34,11 +34,6 @@
         <task ref="Split_Data"/>
         <task ref="Linear_Regression"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -83,11 +78,6 @@
         <task ref="Train_Model"/>
         <task ref="Split_Data"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -130,11 +120,6 @@
       <inputFiles>
         <files accessMode="transferFromGlobalSpace" includes="data_type_identifier/*"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -173,11 +158,6 @@
       <depends>
         <task ref="Import_Data"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -216,11 +196,6 @@
       <depends>
         <task ref="Predict_Model"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -256,11 +231,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ml_regresssion.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_linear_regression"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -301,11 +271,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ml_regresssion.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_support_vector_regression"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/MachineLearningWorkflows/resources/catalog/Vehicle_Type_Using_Model_Explainability.xml
+++ b/MachineLearningWorkflows/resources/catalog/Vehicle_Type_Using_Model_Explainability.xml
@@ -264,11 +264,6 @@
         <files accessMode="transferFromGlobalSpace" includes="data_type_identifier/*"/>
         <files accessMode="transferFromGlobalSpace" includes="templates/*"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/ModelAsService/resources/catalog/Azure_Train_Deploy_Call_Diabetics_Detection_Service.xml
+++ b/ModelAsService/resources/catalog/Azure_Train_Deploy_Call_Diabetics_Detection_Service.xml
@@ -40,11 +40,6 @@
       <inputFiles>
         <files accessMode="transferFromGlobalSpace" includes="data_type_identifier/*"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -83,11 +78,6 @@
       <depends>
         <task ref="Import_Data"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -123,11 +113,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ml_clustering.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_kmeans"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>
@@ -172,11 +157,6 @@
         <task ref="Split_Data"/>
         <task ref="K_Means"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr">
         <envScript>
           <script>

--- a/ModelAsService/resources/catalog/Diabetics_Deploy_Predict_Classifier_Model.xml
+++ b/ModelAsService/resources/catalog/Diabetics_Deploy_Predict_Classifier_Model.xml
@@ -53,11 +53,6 @@
       <inputFiles>
         <files  includes="data_type_identifier/*" accessMode="transferFromGlobalSpace"/>
       </inputFiles>
-      <selection>
-        <script type="static">
-          <file url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw" language="groovy"></file>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr" >
         <envScript>
           <script>
@@ -101,11 +96,6 @@
       <depends>
         <task ref="Import_Data"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw" language="groovy"></file>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr" >
         <envScript>
           <script>
@@ -150,11 +140,6 @@
         <task ref="Split_Data"/>
         <task ref="Random_Forest"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw" language="groovy"></file>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr" >
         <envScript>
           <script>
@@ -200,11 +185,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ml_ensemble.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_random_forest"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw" language="groovy"></file>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr" >
         <envScript>
           <script>

--- a/ModelAsService/resources/catalog/IRIS_Deploy_Flower_Classifier_Model.xml
+++ b/ModelAsService/resources/catalog/IRIS_Deploy_Flower_Classifier_Model.xml
@@ -100,11 +100,6 @@ if (result!=null){
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/load_dataset.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_load_iris_dataset"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw" language="groovy"></file>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr" >
         <envScript>
           <script>
@@ -144,11 +139,6 @@ if (result!=null){
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ml_classification.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_support_vector_machines"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw" language="groovy"></file>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr" >
         <envScript>
           <script>
@@ -198,11 +188,6 @@ if (result!=null){
         <task ref="Support_Vector_Machines"/>
         <task ref="Load_Iris_Dataset"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw" language="groovy"></file>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr" >
         <envScript>
           <script>

--- a/ModelAsService/resources/catalog/IRIS_Deploy_Predict_Flower_Classifier_Model_Interactive.xml
+++ b/ModelAsService/resources/catalog/IRIS_Deploy_Predict_Flower_Classifier_Model_Interactive.xml
@@ -368,11 +368,6 @@ variables.put("SERVICE_TOKEN", SERVICE_TOKEN)
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/load_dataset.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_load_iris_dataset"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw" language="groovy"></file>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr" >
         <envScript>
           <script>
@@ -416,11 +411,6 @@ variables.put("SERVICE_TOKEN", SERVICE_TOKEN)
       <depends>
         <task ref="Load_Iris_Dataset"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw" language="groovy"></file>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr" >
         <envScript>
           <script>
@@ -460,11 +450,6 @@ variables.put("SERVICE_TOKEN", SERVICE_TOKEN)
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/ml_classification.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html#_support_vector_machines"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw" language="groovy"></file>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr" >
         <envScript>
           <script>
@@ -514,11 +499,6 @@ variables.put("SERVICE_TOKEN", SERVICE_TOKEN)
         <task ref="Split_Data"/>
         <task ref="Support_Vector_Machines"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw" language="groovy"></file>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr" >
         <envScript>
           <script>

--- a/ModelAsService/resources/catalog/MNIST_Model_Training_And_Deployment.xml
+++ b/ModelAsService/resources/catalog/MNIST_Model_Training_And_Deployment.xml
@@ -36,11 +36,6 @@
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/keras.png"/>
         <info name="task.documentation" value="PAIO/PAIOUserGuide.html"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw" language="groovy"></file>
-        </script>
-      </selection>
       <forkEnvironment javaHome="/usr" >
         <envScript>
           <script>

--- a/SelectionScripts/METADATA.json
+++ b/SelectionScripts/METADATA.json
@@ -242,14 +242,14 @@
 				"file" : "resources/catalog/check_env_regexp.groovy"
 			},
 			{
-				"name" : "check_node_source_name",
+				"name" : "check_node_source_name_var",
 				"metadata" : {
 					"kind": "Script/selection",
 					"commitMessage": "First commit",
 					"contentType": "text/x-groovy",
 					"projectName" : "Selection Scripts"
 				},
-				"file" : "resources/catalog/check_node_source_name.groovy"
+				"file" : "resources/catalog/check_node_source_name_var.groovy"
 			},
 			{
 				"name" : "check_gpu_exists",

--- a/SelectionScripts/resources/catalog/check_node_source_name_var.groovy
+++ b/SelectionScripts/resources/catalog/check_node_source_name_var.groovy
@@ -1,3 +1,9 @@
+/**
+ * Script which verifies that the current node runs in the node source specified by the NODE_SOURCE variable
+ *
+ * If the NODE_SOURCE variable is not defined or empty, the script always returns true
+ */
+
 selected = false
 NODE_SOURCE_NAME = variables.get("NODE_SOURCE")
 if (NODE_SOURCE_NAME) {

--- a/Tensorboard/resources/catalog/Finish_Tensorboard.xml
+++ b/Tensorboard/resources/catalog/Finish_Tensorboard.xml
@@ -20,11 +20,6 @@
       <description>
         <![CDATA[ The simplest task, ran by a Groovy engine. ]]>
       </description>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <scriptExecutable>
         <script>
           <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/service-automation/resources/Pre_Trigger_Action/raw">
@@ -52,11 +47,6 @@
         <info name="Documentation" value="PSA/PSAUserGuide.html"/>
         <info name="NODE_ACCESS_TOKEN" value="$INSTANCE_NAME"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <pre>
         <script>
           <code language="bash">
@@ -112,11 +102,6 @@ fi
       <depends>
         <task ref="Pre_Trigger_Action"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <scriptExecutable>
         <script>
           <code language="groovy">
@@ -162,11 +147,6 @@ if(engine.toLowerCase().equals("singularity")){
         <info name="Documentation" value="PSA/PSAUserGuide.html"/>
         <info name="NODE_ACCESS_TOKEN" value="$INSTANCE_NAME"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <pre>
         <script>
           <code language="bash">

--- a/Tensorboard/resources/catalog/Tensorboard.xml
+++ b/Tensorboard/resources/catalog/Tensorboard.xml
@@ -37,11 +37,6 @@
         <info name="Documentation" value="PSA/PSAUserGuide.html"/>
         <info name="DISABLE_PTK" value="true"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <pre>
         <script>
           <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/service-automation/resources/Pre_Start_Service/raw"/>
@@ -216,11 +211,6 @@ It will run every minute. ]]>
       <depends>
         <task ref="Start_Tensorboard_S"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <scriptExecutable>
         <script>
           <code language="groovy">
@@ -301,11 +291,6 @@ if (currentStatus.equals("FINISHED")){
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/controls_if.png"/>
         <info name="Documentation" value="user/ProActiveUserGuide.html#_branch"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <scriptExecutable>
         <script>
           <code language="groovy">
@@ -350,11 +335,6 @@ if(engine.toLowerCase().equals("singularity")){
         <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/tensorboard.png"/>
         <info name="Documentation" value="PSA/PSAUserGuide.html"/>
       </genericInformation>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <pre>
         <script>
           <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/service-automation/resources/Pre_Start_Service/raw"/>
@@ -503,11 +483,6 @@ It will run every minute. ]]>
       <depends>
         <task ref="Start_Tensorboard_D"/>
       </depends>
-      <selection>
-        <script type="static">
-          <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/scripts/resources/check_node_source_name/raw"/>
-        </script>
-      </selection>
       <scriptExecutable>
         <script>
           <file language="groovy" url="${PA_CATALOG_REST_URL}/buckets/service-automation/resources/Check_Instance_Status/raw"/>


### PR DESCRIPTION
 - this selection script is superseded by the NODE_SOURCE generic info.
 - also renamed check_node_source_name to check_node_source_name_var to avoid confusion with the existing check_node_source script.