### PR TITLE
Improve Clean_Trigger_Action service job status detection

### DIFF
--- a/PcaScripts/resources/catalog/Clean_Trigger_Action.groovy
+++ b/PcaScripts/resources/catalog/Clean_Trigger_Action.groovy
@@ -35,10 +35,9 @@ def serviceInstanceRestApi = new ServiceInstanceRestApi(apiClient)
 def serviceInstanceData = serviceInstanceRestApi.getServiceInstance(sessionId, instanceId)
 
 // Get the main
-def submittedMainJobId = serviceInstanceData.getJobSubmissions().get(0).getJobId()
-def mainJobState = schedulerapi.getJobState(submittedMainJobId.toString())
+def submittedMainJobId = serviceInstanceData.getJobSubmissions().find {it.getTransitionState().equals("VOID -> RUNNING")}.getJobId()
 
-if (schedulerapi.getJobState(submittedMainJobId.toString()).isFinished()) {
+if (schedulerapi.isJobFinished(submittedMainJobId.toString())) {
     // Add token to the current node
     nodeUrl = variables.get("PA_NODE_URL")
     rmapi.connect()


### PR DESCRIPTION
 - find the service job in job submissions list based on transition state rather than using the first element
 - use isJobFinished() instead of getJobState()