### PR TITLE
Fix token format in big data workflows

### DIFF
--- a/BigData/resources/catalog/iterative_etl.xml
+++ b/BigData/resources/catalog/iterative_etl.xml
@@ -386,7 +386,7 @@ new File(output_file_path).text = StringUtils.substringBetween(output_with_csv.t
               <argument value="spark_master_url"/>
               <argument value="spark_master_url"/>
               <argument value="spark_token_name"/>
-              <argument value="INSTANCE_NAME"/>
+              <argument value="PSA_%{INSTANCE_NAME}"/>
               <argument value="hdfs_namenode_host_port"/>
               <argument value="hdfs_namenode_host_port"/>
             </arguments>

--- a/HDFS/resources/catalog/HDFS.xml
+++ b/HDFS/resources/catalog/HDFS.xml
@@ -32,7 +32,7 @@ A Swarm service (Docker_Swarm) needs to be started first, and the swarm_service_
             <arguments>
               <argument value="$swarm_service_instance_id"/>
               <argument value="swarm_token_name"/>
-              <argument value="INSTANCE_NAME"/>
+              <argument value="PSA_%{INSTANCE_NAME}"/>
               <argument value="swarm_manager_and_workers_pa_node_names"/>
               <argument value="swarm_manager_and_workers_pa_node_names"/>
             </arguments>

--- a/Hive/resources/catalog/Hive.xml
+++ b/Hive/resources/catalog/Hive.xml
@@ -42,7 +42,7 @@ PS: The username and password must be changed, otherwise the default value user/
                             <argument value="yarn_master_container_name"/>
                             <argument value="yarn_master_container_name"/>
                             <argument value="yarn_token_name"/>
-                            <argument value="INSTANCE_NAME"/>
+                            <argument value="PSA_%{INSTANCE_NAME}"/>
                         </arguments>
                     </file>
                 </script>

--- a/PcaScripts/METADATA.json
+++ b/PcaScripts/METADATA.json
@@ -194,7 +194,7 @@
 			{
 				"name" : "Propagate_variables_to_current_service",
 				"metadata" : {
-					"kind": "Script/flow",
+					"kind": "Script/pre",
 					"commitMessage": "First commit",
 					"contentType": "text/x-groovy",
 					"projectName": "9. Scripts"
@@ -204,7 +204,7 @@
 			{
 				"name" : "Retrieve_variables_from_service_instance_id",
 				"metadata" : {
-					"kind": "Script/flow",
+					"kind": "Script/task",
 					"commitMessage": "First commit",
 					"contentType": "text/x-groovy",
 					"projectName": "9. Scripts"

--- a/PcaScripts/resources/catalog/Retrieve_variables_from_service_instance_id.groovy
+++ b/PcaScripts/resources/catalog/Retrieve_variables_from_service_instance_id.groovy
@@ -1,5 +1,6 @@
 import org.ow2.proactive.pca.service.client.ApiClient
 import org.ow2.proactive.pca.service.client.api.ServiceInstanceRestApi
+import org.ow2.proactive.scheduler.common.util.VariableSubstitutor
 
 // Arguments must be <service_id> <var0_name_to_store> <var0_to_retrieve> <var1_name_to_store> <var1_to_retrieve> ...
 if (args.length < 3) {
@@ -27,6 +28,15 @@ def service_instance_rest_api = new ServiceInstanceRestApi(new ApiClient().setBa
 // Retrieve service variables
 def service_instance_data = service_instance_rest_api.getServiceInstanceUsingGET(session_id, service_instance_id)
 for  (i = 1; i < args.length; i = i + 2) {
-    println "[Retrieve_variables_from_service_instance_id] Propagating " + service_instance_data.getVariables().get(args[i+1]) + " under " + args[i]
-    variables.put(args[i], service_instance_data.getVariables().get(args[i+1]))
+    if (args[i+1].contains("%{")) {
+        // var_to_retrieve can contain a reference to another variable in the target service
+        // we use the format %{var} instead of ${var} to prevent conflicts with the current workflow variables
+        def modifiedPattern = args[i+1].replace("%{","\${")
+        def resolvedVariable = VariableSubstitutor.filterAndUpdate(modifiedPattern, service_instance_data.getVariables())
+        println "[Retrieve_variables_from_service_instance_id] Propagating " + resolvedVariable + " under " + args[i]
+        variables.put(args[i], resolvedVariable)
+    } else {
+        println "[Retrieve_variables_from_service_instance_id] Propagating " + service_instance_data.getVariables().get(args[i+1]) + " under " + args[i]
+        variables.put(args[i], service_instance_data.getVariables().get(args[i+1]))
+    }
 }

--- a/Spark/resources/catalog/Spark.xml
+++ b/Spark/resources/catalog/Spark.xml
@@ -34,7 +34,7 @@ To connect a HDFS platform (optional), a HDFS service needs to be started after 
             <arguments>
               <argument value="$swarm_service_instance_id"/>
               <argument value="swarm_token_name"/>
-              <argument value="INSTANCE_NAME"/>
+              <argument value="PSA_%{INSTANCE_NAME}"/>
               <argument value="swarm_manager_and_workers_pa_node_names"/>
               <argument value="swarm_manager_and_workers_pa_node_names"/>
             </arguments>

--- a/SparkOrchestration/resources/catalog/Python_Spark_Pi.xml
+++ b/SparkOrchestration/resources/catalog/Python_Spark_Pi.xml
@@ -28,7 +28,7 @@
               <argument value="spark_master_url"/>
               <argument value="spark_master_url"/>
               <argument value="spark_token_name"/>
-              <argument value="INSTANCE_NAME"/>
+              <argument value="PSA_%{INSTANCE_NAME}"/>
             </arguments>
           </file>
         </script>

--- a/SparkOrchestration/resources/catalog/Scala_Spark_Pi.xml
+++ b/SparkOrchestration/resources/catalog/Scala_Spark_Pi.xml
@@ -28,7 +28,7 @@
               <argument value="spark_master_url"/>
               <argument value="spark_master_url"/>
               <argument value="spark_token_name"/>
-              <argument value="INSTANCE_NAME"/>
+              <argument value="PSA_%{INSTANCE_NAME}"/>
             </arguments>
           </file>
         </script>

--- a/SparkOrchestration/resources/catalog/Scala_Spark_Write_Read_HDFS.xml
+++ b/SparkOrchestration/resources/catalog/Scala_Spark_Write_Read_HDFS.xml
@@ -32,7 +32,7 @@
               <argument value="spark_master_url"/>
               <argument value="spark_master_url"/>
               <argument value="spark_token_name"/>
-              <argument value="INSTANCE_NAME"/>
+              <argument value="PSA_%{INSTANCE_NAME}"/>
               <argument value="hdfs_namenode_host_port"/>
               <argument value="hdfs_namenode_host_port"/>
             </arguments>

--- a/YARN/resources/catalog/YARN.xml
+++ b/YARN/resources/catalog/YARN.xml
@@ -30,7 +30,7 @@ To connect a HDFS platform (optional), a HDFS service needs to be started after 
             <arguments>
               <argument value="$swarm_service_instance_id"/>
               <argument value="swarm_token_name"/>
-              <argument value="INSTANCE_NAME"/>
+              <argument value="PSA_%{INSTANCE_NAME}"/>
               <argument value="swarm_manager_and_workers_pa_node_names"/>
               <argument value="swarm_manager_and_workers_pa_node_names"/>
             </arguments>

--- a/YARNOrchestration/resources/catalog/Java_YARN_Pi.xml
+++ b/YARNOrchestration/resources/catalog/Java_YARN_Pi.xml
@@ -34,7 +34,7 @@
                             <argument value="hdfs_namenode_container_name"/>
                             <argument value="hdfs_namenode_container_name"/>
                             <argument value="yarn_token_name"/>
-                            <argument value="INSTANCE_NAME"/>
+                            <argument value="PSA_%{INSTANCE_NAME}"/>
                         </arguments>
                     </file>
                 </script>


### PR DESCRIPTION
Retrieve_variables_from_service_instance_id : allow using variable references with a %{var_name} format

Use PSA_%{INSTANCE_NAME} when used for a token name

Also, change the script type as it is not used in flow scripts.