### PR TITLE
Enhance SSH_Terminal_For_Distributed_Nodes  + fix Docker_Swarm_HDFS_Zookeeper_HBase_Terminate_Service 

### DIFF
--- a/BigData/resources/catalog/Docker_Swarm_HDFS_Zookeeper_HBase_Terminate_Service.xml
+++ b/BigData/resources/catalog/Docker_Swarm_HDFS_Zookeeper_HBase_Terminate_Service.xml
@@ -16,17 +16,6 @@
         <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/hbase.png"/>
         <info name="group" value="public-objects"/>
     </genericInformation>
-    <pre>
-        <script>
-            <code language="groovy">
-                <![CDATA[
-if (variables.get("INSTANCE_ID_" + variables.get("HBASE_INSTANCE_NAME")) == null) {
-	throw new IllegalArgumentException-("Wrong Hbase instance ID. You must terminate the Hbase service using the UNDEPLOY_PLATFORM signal of the job that deployed the service")
-}
-]]>
-            </code>
-        </script>
-    </pre>
     <taskFlow>
         <task name="Stop_HBase_Service"
 
@@ -42,6 +31,17 @@ if (variables.get("INSTANCE_ID_" + variables.get("HBASE_INSTANCE_NAME")) == null
             <genericInformation>
                 <info name="task.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/hbase.png"/>
             </genericInformation>
+            <pre>
+                <script>
+                    <code language="groovy">
+                        <![CDATA[
+if (variables.get("INSTANCE_ID_" + variables.get("HBASE_INSTANCE_NAME")) == null) {
+	throw new IllegalArgumentException-("Wrong Hbase instance ID. You must terminate the Hbase service using the UNDEPLOY_PLATFORM signal of the job that deployed the service")
+}
+]]>
+                    </code>
+                </script>
+            </pre>
             <scriptExecutable>
                 <script>
                     <file url="${PA_CATALOG_REST_URL}/buckets/service-automation/resources/Service_Action/raw" language="groovy"></file>

--- a/BigData/resources/catalog/Docker_Swarm_HDFS_Zookeeper_HBase_Terminate_Service.xml
+++ b/BigData/resources/catalog/Docker_Swarm_HDFS_Zookeeper_HBase_Terminate_Service.xml
@@ -65,7 +65,7 @@ if (variables.get("INSTANCE_ID_" + variables.get("HBASE_INSTANCE_NAME")) == null
               fork="true">
             <variables>
                 <variable name="INSTANCE_NAME" value="${ZOOKEEPER_INSTANCE_NAME}" inherited="false"  description="The name of the service to be undeployed"  advanced="false" hidden="false"/>
-                <variable name="SERVICE_ACTION_WORKFLOW" value="service-automation/Finish_Zookeeper" inherited="false" model="PA:CATALOG_OBJECT(Workflow/psa,,,%Zookeeper)" description="The action that will be processed regarding the service status."  advanced="false" hidden="false"/>
+                <variable name="SERVICE_ACTION_WORKFLOW" value="service-automation/Finish_Zookeeper" inherited="false" model="PA:CATALOG_OBJECT(Workflow/psa,,,%Zookeeper)" description="The action that will be processed regarding the service status." group="" advanced="false" hidden="false"/>
                 <variable name="INSTANCE_ID" value="" inherited="false"    advanced="false" hidden="false"/>
             </variables>
             <genericInformation>
@@ -96,7 +96,7 @@ if (variables.get("INSTANCE_ID_" + variables.get("HBASE_INSTANCE_NAME")) == null
               fork="true">
             <variables>
                 <variable name="INSTANCE_NAME" value="${HDFS_INSTANCE_NAME}" inherited="false"  description="The name of the service to be undeployed"   />
-                <variable name="SERVICE_ACTION_WORKFLOW" value="service-automation/Finish_HDFS" inherited="false" model="PA:CATALOG_OBJECT(Workflow/psa,,,%HDFS)" description="The action that will be processed regarding the service status."  advanced="false" hidden="false"/>
+                <variable name="SERVICE_ACTION_WORKFLOW" value="service-automation/Finish_HDFS" inherited="false" model="PA:CATALOG_OBJECT(Workflow/psa,,,%HDFS)" description="The action that will be processed regarding the service status." group="" advanced="false" hidden="false"/>
                 <variable name="INSTANCE_ID" value="" inherited="false"  description="The service instance ID"   />
             </variables>
             <genericInformation>
@@ -128,7 +128,7 @@ if (variables.get("INSTANCE_ID_" + variables.get("HBASE_INSTANCE_NAME")) == null
               fork="true">
             <variables>
                 <variable name="INSTANCE_NAME" value="${SWARM_INSTANCE_NAME}" inherited="false"  description="The name of the service to be undeployed"   />
-                <variable name="SERVICE_ACTION_WORKFLOW" value="service-automation/Finish_Docker_Swarm" inherited="false" model="PA:CATALOG_OBJECT(Workflow/psa,,,%Docker_Swarm)" description="The action that will be processed regarding the service status."  advanced="false" hidden="false"/>
+                <variable name="SERVICE_ACTION_WORKFLOW" value="service-automation/Finish_Docker_Swarm" inherited="false" model="PA:CATALOG_OBJECT(Workflow/psa,,,%Docker_Swarm)" description="The action that will be processed regarding the service status." group="" advanced="false" hidden="false"/>
                 <variable name="INSTANCE_ID" value="" inherited="false"  description="The service instance ID"   />
             </variables>
             <genericInformation>

--- a/BigData/resources/catalog/Docker_Swarm_HDFS_Zookeeper_HBase_Terminate_Service.xml
+++ b/BigData/resources/catalog/Docker_Swarm_HDFS_Zookeeper_HBase_Terminate_Service.xml
@@ -50,10 +50,10 @@ if (variables.get("INSTANCE_ID_" + variables.get("HBASE_INSTANCE_NAME")) == null
             <controlFlow block="none"></controlFlow>
             <metadata>
                 <positionTop>
-                    430.63751220703125
+                    177.5
                 </positionTop>
                 <positionLeft>
-                    264.2125244140625
+                    590.25
                 </positionLeft>
             </metadata>
         </task>
@@ -65,7 +65,7 @@ if (variables.get("INSTANCE_ID_" + variables.get("HBASE_INSTANCE_NAME")) == null
               fork="true">
             <variables>
                 <variable name="INSTANCE_NAME" value="${ZOOKEEPER_INSTANCE_NAME}" inherited="false"  description="The name of the service to be undeployed"  advanced="false" hidden="false"/>
-                <variable name="SERVICE_ACTION_WORKFLOW" value="service-automation/Finish_Zookeeper" inherited="false" model="PA:CATALOG_OBJECT(Workflow/psa,,,%Zookeeper)" description="The action that will be processed regarding the service status." group="" advanced="false" hidden="false"/>
+                <variable name="SERVICE_ACTION_WORKFLOW" value="service-automation/Finish_Zookeeper" inherited="false" model="PA:CATALOG_OBJECT(Workflow/psa,,,%Zookeeper)" description="The action that will be processed regarding the service status."  advanced="false" hidden="false"/>
                 <variable name="INSTANCE_ID" value="" inherited="false"    advanced="false" hidden="false"/>
             </variables>
             <genericInformation>
@@ -81,10 +81,10 @@ if (variables.get("INSTANCE_ID_" + variables.get("HBASE_INSTANCE_NAME")) == null
             </scriptExecutable>
             <metadata>
                 <positionTop>
-                    430.7125244140625
+                    304.5
                 </positionTop>
                 <positionLeft>
-                    776.0750732421875
+                    590.25
                 </positionLeft>
             </metadata>
         </task>
@@ -96,7 +96,7 @@ if (variables.get("INSTANCE_ID_" + variables.get("HBASE_INSTANCE_NAME")) == null
               fork="true">
             <variables>
                 <variable name="INSTANCE_NAME" value="${HDFS_INSTANCE_NAME}" inherited="false"  description="The name of the service to be undeployed"   />
-                <variable name="SERVICE_ACTION_WORKFLOW" value="service-automation/Finish_HDFS" inherited="false" model="PA:CATALOG_OBJECT(Workflow/psa,,,%HDFS)" description="The action that will be processed regarding the service status." group="" advanced="false" hidden="false"/>
+                <variable name="SERVICE_ACTION_WORKFLOW" value="service-automation/Finish_HDFS" inherited="false" model="PA:CATALOG_OBJECT(Workflow/psa,,,%HDFS)" description="The action that will be processed regarding the service status."  advanced="false" hidden="false"/>
                 <variable name="INSTANCE_ID" value="" inherited="false"  description="The service instance ID"   />
             </variables>
             <genericInformation>
@@ -113,10 +113,10 @@ if (variables.get("INSTANCE_ID_" + variables.get("HBASE_INSTANCE_NAME")) == null
             <controlFlow block="none"></controlFlow>
             <metadata>
                 <positionTop>
-                    516.6375122070312
+                    432.5
                 </positionTop>
                 <positionLeft>
-                    468.22503662109375
+                    590.25
                 </positionLeft>
             </metadata>
         </task>
@@ -128,7 +128,7 @@ if (variables.get("INSTANCE_ID_" + variables.get("HBASE_INSTANCE_NAME")) == null
               fork="true">
             <variables>
                 <variable name="INSTANCE_NAME" value="${SWARM_INSTANCE_NAME}" inherited="false"  description="The name of the service to be undeployed"   />
-                <variable name="SERVICE_ACTION_WORKFLOW" value="service-automation/Finish_Docker_Swarm" inherited="false" model="PA:CATALOG_OBJECT(Workflow/psa,,,%Docker_Swarm)" description="The action that will be processed regarding the service status." group="" advanced="false" hidden="false"/>
+                <variable name="SERVICE_ACTION_WORKFLOW" value="service-automation/Finish_Docker_Swarm" inherited="false" model="PA:CATALOG_OBJECT(Workflow/psa,,,%Docker_Swarm)" description="The action that will be processed regarding the service status."  advanced="false" hidden="false"/>
                 <variable name="INSTANCE_ID" value="" inherited="false"  description="The service instance ID"   />
             </variables>
             <genericInformation>
@@ -145,10 +145,10 @@ if (variables.get("INSTANCE_ID_" + variables.get("HBASE_INSTANCE_NAME")) == null
             <controlFlow block="none"></controlFlow>
             <metadata>
                 <positionTop>
-                    563.6375122070312
+                    560.5
                 </positionTop>
                 <positionLeft>
-                    684.2249755859375
+                    590.25
                 </positionLeft>
             </metadata>
         </task>

--- a/BigData/resources/catalog/Docker_Swarm_HDFS_Zookeeper_HBase_Terminate_Service.xml
+++ b/BigData/resources/catalog/Docker_Swarm_HDFS_Zookeeper_HBase_Terminate_Service.xml
@@ -3,14 +3,10 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns="urn:proactive:jobdescriptor:3.14" xsi:schemaLocation="urn:proactive:jobdescriptor:3.14 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.14/schedulerjob.xsd"  name="Docker_Swarm_HDFS_Zookeeper_HBase_Terminate_Service" tags="Swarm,Docker,Big Data,Zookeeper,HDFS,Service Automation,Analytics,HBase" projectName="02. Hadoop HBase (NoSQL DB)" priority="normal" onTaskError="continueJobExecution"  maxNumberOfExecution="1"  >
     <variables>
-        <variable name="HBASE_INSTANCE_NAME" value="xxx" model="PA:NOT_EMPTY_STRING" description="Hbase Service instance name."   />
-        <variable name="HBASE_INSTANCE_ID" value="xxx" model="PA:NOT_EMPTY_STRING" description="Hbase Service instance ID."   />
+        <variable name="HBASE_INSTANCE_NAME" value="xxx" model="PA:NOT_EMPTY_STRING" description="HBASE Service instance name."   />
         <variable name="ZOOKEEPER_INSTANCE_NAME" value="xxx" model="PA:NOT_EMPTY_STRING" description="Zookeeper Service instance name."   />
-        <variable name="ZOOKEEPER_INSTANCE_ID" value="xxx" model="PA:NOT_EMPTY_STRING" description="Zookeeper Service instance ID."   />
         <variable name="HDFS_INSTANCE_NAME" value="xxx" model="PA:NOT_EMPTY_STRING" description="HDFS Service instance name."   />
-        <variable name="HDFS_INSTANCE_ID" value="xxx" model="PA:NOT_EMPTY_STRING" description="HDFS Service instance ID."   />
         <variable name="SWARM_INSTANCE_NAME" value="xxx" model="PA:NOT_EMPTY_STRING" description="Swarm Service instance name."   />
-        <variable name="SWARM_INSTANCE_ID" value="xxx" model="PA:NOT_EMPTY_STRING" description="Swarm Service instance ID."   />
     </variables>
     <description>
         <![CDATA[ Undeploy a Docker Swarm-HDFS-Zookeeper-HBase platform. ]]>
@@ -20,6 +16,17 @@
         <info name="workflow.icon" value="/automation-dashboard/styles/patterns/img/wf-icons/hbase.png"/>
         <info name="group" value="public-objects"/>
     </genericInformation>
+    <pre>
+        <script>
+            <code language="groovy">
+                <![CDATA[
+if (variables.get("INSTANCE_ID_" + variables.get("HBASE_INSTANCE_NAME")) == null) {
+	throw new IllegalArgumentException-("You must terminate the Hbase service using the UNDEPLOY_PLATFORM signal of the job that deployed the service")
+}
+]]>
+            </code>
+        </script>
+    </pre>
     <taskFlow>
         <task name="Stop_HBase_Service"
 
@@ -28,8 +35,7 @@
 
               fork="true">
             <variables>
-                <variable name="INSTANCE_NAME" value="${HBASE_INSTANCE_NAME}" inherited="false"  description="The name of the Hbase service to be undeployed"  advanced="false" hidden="false"/>
-                <variable name="INSTANCE_ID" value="${HBASE_INSTANCE_ID}" inherited="false"  description="The ID of the Hbase service to be undeployed"  advanced="false" hidden="false"/>
+                <variable name="INSTANCE_NAME" value="${HBASE_INSTANCE_NAME}" inherited="false"  description="The name of the service to be undeployed"  advanced="false" hidden="false"/>
                 <variable name="SERVICE_ACTION_WORKFLOW" value="service-automation/Finish_HBase" inherited="false" model="PA:CATALOG_OBJECT(Workflow/psa,,,%HBase)" description="The action that will be processed regarding the service status." group="" advanced="false" hidden="false"/>
                 <variable name="INSTANCE_ID" value="" inherited="false"  description="The service instance ID"   />
             </variables>
@@ -58,8 +64,7 @@
 
               fork="true">
             <variables>
-                <variable name="INSTANCE_NAME" value="${ZOOKEEPER_INSTANCE_NAME}" inherited="false"  description="The name of the Zookeeper service to be undeployed"  advanced="false" hidden="false"/>
-                <variable name="INSTANCE_ID" value="${ZOOKEEPER_INSTANCE_ID}" inherited="false"  description="The ID of the Zookeeper service to be undeployed"  advanced="false" hidden="false"/>
+                <variable name="INSTANCE_NAME" value="${ZOOKEEPER_INSTANCE_NAME}" inherited="false"  description="The name of the service to be undeployed"  advanced="false" hidden="false"/>
                 <variable name="SERVICE_ACTION_WORKFLOW" value="service-automation/Finish_Zookeeper" inherited="false" model="PA:CATALOG_OBJECT(Workflow/psa,,,%Zookeeper)" description="The action that will be processed regarding the service status." group="" advanced="false" hidden="false"/>
                 <variable name="INSTANCE_ID" value="" inherited="false"    advanced="false" hidden="false"/>
             </variables>
@@ -90,8 +95,7 @@
 
               fork="true">
             <variables>
-                <variable name="INSTANCE_NAME" value="${HDFS_INSTANCE_NAME}" inherited="false"  description="The name of the HDFS service to be undeployed"   />
-                <variable name="INSTANCE_ID" value="${HDFS_INSTANCE_ID}" inherited="false"  description="The ID of the HDFS service to be undeployed"  advanced="false" hidden="false"/>
+                <variable name="INSTANCE_NAME" value="${HDFS_INSTANCE_NAME}" inherited="false"  description="The name of the service to be undeployed"   />
                 <variable name="SERVICE_ACTION_WORKFLOW" value="service-automation/Finish_HDFS" inherited="false" model="PA:CATALOG_OBJECT(Workflow/psa,,,%HDFS)" description="The action that will be processed regarding the service status." group="" advanced="false" hidden="false"/>
                 <variable name="INSTANCE_ID" value="" inherited="false"  description="The service instance ID"   />
             </variables>
@@ -123,8 +127,7 @@
 
               fork="true">
             <variables>
-                <variable name="INSTANCE_NAME" value="${SWARM_INSTANCE_NAME}" inherited="false"  description="The name of the Docker Swarm service to be undeployed"   />
-                <variable name="INSTANCE_ID" value="${SWARM_INSTANCE_ID}" inherited="false"  description="The name of the Docker Swarm service to be undeployed"   />
+                <variable name="INSTANCE_NAME" value="${SWARM_INSTANCE_NAME}" inherited="false"  description="The name of the service to be undeployed"   />
                 <variable name="SERVICE_ACTION_WORKFLOW" value="service-automation/Finish_Docker_Swarm" inherited="false" model="PA:CATALOG_OBJECT(Workflow/psa,,,%Docker_Swarm)" description="The action that will be processed regarding the service status." group="" advanced="false" hidden="false"/>
                 <variable name="INSTANCE_ID" value="" inherited="false"  description="The service instance ID"   />
             </variables>

--- a/BigData/resources/catalog/Docker_Swarm_HDFS_Zookeeper_HBase_Terminate_Service.xml
+++ b/BigData/resources/catalog/Docker_Swarm_HDFS_Zookeeper_HBase_Terminate_Service.xml
@@ -3,10 +3,14 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns="urn:proactive:jobdescriptor:3.14" xsi:schemaLocation="urn:proactive:jobdescriptor:3.14 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.14/schedulerjob.xsd"  name="Docker_Swarm_HDFS_Zookeeper_HBase_Terminate_Service" tags="Swarm,Docker,Big Data,Zookeeper,HDFS,Service Automation,Analytics,HBase" projectName="02. Hadoop HBase (NoSQL DB)" priority="normal" onTaskError="continueJobExecution"  maxNumberOfExecution="1"  >
     <variables>
-        <variable name="HBASE_INSTANCE_NAME" value="xxx" model="PA:NOT_EMPTY_STRING" description="Spark Service instance name."   />
+        <variable name="HBASE_INSTANCE_NAME" value="xxx" model="PA:NOT_EMPTY_STRING" description="Hbase Service instance name."   />
+        <variable name="HBASE_INSTANCE_ID" value="xxx" model="PA:NOT_EMPTY_STRING" description="Hbase Service instance ID."   />
         <variable name="ZOOKEEPER_INSTANCE_NAME" value="xxx" model="PA:NOT_EMPTY_STRING" description="Zookeeper Service instance name."   />
+        <variable name="ZOOKEEPER_INSTANCE_ID" value="xxx" model="PA:NOT_EMPTY_STRING" description="Zookeeper Service instance ID."   />
         <variable name="HDFS_INSTANCE_NAME" value="xxx" model="PA:NOT_EMPTY_STRING" description="HDFS Service instance name."   />
+        <variable name="HDFS_INSTANCE_ID" value="xxx" model="PA:NOT_EMPTY_STRING" description="HDFS Service instance ID."   />
         <variable name="SWARM_INSTANCE_NAME" value="xxx" model="PA:NOT_EMPTY_STRING" description="Swarm Service instance name."   />
+        <variable name="SWARM_INSTANCE_ID" value="xxx" model="PA:NOT_EMPTY_STRING" description="Swarm Service instance ID."   />
     </variables>
     <description>
         <![CDATA[ Undeploy a Docker Swarm-HDFS-Zookeeper-HBase platform. ]]>
@@ -24,7 +28,8 @@
 
               fork="true">
             <variables>
-                <variable name="INSTANCE_NAME" value="${HBASE_INSTANCE_NAME}" inherited="false"  description="The name of the service to be undeployed"  advanced="false" hidden="false"/>
+                <variable name="INSTANCE_NAME" value="${HBASE_INSTANCE_NAME}" inherited="false"  description="The name of the Hbase service to be undeployed"  advanced="false" hidden="false"/>
+                <variable name="INSTANCE_ID" value="${HBASE_INSTANCE_ID}" inherited="false"  description="The ID of the Hbase service to be undeployed"  advanced="false" hidden="false"/>
                 <variable name="SERVICE_ACTION_WORKFLOW" value="service-automation/Finish_HBase" inherited="false" model="PA:CATALOG_OBJECT(Workflow/psa,,,%HBase)" description="The action that will be processed regarding the service status." group="" advanced="false" hidden="false"/>
                 <variable name="INSTANCE_ID" value="" inherited="false"  description="The service instance ID"   />
             </variables>
@@ -53,7 +58,8 @@
 
               fork="true">
             <variables>
-                <variable name="INSTANCE_NAME" value="${ZOOKEEPER_INSTANCE_NAME}" inherited="false"  description="The name of the service to be undeployed"  advanced="false" hidden="false"/>
+                <variable name="INSTANCE_NAME" value="${ZOOKEEPER_INSTANCE_NAME}" inherited="false"  description="The name of the Zookeeper service to be undeployed"  advanced="false" hidden="false"/>
+                <variable name="INSTANCE_ID" value="${ZOOKEEPER_INSTANCE_ID}" inherited="false"  description="The ID of the Zookeeper service to be undeployed"  advanced="false" hidden="false"/>
                 <variable name="SERVICE_ACTION_WORKFLOW" value="service-automation/Finish_Zookeeper" inherited="false" model="PA:CATALOG_OBJECT(Workflow/psa,,,%Zookeeper)" description="The action that will be processed regarding the service status." group="" advanced="false" hidden="false"/>
                 <variable name="INSTANCE_ID" value="" inherited="false"    advanced="false" hidden="false"/>
             </variables>
@@ -84,7 +90,8 @@
 
               fork="true">
             <variables>
-                <variable name="INSTANCE_NAME" value="${HDFS_INSTANCE_NAME}" inherited="false"  description="The name of the service to be undeployed"   />
+                <variable name="INSTANCE_NAME" value="${HDFS_INSTANCE_NAME}" inherited="false"  description="The name of the HDFS service to be undeployed"   />
+                <variable name="INSTANCE_ID" value="${HDFS_INSTANCE_ID}" inherited="false"  description="The ID of the HDFS service to be undeployed"  advanced="false" hidden="false"/>
                 <variable name="SERVICE_ACTION_WORKFLOW" value="service-automation/Finish_HDFS" inherited="false" model="PA:CATALOG_OBJECT(Workflow/psa,,,%HDFS)" description="The action that will be processed regarding the service status." group="" advanced="false" hidden="false"/>
                 <variable name="INSTANCE_ID" value="" inherited="false"  description="The service instance ID"   />
             </variables>
@@ -116,7 +123,8 @@
 
               fork="true">
             <variables>
-                <variable name="INSTANCE_NAME" value="${SWARM_INSTANCE_NAME}" inherited="false"  description="The name of the service to be undeployed"   />
+                <variable name="INSTANCE_NAME" value="${SWARM_INSTANCE_NAME}" inherited="false"  description="The name of the Docker Swarm service to be undeployed"   />
+                <variable name="INSTANCE_ID" value="${SWARM_INSTANCE_ID}" inherited="false"  description="The name of the Docker Swarm service to be undeployed"   />
                 <variable name="SERVICE_ACTION_WORKFLOW" value="service-automation/Finish_Docker_Swarm" inherited="false" model="PA:CATALOG_OBJECT(Workflow/psa,,,%Docker_Swarm)" description="The action that will be processed regarding the service status." group="" advanced="false" hidden="false"/>
                 <variable name="INSTANCE_ID" value="" inherited="false"  description="The service instance ID"   />
             </variables>

--- a/BigData/resources/catalog/Docker_Swarm_HDFS_Zookeeper_HBase_Terminate_Service.xml
+++ b/BigData/resources/catalog/Docker_Swarm_HDFS_Zookeeper_HBase_Terminate_Service.xml
@@ -21,7 +21,7 @@
             <code language="groovy">
                 <![CDATA[
 if (variables.get("INSTANCE_ID_" + variables.get("HBASE_INSTANCE_NAME")) == null) {
-	throw new IllegalArgumentException-("You must terminate the Hbase service using the UNDEPLOY_PLATFORM signal of the job that deployed the service")
+	throw new IllegalArgumentException-("Wrong Hbase instance ID. You must terminate the Hbase service using the UNDEPLOY_PLATFORM signal of the job that deployed the service")
 }
 ]]>
             </code>

--- a/SSH/resources/catalog/Finish_SSH_Terminal_For_Distributed_Nodes.xml
+++ b/SSH/resources/catalog/Finish_SSH_Terminal_For_Distributed_Nodes.xml
@@ -25,7 +25,7 @@
         <task ref="Pre_Finish"/>
       </depends>
       <selection>
-        <script type="dynamic">
+        <script type="static">
           <code language="groovy">
             <![CDATA[
 /**

--- a/SSH/resources/catalog/Finish_SSH_Terminal_For_Distributed_Nodes.xml
+++ b/SSH/resources/catalog/Finish_SSH_Terminal_For_Distributed_Nodes.xml
@@ -25,7 +25,7 @@
         <task ref="Pre_Finish"/>
       </depends>
       <selection>
-        <script type="static">
+        <script type="dynamic">
           <code language="groovy">
             <![CDATA[
 /**

--- a/SSH/resources/catalog/SSH_Terminal_For_Distributed_Nodes.xml
+++ b/SSH/resources/catalog/SSH_Terminal_For_Distributed_Nodes.xml
@@ -38,7 +38,7 @@
         </topology>
       </parallel>
       <selection>
-        <script type="static">
+        <script type="dynamic">
           <file url="${PA_CATALOG_REST_URL}/buckets/service-automation/resources/Check_Not_Used_By_Other_Service/raw" language="groovy"></file>
         </script>
       </selection>


### PR DESCRIPTION
- Make Start_SSH_Terminal selection script dynamic in SSH_Terminal_For_Distributed_Nodes workflow
- Fix Docker_Swarm_HDFS_Zookeeper_HBase_Terminate_Service workflow by adding input varaibels for child services instance IDs

Setting variable here:
```
def instanceName = variables.get("INSTANCE_NAME")
def instanceId = (!variables.get("INSTANCE_ID") && instanceName)? variables.get("INSTANCE_ID_" + instanceName) : variables.get("INSTANCE_ID")
if (!instanceId && !instanceName){
    throw new IllegalArgumentException("You have to specify an INSTANCE_NAME or an INSTANCE_ID. Empty value for both is not allowed.");
}
```

Code breaks here:
`CloudAutomationWorkflow executableAction = catalogRestApi.getExecutableActionByCatalogObject(sessionId, instanceId as int, bucketName, action)`

Error:
`7t1@trydev2.activeeon.com;Stop_Zookeeper;08:25:15] Caused by: org.codehaus.groovy.runtime.typehandling.GroovyCastException: Cannot cast object 'null' with class 'null' to class 'int'. Try 'java.lang.Integer' instead`